### PR TITLE
Handle unikernels requiring initrd

### DIFF
--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -29,6 +29,7 @@ type ExecArgs struct {
 	UnikernelPath string   // The path of the unikernel inside rootfs
 	TapDevice     string   // The TAP device name
 	BlockDevice   string   // The block device path
+	InitrdPath    string   // The path to the initrd of the unikernel
 	Command       string   // The unikernel's command line
 	IPAddress     string   // The IP address of the TAP device
 	Environment   []string // Environment

--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -28,6 +28,7 @@ type UnikernelParams struct {
 	EthDeviceIP      string // The eth device IP
 	EthDeviceMask    string // The eth device mask
 	EthDeviceGateway string // The eth device gateway
+	RootFSType       string // The rootfs type of the Unikernel
 }
 
 var ErrNotSupportedUnikernel = errors.New("unikernel is not supported")

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -136,11 +136,16 @@ func (u *Unikontainer) Exec() error {
 	unikernelType := u.State.Annotations["com.urunc.unikernel.unikernelType"]
 	rootfsDir := filepath.Join(u.State.Bundle, "rootfs")
 	unikernelAbsPath := filepath.Join(rootfsDir, u.State.Annotations["com.urunc.unikernel.binary"])
+	initrdAbsPath := ""
+	if u.State.Annotations["com.urunc.unikernel.initrd"] != "" {
+		initrdAbsPath := filepath.Join(rootfsDir, u.State.Annotations["com.urunc.unikernel.initrd"])
+	}
 
 	// populate vmm args
 	vmmArgs := hypervisors.ExecArgs{
 		Container:     u.State.ID,
 		UnikernelPath: unikernelAbsPath,
+		InitrdPath:    initrdAbsPath,
 		Environment:   os.Environ(),
 	}
 

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -138,7 +138,7 @@ func (u *Unikontainer) Exec() error {
 	unikernelAbsPath := filepath.Join(rootfsDir, u.State.Annotations["com.urunc.unikernel.binary"])
 	initrdAbsPath := ""
 	if u.State.Annotations["com.urunc.unikernel.initrd"] != "" {
-		initrdAbsPath := filepath.Join(rootfsDir, u.State.Annotations["com.urunc.unikernel.initrd"])
+		initrdAbsPath = filepath.Join(rootfsDir, u.State.Annotations["com.urunc.unikernel.initrd"])
 	}
 
 	// populate vmm args
@@ -173,6 +173,12 @@ func (u *Unikontainer) Exec() error {
 		unikernelParams.EthDeviceIP = ""
 		unikernelParams.EthDeviceMask = ""
 		unikernelParams.EthDeviceGateway = ""
+	}
+
+	if initrdAbsPath != "" {
+		unikernelParams.RootFSType = "initrd"
+	} else {
+		unikernelParams.RootFSType = ""
 	}
 
 	// handle storage


### PR DESCRIPTION
This PR adds support for unikernels requiring an initrd to run.

- Parse initrd annotation from OCI image: `com.urunc.unikernel.initrd`
- Add initrd field to ExecArg
- Add initrd info to Unikernel Params