### PR TITLE
ci: Update shutdown flag

### DIFF
--- a/.github/resources/profiles.yml
+++ b/.github/resources/profiles.yml
@@ -9,7 +9,7 @@ ubuntuthin:
     - size: 10
   keys:
     - mydefaultkey.pub
-  shutdown_flag: false
+  shutdown_flag: true
 
 ubuntuurunc:
   client: fuji00
@@ -21,7 +21,7 @@ ubuntuurunc:
   disks: [20]
   keys:
     - mydefaultkey.pub
-  shutdown_flag: false
+  shutdown_flag: true
 
 ubuntufat:
   client: fuji00
@@ -34,5 +34,5 @@ ubuntufat:
     - size: 30
   keys:
     - mydefaultkey.pub
-  shutdown_flag: false
+  shutdown_flag: true
   


### PR DESCRIPTION
For the VM test workflow, the default behavior should be to shutdown the VM after the test. If we debug stuff on a PR, we should be able to change this to false, so that the VM stays online and we can manually shut it down. Otherwise, it leaves stale VMs on our infra.

partially addresses https://github.com/nubificus/roadmap/issues/204