### PR TITLE
internal: move constants to separate pkg

### DIFF
--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/nubificus/urunc/internal/constants"
 	m "github.com/nubificus/urunc/internal/metrics"
 	"github.com/sirupsen/logrus"
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -57,7 +58,7 @@ value for "bundle" is the current directory.`
 var version string
 
 // FIXME: We need to find a way to set the output file
-var metrics = m.NewZerologMetrics("/tmp/urunc.zlog")
+var metrics = m.NewZerologMetrics(constants.TimestampTargetFile)
 
 func main() {
 	root := "/run/urunc"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Nubificus LTD.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const TimestampTargetFile = "/tmp/urunc.zlog"

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
+	"github.com/nubificus/urunc/internal/constants"
 	m "github.com/nubificus/urunc/internal/metrics"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -131,7 +132,7 @@ func (u *Unikontainer) Create(pid int) error {
 
 func (u *Unikontainer) Exec() error {
 	// FIXME: We need to find a way to set the output file
-	var metrics = m.NewZerologMetrics("/tmp/urunc.zlog")
+	var metrics = m.NewZerologMetrics(constants.TimestampTargetFile)
 	err := u.joinSandboxNetNs()
 	if err != nil {
 		return err

--- a/tests/benchmarks/benchmark_test.go
+++ b/tests/benchmarks/benchmark_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/nubificus/urunc/internal/constants"
 	m "github.com/nubificus/urunc/internal/metrics"
 )
 
 func BenchmarkZerologWriter(b *testing.B) {
-	var zerologWriter = m.NewZerologMetrics(("/tmp/urunc.zlog"))
+	var zerologWriter = m.NewZerologMetrics(constants.TimestampTargetFile)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 20; j++ {
 			zerologWriter.Capture(fmt.Sprintf("container%02d", i), fmt.Sprintf("TS%02d", j))
@@ -17,7 +18,7 @@ func BenchmarkZerologWriter(b *testing.B) {
 }
 
 func BenchmarkMockWriter(b *testing.B) {
-	var mockWriter = m.NewMockMetrics(("/tmp/urunc.zlog"))
+	var mockWriter = m.NewMockMetrics(constants.TimestampTargetFile)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 20; j++ {
 			mockWriter.Capture(fmt.Sprintf("container%02d", i), fmt.Sprintf("TS%02d", j))


### PR DESCRIPTION
Create internal pkg to hold constants. Setting all constants in a single place will help to manage constants in future versions.
Move timestamp logging output file declaration to new package.