### PR TITLE
ci: Remove generated ssh key after artifact creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-      branches:
-        - main
   pull_request:
     branches: [ "main" ]
     types:
@@ -15,6 +12,7 @@ on:
 
 jobs:
   build:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     runs-on: [ self-hosted, "${{ matrix.archconfig }}", go]
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,5 @@
 name: Code linting
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches: [ "main" ]
     types:
@@ -16,6 +13,7 @@ permissions:
 
 jobs:
   golangci:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -1,8 +1,5 @@
 name: custom VM spawner 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches: [ "main" ]
     types:
@@ -16,7 +13,8 @@ env:
 
 jobs:
   prepare:
-    name: 
+    name: VM test
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     runs-on: [ self-hosted, gcc, lite, "x86_64" ]
     # outputs:
 
@@ -28,10 +26,8 @@ jobs:
         sudo rm -rf ${{ github.workspace }}/.??*
         sudo rm -rf ~/.kcli
 
-
     - name: Checkout
       uses: actions/checkout@v3
-
 
     - name: get & install kcli
       id: kcli-install
@@ -98,8 +94,6 @@ jobs:
         echo "vm_spawn_result=$result" >> $GITHUB_ENV
         echo "vm_spawn_ip=$output" >> $GITHUB_ENV
       shell: bash
-        
-
 
     - name: Execute script in vm
       id: script-execute-vm
@@ -157,7 +151,6 @@ jobs:
           exit 1
         fi
 
-
     - name: Run crictl tests
       id: test-crictl
       if: ${{ !cancelled() }}
@@ -193,7 +186,6 @@ jobs:
         echo "clean kcli ssh keys"
         sudo rm -rf /home/runner/.ssh/id_rsa_kcli_${{ github.run_id }}
 
-
     - name: prepare artifacts
       id: prepare_artifacts
       if: ${{ !cancelled() }}
@@ -219,7 +211,3 @@ jobs:
       with:
         name: ${{ github.run_id }}_artifacts
         path: ${{ github.workspace }}/${{ github.run_id }}_artifacts.tar
-
-
-
-

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -211,6 +211,7 @@ jobs:
           echo $vm_spawn_ip >> ${{ github.workspace }}/${{ github.run_id }}_vm_info
           tar -rf ${{ github.workspace }}/${{ github.run_id }}_artifacts.tar -C ${{ github.workspace }} ${{ github.run_id }}_vm_info
         fi
+        sudo rm -rf /home/runner/.ssh/${{ github.run_id }}_ubuntu*
 
     - name: upload artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
There are cases when the tests job fails. If we want to re-run the specific test job, it will probably be placed in the same github runner. The job id will remain the same, so it will try to overwrite the generated ssh key.

This is probably a bug on the ci logic, as we should cleanup the generated keys.