### PR TITLE
Introduce support to boot up Firecracker with initrd

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -47,6 +47,7 @@ type InterfaceInfo struct {
 	DefaultGateway string
 	Mask           string
 	Interface      string
+	MAC            string
 }
 
 func getInterfaceInfo(iface string) (InterfaceInfo, error) {
@@ -54,6 +55,12 @@ func getInterfaceInfo(iface string) (InterfaceInfo, error) {
 	if err != nil {
 		return InterfaceInfo{}, err
 	}
+
+	IfMAC := ief.HardwareAddr.String()
+	if IfMAC == "" {
+		return InterfaceInfo{}, fmt.Errorf("failed to get MAC address of %q", iface)
+	}
+
 	addrs, err := ief.Addrs()
 	if err != nil {
 		return InterfaceInfo{}, err
@@ -92,6 +99,7 @@ func getInterfaceInfo(iface string) (InterfaceInfo, error) {
 		DefaultGateway: gateway.String(),
 		Mask:           mask,
 		Interface:      iface,
+		MAC:            IfMAC,
 	}, nil
 }
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -1,0 +1,128 @@
+// Copyright 2023 Nubificus LTD.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const (
+	FirecrackerVmm    VmmType = "firecracker"
+	FirecrackerBinary string  = "firecracker"
+)
+
+type Firecracker struct {
+	binaryPath string
+	binary     string
+}
+
+type FirecrackerBootSource struct {
+	ImagePath  string `json:"kernel_image_path"`
+	BootArgs   string `json:"boot_args"`
+	InitrdPath string `json:"initrd_path,omitempty"`
+}
+
+type FirecrackerMachine struct {
+	VcpuCount       uint `json:"vcpu_count"`
+	MemSizeMiB      uint `json:"mem_size_mib"`
+	Smt             bool `json:"smt"`
+	TrackDirtyPages bool `json:"track_dirty_pages"`
+}
+
+type FirecrackerDrive struct {
+	DriveID   string `json:"drive_id"`
+	IsRO      bool   `json:"is_read_only"`
+	IsRootDev bool   `json:"is_root_device"`
+	HostPath  string `json:"path_on_host"`
+}
+
+type FirecrackerNet struct {
+	IfaceID  string `json:"iface_id"`
+	GuestMAC string `json:"guest_mac,omitempty"`
+	HostIF   string `json:"host_dev_name"`
+}
+
+type FirecrackerConfig struct {
+	Source  FirecrackerBootSource `json:"boot-source"`
+	Machine FirecrackerMachine    `json:"machine-config"`
+	Drives  []FirecrackerDrive    `json:"drives"`
+	NetIfs  []FirecrackerNet      `json:"network-interfaces"`
+}
+
+func (fc *Firecracker) Stop(_ string) error {
+	return nil
+}
+
+func (fc *Firecracker) Ok() error {
+	return nil
+}
+func (fc *Firecracker) Path() string {
+	return fc.binaryPath
+}
+
+func (fc *Firecracker) Execve(args ExecArgs) error {
+	cmdString := fc.Path() + " --no-api --config-file "
+	JSONConfigDir := filepath.Dir(args.UnikernelPath)
+	JSONConfigFile := filepath.Join(JSONConfigDir, "fc.json")
+	cmdString += JSONConfigFile
+
+	// VM config for Firecracker
+	FCMachine := FirecrackerMachine{
+		VcpuCount:       1,   // TODO: Use value from configuration or Environment variable
+		MemSizeMiB:      256, // TODO: Use value from configuration or Environment variable
+		Smt:             false,
+		TrackDirtyPages: false,
+	}
+
+	// Net config for Firecracker
+	FCNet := make([]FirecrackerNet, 0)
+	AnIF := FirecrackerNet{
+		IfaceID:  "net1",
+		GuestMAC: args.GuestMAC,
+		HostIF:   args.TapDevice,
+	}
+	FCNet = append(FCNet, AnIF)
+
+	// Block config for Firecracker
+	// TODO: Add support for block devices in FIrecracker
+	FCDrives := make([]FirecrackerDrive, 0)
+
+	FCSource := FirecrackerBootSource{
+		ImagePath:  args.UnikernelPath,
+		BootArgs:   args.Command,
+		InitrdPath: args.InitrdPath,
+	}
+	FCConfig := &FirecrackerConfig{
+		Source:  FCSource,
+		Machine: FCMachine,
+		Drives:  FCDrives,
+		NetIfs:  FCNet,
+	}
+	FCConfigJSON, _ := json.Marshal(FCConfig)
+	if err := os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
+		return fmt.Errorf("failed to save Firecracker json config: %w", err)
+	}
+	vmmLog.WithField("Json=", string(FCConfigJSON)).Info("Firecracker json config")
+
+	exArgs := strings.Split(cmdString, " ")
+	vmmLog.WithField("Firecracker command", exArgs).Info("Ready to execve Firecracker")
+
+	return syscall.Exec(fc.Path(), exArgs, args.Environment) //nolint: gosec
+}

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -32,6 +32,7 @@ type ExecArgs struct {
 	InitrdPath    string   // The path to the initrd of the unikernel
 	Command       string   // The unikernel's command line
 	IPAddress     string   // The IP address of the TAP device
+	GuestMAC      string   // The MAC address of the guest network device
 	Environment   []string // Environment
 }
 
@@ -66,6 +67,12 @@ func NewVMM(vmmType VmmType) (vmm VMM, err error) {
 			return nil, ErrVMMNotInstalled
 		}
 		return &Qemu{binary: QemuBinary, binaryPath: vmmPath}, nil
+	case FirecrackerVmm:
+		vmmPath, err := exec.LookPath(FirecrackerBinary)
+		if err != nil {
+			return nil, ErrVMMNotInstalled
+		}
+		return &Firecracker{binary: FirecrackerBinary, binaryPath: vmmPath}, nil
 	case HedgeVmm:
 		hedge := Hedge{}
 		err := hedge.Ok()

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -175,6 +175,9 @@ func (u *Unikontainer) Exec() error {
 	if networkInfo != nil {
 		vmmArgs.TapDevice = networkInfo.TapDevice
 		vmmArgs.IPAddress = networkInfo.EthDevice.IP
+		// The MAC address for the guest network device is the same as the
+		// ethernet device inside the namespace
+		vmmArgs.GuestMAC = networkInfo.EthDevice.MAC
 		unikernelParams.EthDeviceIP = networkInfo.EthDevice.IP
 		unikernelParams.EthDeviceMask = networkInfo.EthDevice.Mask
 		unikernelParams.EthDeviceGateway = networkInfo.EthDevice.DefaultGateway


### PR DESCRIPTION
Add initial support for booting unikernels over Firecracker with urunc. For the time being, we do not have support for virtio-blk, but only for initrd. THerefore, the guest can only read data from the initrd. Regarding networking, we use virtio-net  over the tap interface  that we create with urunc. Currently there is support for only one network device per guest. Moreover, in the case of Firecracker the guest's network interface has the same MAC address as the tap interface in the network namespace of the container.

Overall, things we need to consider in the future:
- Support for virtio-blk
- VM memory
- Generate Firecracker's configuration, based on a specific config
- Use Firecracker's API to spawn, instead of creating a JSON file

Fixes #8 