### PR TITLE
Add end-to-end tests for Qemu-Unikraft

### DIFF
--- a/tests/crictl/crictl_test.go
+++ b/tests/crictl/crictl_test.go
@@ -13,33 +13,6 @@ import (
 	common "github.com/nubificus/urunc/tests"
 )
 
-const PodConfig = `{
-    "metadata": {
-        "name": "redis-sandbox",
-        "namespace": "default",
-        "attempt": 1,
-        "uid": "abcshd83djaidwnduwk28bcsb"
-    },
-    "linux": {
-    }
-}
-`
-
-const ContainerConfig = `{
-	"metadata": {
-		"name": "redis-hvt"
-	},
-	"image":{
-		"image": "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
-	},
-	"command": [
-		"/unikernel/redis6.hvt"
-	],
-	"linux": {
-	}
-  }
-`
-
 func writeToFile(filename string, content string) error {
 	f, err := os.Create(filename)
 	if err != nil {
@@ -54,6 +27,32 @@ func writeToFile(filename string, content string) error {
 }
 
 func TestCrictlHvtRumprunRedis(t *testing.T) {
+	var podConfig = `{
+		"metadata": {
+			"name": "redis-sandbox",
+			"namespace": "default",
+			"attempt": 1,
+			"uid": "abcshd83djaidwnduwk28bcsb"
+		},
+		"linux": {
+		}
+	}
+	`
+	var containerConfig = `{
+		"metadata": {
+			"name": "redis-hvt"
+		},
+		"image":{
+			"image": "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+		},
+		"command": [
+			"/unikernel/redis6.hvt"
+		],
+		"linux": {
+		}
+	  }
+	`
+
 	// create config files
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -61,12 +60,12 @@ func TestCrictlHvtRumprunRedis(t *testing.T) {
 	}
 	absPodConf := filepath.Join(cwd, "pod.json")
 	absContConf := filepath.Join(cwd, "cont.json")
-	err = writeToFile(absPodConf, PodConfig)
+	err = writeToFile(absPodConf, podConfig)
 	if err != nil {
 		t.Fatalf("Failed to write pod config: %v", err)
 	}
 	defer os.Remove(absPodConf)
-	err = writeToFile(absContConf, ContainerConfig)
+	err = writeToFile(absContConf, containerConfig)
 	if err != nil {
 		t.Fatalf("Failed to write container config: %v", err)
 	}
@@ -141,5 +140,122 @@ func TestCrictlHvtRumprunRedis(t *testing.T) {
 	proc, _ = common.FindProc("solo5-hvt")
 	if proc != nil {
 		t.Fatal("solo5-hvt process is still alive")
+	}
+}
+
+func TestCrictlQemuUnikraftRedis(t *testing.T) {
+	var podConfig = `{
+		"metadata": {
+			"name": "redis-sandbox",
+			"namespace": "default",
+			"attempt": 1,
+			"uid": "abcshd83djaidwnduwk28bcsb"
+		},
+		"linux": {
+		}
+	}
+	`
+	var containerConfig = `{
+		"metadata": {
+			"name": "redis-qemu-unikraft"
+		},
+		"image":{
+			"image": "harbor.nbfc.io/nubificus/urunc/redis-qemu-unikraft-initrd@sha256:e45db3a656996212664a210381a18ca0b1823dc2aa92e64cbc8db08e1948e23d"
+		},
+		"command": [
+			"/unikernel/redis"
+		],
+		"linux": {
+		}
+	  }
+	`
+
+	// create config files
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Failed to retrieve current directory")
+	}
+	absPodConf := filepath.Join(cwd, "pod.json")
+	absContConf := filepath.Join(cwd, "cont.json")
+	err = writeToFile(absPodConf, podConfig)
+	if err != nil {
+		t.Fatalf("Failed to write pod config: %v", err)
+	}
+	defer os.Remove(absPodConf)
+	err = writeToFile(absContConf, containerConfig)
+	if err != nil {
+		t.Fatalf("Failed to write container config: %v", err)
+	}
+	defer os.Remove(absContConf)
+
+	// pull image
+	params := strings.Split("crictl pull harbor.nbfc.io/nubificus/urunc/redis-qemu-unikraft-initrd@sha256:e45db3a656996212664a210381a18ca0b1823dc2aa92e64cbc8db08e1948e23d", " ")
+	cmd := exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to pull image: %v\n%s", err, output)
+	}
+
+	// start unikernel in pod
+	params = strings.Split("crictl run --runtime=urunc cont.json pod.json", " ")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to run unikernel: %v\n%s", err, output)
+	}
+	time.Sleep(2 * time.Second)
+	// Find the qemu process
+	proc, err := common.FindProc("qemu-system")
+	if err != nil {
+		t.Fatalf("Failed to find qemu-system process: %v", err)
+	}
+	cmdLine, err := proc.Cmdline()
+	if err != nil {
+		t.Fatalf("Failed to find qemu-system process' command line: %v", err)
+	}
+	// Extract the IP address
+	re := regexp.MustCompile(`netdev.ipv4_addr=([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)`)
+	match := re.FindStringSubmatch(cmdLine)
+	extractedIPAddr := ""
+	if len(match) == 2 {
+		extractedIPAddr = match[1]
+	} else {
+		t.Fatal("Failed to extract IP address for solo5 process")
+	}
+
+	// Create a new Pinger and ping the redis IP
+	pinger, err := ping.NewPinger(extractedIPAddr)
+	if err != nil {
+		t.Fatalf("Failed to create Pinger: %v", err)
+	}
+	pinger.Count = 3
+	err = pinger.Run() // Blocks until finished.
+	if err != nil {
+		t.Fatalf("Failed to ping %s: %v", extractedIPAddr, err)
+	}
+
+	// Find pod ID
+	params = strings.Split("crictl pods -q", " ")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to find pod: %v\n%s", err, output)
+	}
+
+	podID := string(output)
+	podID = strings.TrimSpace(podID)
+
+	// Stop and remove pod
+	params = strings.Split("crictl rmp --force "+podID, " ")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to stop and remove pod: %v\n%s", err, output)
+	}
+
+	// Check if solo5 process still alive
+	proc, _ = common.FindProc("qemu-system")
+	if proc != nil {
+		t.Fatal("qemu-system process is still alive")
 	}
 }

--- a/tests/nerdctl/nerdctl_test.go
+++ b/tests/nerdctl/nerdctl_test.go
@@ -137,3 +137,107 @@ func TestNerdctlSptUnikraft(t *testing.T) {
 func TestNerdctlSptRumprun(t *testing.T) {
 	t.Log(NotImplemented)
 }
+
+func TestNerdctlQemuUnikraftRedis(t *testing.T) {
+	params := strings.Split("nerdctl run --name redis-qemu-test -d --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-qemu-unikraft-initrd:latest", " ")
+	cmd := exec.Command(params[0], params[1:]...) //nolint:gosec
+	containerIDBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%v: Error executing redis unikraft unikernel with qemu using nerdctl: %s", err, containerIDBytes)
+	}
+	time.Sleep(2 * time.Second)
+	// Get the container ID
+	containerID := string(containerIDBytes)
+	containerID = strings.TrimSpace(containerID)
+
+	// Find the qemu process
+	proc, err := common.FindProc("qemu")
+	if err != nil {
+		t.Fatalf("Failed to find qemu process: %v", err)
+	}
+	cmdLine, err := proc.Cmdline()
+	if err != nil {
+		t.Fatalf("Failed to find qemu process's command line: %v", err)
+	}
+
+	// Extract the IP address
+	re := regexp.MustCompile(`netdev.ipv4_addr=([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)`)
+	match := re.FindStringSubmatch(cmdLine)
+	extractedIPAddr := ""
+	if len(match) == 2 {
+		extractedIPAddr = match[1]
+	} else {
+		t.Fatal("Failed to extract IP address for qemu process")
+	}
+
+	// Create a new Pinger and ping the redis IP
+	pinger, err := ping.NewPinger(extractedIPAddr)
+	if err != nil {
+		t.Fatalf("Failed to create Pinger: %v", err)
+	}
+	pinger.Count = 3
+	err = pinger.Run() // Blocks until finished.
+	if err != nil {
+		t.Fatalf("Failed to ping %s: %v", extractedIPAddr, err)
+	}
+	// Stop the unikernel
+	stopCmdString := "nerdctl stop " + containerID
+	params = strings.Split(stopCmdString, " ")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("%v: Error stopping redis unikraft unikernel with qemu using nerdctl", err)
+	}
+	retMsg := strings.TrimSpace(string(output))
+	if containerID != retMsg {
+		t.Fatalf("Unexpected output when stopping redis. Expected: %s, got: %s", containerID, retMsg)
+	}
+
+	// Delete the unikernel
+	deleteCmdString := "nerdctl rm " + containerID
+	params = strings.Split(deleteCmdString, " ")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("%v: Error deleting redis unikraft unikernel with qemu using nerdctl", err)
+	}
+	retMsg = strings.TrimSpace(string(output))
+	if containerID != retMsg {
+		t.Fatalf("Unexpected output when deleting redis. Expected: %s, got: %s", containerID, retMsg)
+	}
+
+	// Check the unikernel is removed from nerdctl ps -a
+	listCmdString := "nerdctl ps -a --no-trunc -q"
+	params = strings.Split(listCmdString, " ")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("%v: Error listing all containers using nerdctl", err)
+	}
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+	for _, line := range lines {
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+		cID := strings.TrimSpace(line)
+		if cID == containerID {
+			t.Fatalf("Unikernel %s was not successfully removed from nerdctl", containerID)
+		}
+	}
+
+	// Check /run/containerd/runc/default/containerID directory does not exist
+	dirPath := "/run/containerd/runc/default/" + containerID
+	_, err = os.Stat(dirPath)
+	if !os.IsNotExist(err) {
+		t.Fatalf("root directory %s still exists", dirPath)
+	}
+
+	// Check /run/containerd/io.containerd.runtime.v2.task/default/containerID directory does not exist
+	dirPath = "run/containerd/io.containerd.runtime.v2.task/default/" + containerID
+	_, err = os.Stat(dirPath)
+	if !os.IsNotExist(err) {
+		t.Fatalf("bundle directory %s still exists", dirPath)
+	}
+}


### PR DESCRIPTION
This commit adds end-to-end tests for booting Unikraft unikernels with Qemu using `nerdctl`, `ctr` and `crictl`.