### PR TITLE
Network: Add static network mode

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -80,7 +80,6 @@ var createCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-
 			return createUnikontainer(context)
 		}
 		err := handleNonBimaContainer(context)

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -76,6 +76,10 @@ var createCommand = cli.Command{
 		if !context.Bool("reexec") {
 			containerID := context.Args().First()
 			metrics.Capture(containerID, "TS00")
+			err := handleQueueProxy(context)
+			if err != nil {
+				return err
+			}
 			return createUnikontainer(context)
 		}
 		containerID := context.Args().First()

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -68,10 +68,6 @@ var createCommand = cli.Command{
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}
-		err := handleNonBimaContainer(context)
-		if err != nil {
-			return err
-		}
 
 		if !context.Bool("reexec") {
 			containerID := context.Args().First()
@@ -80,8 +76,18 @@ var createCommand = cli.Command{
 			if err != nil {
 				return err
 			}
+			err = handleNonBimaContainer(context)
+			if err != nil {
+				return err
+			}
+
 			return createUnikontainer(context)
 		}
+		err := handleNonBimaContainer(context)
+		if err != nil {
+			return err
+		}
+
 		containerID := context.Args().First()
 		metrics.Capture(containerID, "TS04")
 		return reexecUnikontainer(context)

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -15,13 +15,17 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 
+	"github.com/nubificus/urunc/internal/constants"
 	"github.com/nubificus/urunc/pkg/unikontainers"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -111,4 +115,66 @@ func fatalWithCode(err error, ret int) {
 	}
 
 	os.Exit(ret)
+}
+
+// handleQueueProxy checks if the provided bundle contains a queue-proxy container
+// and adds a hardcoded IP to the process's environment
+func handleQueueProxy(context *cli.Context) error {
+	logrus.Error("handleQueueProxy")
+	containerID := context.Args().First()
+	root := context.GlobalString("root")
+	if containerID == "" {
+		return nil
+	}
+	ctrNamespace := filepath.Base(root)
+	bundle := filepath.Join("/run/containerd/io.containerd.runtime.v2.task/", ctrNamespace, containerID)
+
+	var spec specs.Spec
+	absDir, err := filepath.Abs(bundle)
+	if err != nil {
+		return fmt.Errorf("failed to find absolute bundle path: %w", err)
+	}
+	configDir := filepath.Join(absDir, "config.json")
+	data, err := os.ReadFile(configDir)
+	if err != nil {
+		return fmt.Errorf("failed to read config.json: %w", err)
+	}
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return fmt.Errorf("failed to parse config.json: %w", err)
+	}
+	containerName := spec.Annotations["io.kubernetes.cri.container-name"]
+	if containerName == "queue-proxy" {
+		logrus.Error("This is a queue-proxy container. Adding IP env.")
+		for i, envVar := range spec.Process.Env {
+			if strings.HasPrefix(envVar, "SERVING_READINESS_PROBE") {
+				spec.Process.Env = remove(spec.Process.Env, i)
+				break
+			}
+		}
+		readinessProbeEnv := fmt.Sprintf("SERVING_READINESS_PROBE={\"tcpSocket\":{\"port\":8080,\"host\":\"%s\"},\"successThreshold\":1}", constants.QueueProxyRedirectIP)
+		redirectIPEnv := fmt.Sprintf("REDIRECT_IP=%s", constants.QueueProxyRedirectIP)
+		envs := []string{readinessProbeEnv, redirectIPEnv}
+		spec.Process.Env = append(spec.Process.Env, envs...)
+		fileInfo, err := os.Stat(configDir)
+		if err != nil {
+			return fmt.Errorf("error getting file info: %v", err)
+		}
+		permissions := fileInfo.Mode()
+		// Write the modified struct back to the JSON file
+		updatedData, err := json.MarshalIndent(spec, "", "  ")
+		if err != nil {
+			return fmt.Errorf("error marshalling JSON: %v", err)
+		}
+
+		err = os.WriteFile(configDir, updatedData, permissions)
+		if err != nil {
+			return fmt.Errorf("error writing to file: %v", err)
+		}
+	}
+	return nil
+}
+
+func remove(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
 }

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -118,7 +118,9 @@ func fatalWithCode(err error, ret int) {
 }
 
 // handleQueueProxy checks if the provided bundle contains a queue-proxy container
-// and adds a hardcoded IP to the process's environment
+// and adds a hardcoded IP to the process's environment.
+// Then, the container is identified as a non-bima container
+// is spawned using runc.
 func handleQueueProxy(context *cli.Context) error {
 	logrus.Error("handleQueueProxy")
 	containerID := context.Args().First()

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -87,6 +87,10 @@ func handleNonBimaContainer(context *cli.Context) error {
 		return nil
 	}
 	logrus.Info("This is a normal container. Calling runc...")
+	return runcExec()
+}
+
+func runcExec() error {
 	args := os.Args
 	binPath, err := exec.LookPath("runc")
 	if err != nil {
@@ -172,6 +176,7 @@ func handleQueueProxy(context *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("error writing to file: %v", err)
 		}
+		return runcExec()
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/nubificus/urunc
 go 1.18
 
 require (
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/containerd/containerd v1.6.10
 	github.com/creack/pty v1.1.11
 	github.com/go-ping/ping v1.1.0
 	github.com/jackpal/gateway v1.0.10
 	github.com/moby/sys/mount v0.3.3
 	github.com/nubificus/hedge_cli v0.0.3
+	github.com/opencontainers/runc v1.1.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/rs/zerolog v1.31.0
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -96,6 +97,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
+github.com/checkpoint-restore/go-criu/v5 v5.3.0 h1:wpFFOoomK3389ue2lAb0Boag6XPht5QYpipxmSNL4d8=
+github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -236,6 +239,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
@@ -494,6 +499,7 @@ github.com/moby/sys/mount v0.3.3 h1:fX1SVkXFJ47XWDoeFW4Sq7PdQJnV2QIDZAqjNqgEjUs=
 github.com/moby/sys/mount v0.3.3/go.mod h1:PBaEorSNTLG5t/+4EgukEQVlAvVEc6ZjTySwKdqp5K0=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
+github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
@@ -503,6 +509,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -547,6 +554,8 @@ github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
+github.com/opencontainers/runc v1.1.2 h1:2VSZwLx5k/BfsBxMMipG/LYUnmqOD/BPkIVgQUcTlLw=
+github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -558,6 +567,8 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -614,6 +625,8 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921 h1:58EBmR2dMNL2n/FnbQewK3D14nXr0V9CObDSvMJLq+Y=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil/v3 v3.23.9 h1:ZI5bWVeu2ep4/DIxB4U9okeYJ7zp/QLTO4auRb/ty/E=
@@ -670,6 +683,7 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
@@ -902,6 +916,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/constants/network_constants.go
+++ b/internal/constants/network_constants.go
@@ -17,6 +17,7 @@ package constants
 const (
 	StaticNetworkTapIP       = "172.16.1.1"
 	StaticNetworkUnikernelIP = "172.16.1.2"
-	DynamicNetworkTapIP      = "172.16.X.2"
-	QueueProxyRedirectIP     = "172.16.1.2"
+	// TODO: Experiment with DynamicNetworkTapIP starting from 172.16.X.1
+	DynamicNetworkTapIP  = "172.16.X.2"
+	QueueProxyRedirectIP = "172.16.1.2"
 )

--- a/internal/constants/network_constants.go
+++ b/internal/constants/network_constants.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Nubificus LTD.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	StaticNetworkTapIP       = "172.16.1.1"
+	StaticNetworkUnikernelIP = "172.16.1.2"
+	DynamicNetworkTapIP      = "172.16.X.2"
+	QueueProxyRedirectIP     = "172.16.1.2"
+)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -40,7 +40,6 @@ func NewZerologMetrics(target string) Writer {
 		if err != nil {
 			return nil
 		}
-		defer file.Close()
 		logger := zerolog.New(file).Level(zerolog.InfoLevel).With().Timestamp().Logger()
 		zerolog.TimeFieldFormat = zerolog.TimeFormatUnixNano
 		return &zerologMetrics{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Nubificus LTD.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metrics
 
 import (
@@ -26,6 +40,7 @@ func NewZerologMetrics(target string) Writer {
 		if err != nil {
 			return nil
 		}
+		defer file.Close()
 		logger := zerolog.New(file).Level(zerolog.InfoLevel).With().Timestamp().Logger()
 		zerolog.TimeFieldFormat = zerolog.TimeFormatUnixNano
 		return &zerologMetrics{

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os/user"
+	"strconv"
 	"strings"
 
 	"github.com/jackpal/gateway"
@@ -71,6 +73,9 @@ func getTapIndex() (int, error) {
 		if strings.Contains(iface.Name, "tap") {
 			tapCount++
 		}
+	}
+	if tapCount > 255 {
+		return tapCount, fmt.Errorf("TAP interfaces count higher than 255")
 	}
 	return tapCount, nil
 }
@@ -211,4 +216,61 @@ func addRedirectFilter(source netlink.Link, target netlink.Link) error {
 			},
 		},
 	})
+}
+
+func networkSetup(tapName string, ipAdrress string, redirectLink netlink.Link, addTCRules bool) (netlink.Link, error) {
+	err := ensureEth0Exists()
+	// if eth0 does not exist in the namespace, the unikernel was spawned using ctr, so we skip the network setup
+	if err != nil {
+		netlog.Info("eth0 interface not found, assuming unikernel was spawned using ctr")
+		return nil, nil
+	}
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	uid, err := strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		return nil, err
+	}
+	gid, err := strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		return nil, err
+	}
+	newTapDevice, err := createTapDevice(tapName, redirectLink.Attrs().MTU, uid, gid)
+	if err != nil {
+		return nil, err
+	}
+	if addTCRules {
+		err = addIngressQdisc(newTapDevice)
+		if err != nil {
+			return nil, err
+		}
+		err = addIngressQdisc(redirectLink)
+		if err != nil {
+			return nil, err
+		}
+		err = addRedirectFilter(newTapDevice, redirectLink)
+		if err != nil {
+			return nil, err
+		}
+		err = addRedirectFilter(redirectLink, newTapDevice)
+		if err != nil {
+			return nil, err
+		}
+	}
+	ipn, err := netlink.ParseAddr(ipAdrress)
+	if err != nil {
+		return nil, err
+	}
+	err = netlink.AddrReplace(newTapDevice, ipn)
+	if err != nil {
+		return nil, err
+	}
+
+	err = netlink.LinkSetUp(newTapDevice)
+	if err != nil {
+		return nil, err
+	}
+	return newTapDevice, nil
 }

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Nubificus LTD.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"strings"
+
+	"github.com/nubificus/urunc/internal/constants"
+	"github.com/vishvananda/netlink"
+)
+
+type DynamicNetwork struct {
+}
+
+// NetworkSetup checks if any tap device is available in the current netns. If not,
+// creates a new tap device and sets TC rules between the veth interface and the tap device inside the namespace.
+// If one or more tap devices are already present in the netns, it creates a new tap device
+// without tc rules and returns.
+//
+// FIXME: CUrrently only the first tap device can provide functional networking. The rest are "dummy" devices
+// rendering the unikernels they are attached to unreachable. We need to find a proper way to handle networking
+// for multiple unikernels in the same pod/network namespace
+// See: https://github.com/nubificus/urunc/issues/13
+func (n DynamicNetwork) NetworkSetup() (*UnikernelNetworkInfo, error) {
+	err := ensureEth0Exists()
+	// if eth0 does not exist in the namespace, the unikernel was spawned using ctr, so we skip the network setup
+	if err != nil {
+		netlog.Info("eth0 interface not found, assuming unikernel was spawned using ctr")
+		return nil, nil
+	}
+	redirectLink, err := netlink.LinkByName(DefaultInterface)
+	if err != nil {
+		netlog.Errorf("failed to find %s  interface", DefaultInterface)
+		return nil, err
+	}
+	ifInfo, err := getInterfaceInfo(DefaultInterface)
+	if err != nil {
+		return nil, err
+	}
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	uid, err := strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		return nil, err
+	}
+	gid, err := strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		return nil, err
+	}
+	tapIndex, err := getTapIndex()
+	if err != nil {
+		return nil, err
+	}
+	newTapName := strings.ReplaceAll(DefaultTap, "X", strconv.Itoa(tapIndex))
+	newTapDevice, err := createTapDevice(newTapName, redirectLink.Attrs().MTU, uid, gid)
+	if err != nil {
+		return nil, err
+	}
+	if tapIndex == 0 {
+		err = addIngressQdisc(newTapDevice)
+		if err != nil {
+			return nil, err
+		}
+		err = addIngressQdisc(redirectLink)
+		if err != nil {
+			return nil, err
+		}
+		err = addRedirectFilter(newTapDevice, redirectLink)
+		if err != nil {
+			return nil, err
+		}
+		err = addRedirectFilter(redirectLink, newTapDevice)
+		if err != nil {
+			return nil, err
+		}
+	}
+	ipTemplate := fmt.Sprintf("%s/24", constants.DynamicNetworkTapIP)
+	newIPAddr := strings.ReplaceAll(ipTemplate, "X", strconv.Itoa(tapIndex+1))
+	ipn, err := netlink.ParseAddr(newIPAddr)
+	if err != nil {
+		return nil, err
+	}
+	err = netlink.AddrReplace(newTapDevice, ipn)
+	if err != nil {
+		return nil, err
+	}
+
+	err = netlink.LinkSetUp(newTapDevice)
+	if err != nil {
+		return nil, err
+	}
+	return &UnikernelNetworkInfo{
+		TapDevice: newTapDevice.Attrs().Name,
+		EthDevice: ifInfo,
+	}, nil
+}

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Nubificus LTD.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"strings"
+
+	"github.com/nubificus/urunc/internal/constants"
+	"github.com/vishvananda/netlink"
+)
+
+var StaticIPAddr = fmt.Sprintf("%s/24", constants.StaticNetworkTapIP)
+
+type StaticNetwork struct {
+}
+
+func (n StaticNetwork) NetworkSetup() (*UnikernelNetworkInfo, error) {
+	err := ensureEth0Exists()
+	if err != nil {
+		netlog.Error("failed to find eth0 interface in current netns")
+		return nil, err
+	}
+	redirectLink, err := netlink.LinkByName(DefaultInterface)
+	if err != nil {
+		netlog.Errorf("failed to find %s  interface", DefaultInterface)
+		return nil, err
+	}
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	uid, err := strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		return nil, err
+	}
+	gid, err := strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		return nil, err
+	}
+	newTapName := strings.ReplaceAll(DefaultTap, "X", "0")
+	newTapDevice, err := createTapDevice(newTapName, redirectLink.Attrs().MTU, uid, gid)
+	if err != nil {
+		return nil, err
+	}
+	ipn, err := netlink.ParseAddr(StaticIPAddr)
+	if err != nil {
+		return nil, err
+	}
+	err = netlink.AddrReplace(newTapDevice, ipn)
+	if err != nil {
+		return nil, err
+	}
+	err = netlink.LinkSetUp(newTapDevice)
+	if err != nil {
+		return nil, err
+	}
+	return &UnikernelNetworkInfo{
+		TapDevice: newTapDevice.Attrs().Name,
+		EthDevice: Interface{
+			IP:             constants.StaticNetworkUnikernelIP,
+			DefaultGateway: constants.StaticNetworkTapIP,
+			Mask:           "255.255.255.0",
+			Interface:      "eth0", // or tap0_urunc?
+			MAC:            redirectLink.Attrs().HardwareAddr.String(),
+		},
+	}, nil
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -169,7 +169,7 @@ func (u *Unikontainer) Exec() error {
 	}
 	networkInfo, err := netManager.NetworkSetup()
 	if err != nil {
-		return err
+		Log.Errorf("Failed to setup network :%v. Possibly due to ctr", err)
 	}
 	metrics.Capture(u.State.ID, "TS17")
 

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -163,7 +163,11 @@ func (u *Unikontainer) Exec() error {
 	}
 
 	// handle network
-	networkInfo, err := network.Setup()
+	netManager, err := network.NewNetworkManager(u.getNetworkType())
+	if err != nil {
+		return err
+	}
+	networkInfo, err := netManager.NetworkSetup()
 	if err != nil {
 		return err
 	}
@@ -590,4 +594,12 @@ func (u *Unikontainer) isRunning() bool {
 	hedge := hypervisors.Hedge{}
 	state := hedge.VMState(u.State.ID)
 	return state == "running"
+}
+
+// getNetworkType checks if current container is a knative user-container
+func (u Unikontainer) getNetworkType() string {
+	if u.Spec.Annotations["io.kubernetes.cri.container-name"] == "user-container" {
+		return "static"
+	}
+	return "dynamic"
 }

--- a/tests/crictl/crictl_test.go
+++ b/tests/crictl/crictl_test.go
@@ -3,15 +3,20 @@ package urunc
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/asaskevich/govalidator"
 	common "github.com/nubificus/urunc/tests"
+	_ "github.com/opencontainers/runc/libcontainer/nsenter"
+	"github.com/vishvananda/netns"
 )
 
 func TestCrictlHvtRumprunRedis(t *testing.T) {
@@ -368,6 +373,160 @@ func TestCrictlFCUnikraftNginx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ping failed: %v", err)
 	}
+
+	// Find pod ID
+	params = strings.Fields("crictl pods -q")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to find pod: %v\n%s", err, output)
+	}
+
+	podID := string(output)
+	podID = strings.TrimSpace(podID)
+
+	// Stop and remove pod
+	params = strings.Fields("crictl rmp --force " + podID)
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to stop and remove pod: %v\n%s", err, output)
+	}
+
+	proc, _ = common.FindProc(procName)
+	if proc != nil {
+		t.Fatalf("%s process is still alive", procName)
+	}
+}
+
+func TestCrictlHTTPStaticNet(t *testing.T) {
+	containerImage := "harbor.nbfc.io/nubificus/httpreply-fc:x86_64"
+	procName := "firecracker"
+	podConfig := crictlSandboxConfig("fc-unikraft-knative-sandbox")
+
+	// user-container is used as "io.kubernetes.cri.container-name" annotation by crictl
+	// in order to trigger the static net mode
+	containerConfig := crictlContainerConfig("user-container", containerImage)
+
+	// create config files
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Failed to retrieve current directory")
+	}
+	absPodConf := filepath.Join(cwd, "pod.json")
+	absContConf := filepath.Join(cwd, "cont.json")
+	err = writeToFile(absPodConf, podConfig)
+	if err != nil {
+		t.Fatalf("Failed to write pod config: %v", err)
+	}
+	defer os.Remove(absPodConf)
+	err = writeToFile(absContConf, containerConfig)
+	if err != nil {
+		t.Fatalf("Failed to write container config: %v", err)
+	}
+	defer os.Remove(absContConf)
+
+	// pull image
+	params := []string{"crictl", "pull", containerImage}
+	cmd := exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to pull image: %v\n%s", err, output)
+	}
+
+	// start unikernel in pod
+	params = strings.Fields("crictl run --runtime=urunc cont.json pod.json")
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to run unikernel: %v\n%s", err, output)
+	}
+	time.Sleep(2 * time.Second)
+	proc, err := common.FindProc(procName)
+	if err != nil {
+		t.Fatalf("Failed to find %s process: %v", procName, err)
+	}
+	netNs, err := netns.GetFromPid(int(proc.Pid))
+	if err != nil {
+		t.Fatalf("Failed to find %s process network namespace: %v", procName, err)
+	}
+	origns, _ := netns.Get()
+	defer origns.Close()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	err = netns.Set(netNs)
+	defer func() {
+		err := netns.Set(origns)
+		if err != nil {
+			t.Fatalf("Failed to revert to default network nampespace: %v", err)
+		}
+	}()
+	if err != nil {
+		t.Fatalf("Failed to change network namespace: %v", err)
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatalf("Failed to get all interfaces in current network namespace: %v", err)
+	}
+	var tapUrunc net.Interface
+	for _, iface := range ifaces {
+		if strings.Contains(iface.Name, "urunc") {
+			tapUrunc = iface
+			break
+		}
+	}
+	if tapUrunc.Name == "" {
+		var names []string
+		for _, iface := range ifaces {
+			names = append(names, iface.Name)
+		}
+		err = fmt.Errorf("Expected tap0_urunc, got %v", names)
+		t.Fatalf("Failed to find urunc's tap device: %v", err)
+	}
+
+	addrs, err := tapUrunc.Addrs()
+	if err != nil {
+		t.Fatalf("Failed to get %s interface's IP addresses: %v", tapUrunc.Name, err)
+	}
+	ipAddr := ""
+	for _, addr := range addrs {
+		tmp := strings.Split(addr.String(), "/")[0]
+		if govalidator.IsIPv4(tmp) {
+			ipAddr = tmp
+			break
+		}
+	}
+	if ipAddr == "" {
+		t.Fatalf("Failed to get %s interface's IPv4 address", tapUrunc.Name)
+	}
+	parts := strings.Split(ipAddr, ".")
+	newIP := fmt.Sprintf("%s.%s.%s.2", parts[0], parts[1], parts[2])
+	url := fmt.Sprintf("http://%s:8080", newIP)
+	curlCmd := fmt.Sprintf("curl %s", url)
+	params = strings.Fields(curlCmd)
+	cmd = exec.Command(params[0], params[1:]...) //nolint:gosec
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to run curl: %v\n%s", err, output)
+	}
+	if string(output) == "" {
+		t.Fatal("Failed to receive valid response")
+	}
+
+	// FIXME: Investigate why the GET request using net/http fails, while is successful using curl
+	//
+	// client := http.DefaultClient
+	// client.Timeout = 10 * time.Second
+	// resp, err := client.Get(url)
+	// if err != nil {
+	// 	t.Logf("Failed to perform GET request to %s: %v", url, err)
+	// }
+	// defer resp.Body.Close()
+	// body, err := io.ReadAll(resp.Body)
+	// if err != nil {
+	// 	t.Logf("Error reading response body: %v", err)
+	// }
+	// t.Log(string(body))
 
 	// Find pod ID
 	params = strings.Fields("crictl pods -q")


### PR DESCRIPTION
This PR brings support for dynamic and static network mode.

Static network mode allows urunc to be used to run Knative user functions packaged in unikernels.
In Knative, each user function container must run alongside a queue-proxy container inside the same pod.

To support this, we check if the current container is a queue-proxy container or a user-function container.
A ENV variable with a static IP is injected in the queue-proxy container before calling `runc` to actually execute it. 
Then, the user-function unikernel interface is assigned a static IP which is reachable by the queue-proxy container. 
In that way, the queue-proxy container can reach the user-function unikernel inside the same Pod / network namespace to provide the usual Knative functionality.

Dynamic network mode allows for creating multiple TAP devices in the same network interface to allow multiple unikernels to be spawned inside the same Pod / network namespace.
BUT, only the first TAP devices provides working networking (via TC). The other TAP devices are not reachable. So, only the first unikernel of each Pod / network namespace have actual networking functionality.

This PR also fixes issue #13 in dynamic network mode.