### PR TITLE
Add timestamps to measure performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ bundles/
 
 # 
 dev.md
+
+# python-related directories
+__pycache__/

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	m "github.com/nubificus/urunc/pkg/metrics"
 	"github.com/sirupsen/logrus"
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 
@@ -54,6 +55,9 @@ value for "bundle" is the current directory.`
 )
 
 var version string
+
+// FIXME: We need to find a way to set the output file
+var metrics = m.NewZerologMetrics("/tmp/urunc.zlog")
 
 func main() {
 	root := "/run/urunc"

--- a/cmd/urunc/start.go
+++ b/cmd/urunc/start.go
@@ -15,7 +15,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/nubificus/urunc/pkg/unikontainers"
 	"github.com/sirupsen/logrus"
@@ -33,7 +35,10 @@ your host.`,
 	Description: `The start command executes the user defined process in a created container.`,
 	Action: func(context *cli.Context) error {
 		// FIXME: Remove or change level of log
+		containerID := context.Args().First()
 		logrus.WithField("args", os.Args).Info("urunc INVOKED")
+		nowTime := time.Now().UnixNano()
+		metrics.Log(fmt.Sprintf("%s,TS12,%d", containerID, nowTime))
 
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
@@ -57,9 +62,14 @@ func startUnikontainer(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	nowTime := time.Now().UnixNano()
+	metrics.Log(fmt.Sprintf("%s,TS13,%d", containerID, nowTime))
+
 	err = unikontainer.SendStartExecve()
 	if err != nil {
 		return err
 	}
+	nowTime = time.Now().UnixNano()
+	metrics.Log(fmt.Sprintf("%s,TS14,%d", containerID, nowTime))
 	return unikontainer.ExecuteHooks("Poststart")
 }

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/nubificus/urunc/pkg/unikontainers"
 	"github.com/sirupsen/logrus"
@@ -66,6 +67,12 @@ func checkArgs(context *cli.Context, expected, checkType int) error {
 // if not, it execve's itself using the exact same arguments and runc
 func handleNonBimaContainer(context *cli.Context) error {
 	containerID := context.Args().First()
+	nowTime := time.Now().UnixNano()
+	metrics.Log(fmt.Sprintf("%s,cTS00,%d", containerID, nowTime))
+	defer func() {
+		nowTime := time.Now().UnixNano()
+		metrics.Log(fmt.Sprintf("%s,cTS01,%d", containerID, nowTime))
+	}()
 	root := context.GlobalString("root")
 	if containerID == "" {
 		// cli.ShowAppHelpAndExit(context, 129)

--- a/docs/Performance-timestamping.md
+++ b/docs/Performance-timestamping.md
@@ -1,0 +1,197 @@
+# Measuring urunc execution
+
+## Adding timestamps
+
+To facilitate performance measurements, a few timestamps have been added to the code base to provide a clear view of the time spent on each part of the execution flow.
+
+The timestamps currently depicting each unikernel container execution are the following:
+
+| Timestamp ID | Process | Description                                   |
+|--------------|---------|-----------------------------------------------|
+| TS00         | create  | `urunc create` was invoked                    |
+| TS01         | create  | unikontainer struct created for spec          |
+| TS02         | create  | initial setup completed                       |
+| TS03         | create  | start reexec process (with or without pty)    |
+| TS04         | reexec  | `urunc create --reexec` was invoked           |
+| TS05         | reexec  | unikontainer struct created for spec          |
+| TS06         | reexec  | sent `BOOTED` IPC message to `create` process |
+| TS07         | create  | received `BOOTED` message from `reexec`       |
+| TS08         | create  | executed `CreateRuntime` hooks                |
+| TS09         | create  | sent `ACK` IPC message to `reexec` process    |
+| TS10         | reexec  | received `ACK` message from `create`          |
+| TS11         | create  | `urunc create` terminated                     |
+| TS12         | start   | `urunc start` was invoked                     |
+| TS13         | start   | unikontainer struct created for spec          |
+| TS14         | start   | sent `START` IPC message to `reexec`          |
+| TS15         | reexec  | received `START` message from `start`         |
+| TS16         | reexec  | joined sandbox network namespace              |
+| TS17         | reexec  | network setup completed                       |
+| TS18         | reexec  | disk setup completed                          |
+| TS19         | reexec  | `execve` the hypervisor process               |
+
+In addition to these timestamps, two more are added to measure the delay caused by the `handleNonBimaContainer` function that is run every time `urunc` is invoked:
+
+| Timestamp ID | Description                               |
+|--------------|-------------------------------------------|
+| cTS00        | before invoking  `handleNonBimaContainer` |
+| cTS01        | after invoking  `handleNonBimaContainer`  |
+
+## Timestamping logging method
+
+To log the timestamps with minimal overhead, we opted to use the [zerolog](https://github.com/rs/zerolog) package. We were able to keep the delay caused by the timestamp logging in a low level, around 38351ns for the 20 timestamps required. In comparison, when using [logrus](https://github.com/sirupsen/logrus) the overhead was measured at around 71589ns.
+
+To run the benchmarks for the currently supported logging methods:
+
+```bash
+URUNC_TIMESTAMPS=1 GOFLAGS="-count=1" go test ./tests/benchmarks -bench=. -count 5 -v
+```
+
+## How to enable timestamping
+
+In order to capture the timestamps, a separate `containerd-shim` and container runtime must be configured in your system.
+
+To create the "timestamping" version of `containerd-shim-urunc-v2`:
+
+```bash
+sudo tee -a /usr/local/bin/containerd-shim-uruncts-v2 > /dev/null << 'EOT'
+#!/bin/bash
+URUNC_TIMESTAMPS=1 /usr/local/bin/containerd-shim-urunc-v2 $@
+EOT
+
+sudo chmod +x /usr/local/bin/containerd-shim-uruncts-v2
+```
+
+To add the "timestamping" urunc to containerd config:
+
+```bash
+sudo tee -a /etc/containerd/config.toml > /dev/null << 'EOT'
+# timestamping urunc
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.uruncts]
+    runtime_type = "io.containerd.uruncts.v2"
+    container_annotations = ["com.urunc.unikernel.*"]
+    pod_annotations = ["com.urunc.unikernel.*"]
+    snapshotter = "devmapper"
+EOT
+sudo systemctl restart containerd.service
+```
+
+## How to gather timestamps
+
+Now we need to run a unikernel using the new container runtime `uruncts`:
+
+```bash
+sudo nerdctl run --rm --snapshotter devmapper --runtime io.containerd.uruncts.v2 \
+    harbor.nbfc.io/nubificus/urunc/hello-hvt-rump:latest
+```
+
+The timestamp logs are located at `/tmp/urunc.zlog`:
+
+```bash
+cat /tmp/urunc.zlog | grep TS
+{"message":"57657c7c5564e6b01171b926181a4ffb41a6a7c08f2ee4db3cd860f34b4aed18,cTS00,1702485404611088480"}
+{"message":"57657c7c5564e6b01171b926181a4ffb41a6a7c08f2ee4db3cd860f34b4aed18,cTS01,1702485404618102044"}
+{"message":"57657c7c5564e6b01171b926181a4ffb41a6a7c08f2ee4db3cd860f34b4aed18,TS00,1702485404618120655"}
+{"message":"57657c7c5564e6b01171b926181a4ffb41a6a7c08f2ee4db3cd860f34b4aed18,TS01,1702485404618804315"}
+{"message":"57657c7c5564e6b01171b926181a4ffb41a6a7c08f2ee4db3cd860f34b4aed18,TS02,1702485404618914546"}
+{"message":"57657c7c5564e6b01171b926181a4ffb41a6a7c08f2ee4db3cd860f34b4aed18,TS03,1702485404619039581"}
+# ... (rest of the output)
+```
+
+> Note: the timestamp destination (`/tmp/urunc.zlog`) is hardcoded for the time being.
+
+## Using the Python utilities
+
+There are 3 Python utilites inside the `script/performance` directory to help gather the timestamps.
+
+### Measure single container execution
+
+To gather the timestamps produced by a single unikernel container execution, you can use the `measure_single.py` script, passing the desired container id.
+
+```bash
+cd urunc/script/performance
+python3 measure_single.py 15c769b9be14c59174626521f7964a8ae06e75c48c5cfd91e2829317c15d455b
+```
+
+If no container ID is specified, it will return an error:
+
+```bash
+$ python3 measure_single.py 
+Error: Container ID not specified!
+
+Usage:
+        measure_single.py <CONTAINER_ID>
+```
+
+Sample output:
+
+```
+$ python3 measure_single.py 1bd50216c1709b854f78d50ec36cbbc55e0d4bc2e1509344082b51edc974af6d
+TS00 -> TS01:   1086512 ns
+TS01 -> TS02:   97936 ns
+TS02 -> TS03:   119786 ns
+# ... (rest of the output)
+```
+
+### Automatically measure multiple containers
+
+To automatically gather the timestamps produced by multiple unikernel container executions you can use the `measure.py` script, passing the desired iterations amount. Make sure to use `sudo` or execute this script as root, as it relies on `nerdctl` for spawning the unikernel containers.
+
+```bash
+cd urunc/script/performance
+sudo python3 measure.py 5
+```
+
+If the amount of iterations is not specified, it will return an error:
+
+```bash
+$ sudo python3 measure.py 
+Error: Iterations not specified!
+
+Usage:
+        measure.py <ITERATIONS>
+```
+
+Sample output:
+
+```
+$ sudo python3 measure.py 2
+{'TS00 -> TS01': {'average': '11544405 ns',
+                  'maximum': '22292698 ns',
+                  'minimum': '796112 ns'},
+ 'TS01 -> TS02': {'average': '127228 ns',
+                  'maximum': '157051 ns',
+                  'minimum': '97405 ns'},
+ 'TS02 -> TS03': {'average': '120198 ns',
+                  'maximum': '162634 ns',
+                  'minimum': '77763 ns'},
+# ... (rest of the output)
+```
+
+
+The same functionality is provided by `measure_to_json.py`, but instead of `stdout` the results are saved in a .json file:
+
+```bash
+sudo python3 measure_to_json.py 5 ts.json
+cat ts.json | jq
+{
+  "TS00 -> TS01": {
+    "maximum": "989525 ns",
+    "minimum": "474103 ns",
+    "average": "719644 ns"
+  },
+  "TS01 -> TS02": {
+    "maximum": "212337 ns",
+    "minimum": "76951 ns",
+    "average": "122868 ns"
+# ... (rest of the output)
+```
+
+If the amount of iterations or output file are not specified, it will return an error:
+
+```bash
+$ sudo python3 measure_to_json.py 5 
+Error: Iterations or output file not specified!
+
+Usage:
+        measure_to_json.py <ITERATIONS> <OUTPUT>
+```

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/moby/sys/mount v0.3.3
 	github.com/nubificus/hedge_cli v0.0.3
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
+	github.com/rs/zerolog v1.31.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.0
@@ -29,7 +30,7 @@ require (
 	github.com/containerd/go-runc v1.0.0 // indirect
 	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
-	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.4.0 // indirect
@@ -42,6 +43,8 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,9 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -471,7 +472,12 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -598,6 +604,9 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
+github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -896,6 +905,8 @@ golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,44 @@
+package metrics
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+)
+
+var enableTimestamps = os.Getenv("URUNC_TIMESTAMPS")
+
+type Writer interface {
+	Log(msg string)
+}
+
+type zerologMetrics struct {
+	logger *zerolog.Logger
+}
+
+func (z *zerologMetrics) Log(msg string) {
+	z.logger.Log().Msg(msg)
+}
+
+func NewZerologMetrics(target string) Writer {
+	if enableTimestamps == "1" {
+		file, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			return nil
+		}
+
+		logger := zerolog.New(file).Level(zerolog.InfoLevel)
+		return &zerologMetrics{
+			logger: &logger,
+		}
+	}
+	return &mockWriter{}
+}
+
+type mockWriter struct{}
+
+func (m *mockWriter) Log(_ string) {}
+
+func NewMockMetrics(_ string) Writer {
+	return &mockWriter{}
+}

--- a/script/performance/__modules__.py
+++ b/script/performance/__modules__.py
@@ -1,0 +1,153 @@
+from json import loads, dump
+from typing import List, Tuple, Dict
+from subprocess import run, PIPE
+
+
+class Timestamp:
+    def __init__(self, tsID: str, timestamp: int) -> None:
+        self.tsID = tsID
+        self.timestamp = timestamp
+
+    def __repr__(self) -> str:
+        return f'{self.tsID}: {self.timestamp}'
+
+    def __sub__(self, other):
+        return int(self.timestamp - other.timestamp)
+
+    @classmethod
+    def fromLogLine(cls, logLine: str):
+        raw_ts = loads(logLine)['message']
+        raw_ts_parts = raw_ts.split(",")
+        tsID = str(raw_ts_parts[1])
+        timestamp = int(raw_ts_parts[2])
+        return cls(tsID=tsID, timestamp=timestamp)
+
+
+class TimestampDiff:
+    startTsID: str
+    stopTsID: str
+    tdID: str
+    duration: int
+
+    def __init__(self, startTsID: str, stopTsID: str, duration: int) -> None:
+        self.startTsID = startTsID
+        self.stopTsID = stopTsID
+        self.duration = duration
+        self.tdID = f"{startTsID} -> {stopTsID}"
+
+    def __str__(self) -> str:
+        return f"{self.startTsID} -> {self.stopTsID}:\t{self.duration} ns"
+
+    @classmethod
+    def fromTimestamps(cls, start: Timestamp, stop: Timestamp):
+        duration = stop-start
+        return cls(startTsID=start.tsID, stopTsID=stop.tsID, duration=duration)
+
+
+class TimestampSeries:
+
+    timestamps: List[Timestamp]
+    containerID: str
+
+    def __init__(self, data: List[str]) -> None:
+        self.timestamps = []
+        self.containerID = str(loads(data[0])['message'].split(",")[0])
+        for line in data:
+            self.timestamps.append(Timestamp.fromLogLine(logLine=line))
+
+    def __str__(self) -> str:
+        msg = ""
+        for ts in self.sorted:
+            msg += f'{ts.tsID}:  {ts.timestamp}\n'
+        msg += "\n"
+        for i in range(len(self.common)):
+            cts = self.common[i]
+            msg += f'{cts[0].tsID}: {cts[0].timestamp}\n'
+            msg += f'{cts[1].tsID}: {cts[1].timestamp}\n\n'
+        msg = msg[:-2]
+        return msg
+
+    @property
+    def report(self) -> str:
+        msg = ""
+        for i in range(len(self.sorted)-1):
+            diff = TimestampDiff.fromTimestamps(
+                start=self.sorted[i], stop=self.sorted[i+1])
+            msg += f"{diff}\n"
+        msg = msg[:-1]
+        return msg
+
+    @property
+    def diffs(self) -> Dict[str, TimestampDiff]:
+        diffs = {}
+        for i in range(len(self.sorted)-1):
+            diff = TimestampDiff.fromTimestamps(
+                start=self.sorted[i], stop=self.sorted[i+1])
+            diffs[diff.tdID] = diff
+        return diffs
+
+    @property
+    def common(self) -> List[Tuple[Timestamp]]:
+        temp = []
+        for i in range(len(self.timestamps)):
+            ts = self.timestamps[i]
+            if ts.tsID == 'cTS00':
+                this = (ts, self.timestamps[i+1])
+                temp.append(this)
+        return temp
+
+    @property
+    def sorted(self) -> List[Timestamp]:
+        unique = [ts for ts in self.timestamps if 'cTS' not in ts.tsID]
+        temp = [ts for ts in unique]
+        temp.sort(key=lambda x: int(x.timestamp))
+        return temp
+
+
+def parseSingleContainerTimestamps(filename: str, containerID: str) -> List[str]:
+    with open(filename, 'r') as f:
+        data = f.readlines()
+        return [line for line in data if containerID in line]
+
+
+def emptyFile(filename: str) -> None:
+    open(filename, "w").close()
+
+
+def spawnContainer() -> str:
+    command = "nerdctl run --name redis-test -d --snapshotter devmapper --runtime io.containerd.uruncts.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+    cmdParts = command.split(" ")
+    cmd = run(cmdParts,
+              stdout=PIPE,
+              text=True)
+    response = cmd.stdout
+    containerID = response.splitlines()[-1]
+    return containerID
+
+
+def deleteContainer() -> bool:
+    command = "nerdctl rm --force redis-test"
+    cmdParts = command.split(" ")
+    cmd = run(cmdParts,
+              stdout=PIPE,
+              text=True)
+    response = cmd.stdout
+    containerID = response.splitlines()[-1]
+    return containerID == "redis-test"
+
+
+def myprint(msg: str):
+    print(msg)
+    clear_line()
+
+
+def clear_line(n=1):
+    line_up = '\033[1A'
+    line_clear = '\x1b[2K'
+    for i in range(n):
+        print(line_up, end=line_clear)
+
+
+def saveToJsonFile(filename: str, data: dict):
+    with open(filename, "w") as file:
+        dump(data, file)

--- a/script/performance/measure.py
+++ b/script/performance/measure.py
@@ -1,0 +1,59 @@
+from __modules__ import *
+from sys import argv
+from time import sleep
+from pprint import pprint
+
+LOGFILE = "/tmp/urunc.zlog"
+DELAY = 2
+
+
+def main():
+    if len(argv) != 2:
+        print("Error: Iterations not specified!")
+        print("")
+        print("Usage:")
+        print(f"\t{argv[0]} <ITERATIONS>")
+        exit(1)
+    iterations = int(argv[1])
+    myprint(f"Collecting timestamps for {iterations} iterations")
+    sleep(2)
+    emptyFile(filename=LOGFILE)
+    containerIDs = []
+    for i in range(iterations):
+        myprint(f"Running iteration {i+1} of {iterations}")
+        containerID = spawnContainer()
+        containerIDs.append(containerID)
+        sleep(DELAY)
+        success = deleteContainer()
+        if not success:
+            print("Error removing container.")
+            exit(1)
+    myprint("Done")
+    timestampDiffs = {}
+    for containerID in containerIDs:
+        data = parseSingleContainerTimestamps(
+            filename=LOGFILE, containerID=containerID)
+        series = TimestampSeries(data=data)
+        diffs = series.diffs
+        for key in diffs:
+            value = diffs[key]
+            if key in timestampDiffs:
+                timestampDiffs[key].append(value)
+            else:
+                timestampDiffs[key] = [value]
+    result = {}
+    for key in timestampDiffs:
+        value = timestampDiffs[key]
+        current = timestampDiffs[key]
+        durations = [c.duration for c in current]
+        max_duration = f"{max(durations)} ns"
+        min_duration = f"{min(durations)} ns"
+        avg_duration = f"{int(sum(durations)/len(durations))} ns"
+        result[key] = {"maximum": max_duration,
+                       "minimum": min_duration, "average": avg_duration}
+    pprint(result)
+    emptyFile(filename=LOGFILE)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/performance/measure_single.py
+++ b/script/performance/measure_single.py
@@ -1,0 +1,22 @@
+from __modules__ import *
+from sys import argv
+
+LOGFILE = "/tmp/urunc.zlog"
+
+
+def main():
+    if len(argv) != 2:
+        print("Error: Container ID not specified!")
+        print("")
+        print("Usage:")
+        print(f"\t{argv[0]} <CONTAINER_ID>")
+        exit(1)
+    containerID = argv[1]
+    data = parseSingleContainerTimestamps(
+        filename=LOGFILE, containerID=containerID)
+    series = TimestampSeries(data=data)
+    print(series.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/performance/measure_to_json.py
+++ b/script/performance/measure_to_json.py
@@ -1,0 +1,68 @@
+from __modules__ import *
+from sys import argv
+from time import sleep
+from pprint import pprint
+
+LOGFILE = "/tmp/urunc.zlog"
+DELAY = 2
+
+
+def main():
+    if len(argv) != 3:
+        print("Error: Iterations or output file not specified!")
+        print("")
+        print("Usage:")
+        print(f"\t{argv[0]} <ITERATIONS> <OUTPUT>")
+        exit(1)
+    iterations = int(argv[1])
+    outputFile = argv[2]
+    myprint(f"Collecting timestamps for {iterations} iterations")
+    sleep(2)
+    emptyFile(filename=LOGFILE)
+    containerIDs = []
+    for i in range(iterations):
+        myprint(f"Running iteration {i+1} of {iterations}")
+        containerID = spawnContainer()
+        containerIDs.append(containerID)
+        sleep(DELAY)
+        success = deleteContainer()
+        if not success:
+            print("Error removing container.")
+            exit(1)
+    myprint("Done")
+    timestampDiffs = {}
+    for containerID in containerIDs:
+        data = parseSingleContainerTimestamps(
+            filename=LOGFILE, containerID=containerID)
+        series = TimestampSeries(data=data)
+        diffs = series.diffs
+        for key in diffs:
+            value = diffs[key]
+            if key in timestampDiffs:
+                timestampDiffs[key].append(value)
+            else:
+                timestampDiffs[key] = [value]
+    result = {}
+    for key in timestampDiffs:
+        value = timestampDiffs[key]
+        current = timestampDiffs[key]
+        durations = [c.duration for c in current]
+        max_duration = f"{max(durations)} ns"
+        min_duration = f"{min(durations)} ns"
+        avg_duration = f"{int(sum(durations)/len(durations))} ns"
+        result[key] = {"maximum": max_duration,
+                       "minimum": min_duration, "average": avg_duration}
+    saveToJsonFile(outputFile, result)
+    emptyFile(filename=LOGFILE)
+
+    # nerdctl run --name redis-test -d --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest
+    # nerdctl rm --force redis-test
+
+    # data = parseSingleContainerTimestamps(
+    #     filename=LOGFILE, containerID=containerID)
+    # series = TimestampSeries(data=data)
+    # print(series.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/benchmark_test.go
+++ b/tests/benchmarks/benchmark_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	m "github.com/nubificus/urunc/pkg/metrics"
+)
+
+func BenchmarkZerologWriter(b *testing.B) {
+	var zerologWriter = m.NewZerologMetrics(("/tmp/urunc.zlog"))
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 20; j++ {
+			zerologWriter.Log(fmt.Sprintf("run%d", j))
+		}
+	}
+}
+
+func BenchmarkMockWriter(b *testing.B) {
+	var mockWriter = m.NewMockMetrics(("/tmp/urunc.zlog"))
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 20; j++ {
+			mockWriter.Log(fmt.Sprintf("run%d", j))
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces timestamping logs to accurately measure `urunc`'s performance.

- Implement timestamp logging using zerolog to minimize overhead
- Develop Python scripts to gather timestamps
- Add documentation for enabling timestamping
- Add documentation for the Python scripts

Fixes: #9