### PR TITLE
Introduce support for seccomp in VMMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/containerd/containerd v1.6.10
 	github.com/creack/pty v1.1.11
+	github.com/elastic/go-seccomp-bpf v1.4.0
 	github.com/go-ping/ping v1.1.0
 	github.com/jackpal/gateway v1.0.10
 	github.com/moby/sys/mount v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elastic/go-seccomp-bpf v1.4.0 h1:6y3lYrEHrLH9QzUgOiK8WDqmPaMnnB785WxibCNIOH4=
+github.com/elastic/go-seccomp-bpf v1.4.0/go.mod h1:wIMxjTbKpWGQk4CV9WltlG6haB4brjSH/dvAohBPM1I=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -82,6 +82,9 @@ func (fc *Firecracker) Execve(args ExecArgs) error {
 	JSONConfigDir := filepath.Dir(args.UnikernelPath)
 	JSONConfigFile := filepath.Join(JSONConfigDir, "fc.json")
 	cmdString += JSONConfigFile
+	if !args.Seccomp {
+		cmdString += " --no-seccomp"
+	}
 
 	// VM config for Firecracker
 	FCMachine := FirecrackerMachine{

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -18,6 +18,8 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+
+	seccomp "github.com/elastic/go-seccomp-bpf"
 )
 
 const (
@@ -28,6 +30,85 @@ const (
 type HVT struct {
 	binaryPath string
 	binary     string
+}
+
+// applySeccompFIlter applies some secomp filters for the Hvt process.
+// By default all systemcalls will cause a SIGSYS, except the ones that we whitelist
+func applySeccompFilter() error {
+	syscalls := []string{
+		"rt_sigaction",
+		"ioctl",
+		"pread64",
+		"mmap",
+		"recvmsg",
+		"openat",
+		"sendto",
+		"mprotect",
+		"write",
+		"epoll_ctl",
+		"epoll_create1",
+		"read",
+		"open",
+		"close",
+		"fstat",
+		"stat",
+		"munmap",
+		"brk",
+		"access",
+		"execve",
+		"timerfd_create",
+		"arch_prctl",
+		"lseek",
+		"personality",
+		"socket",
+		"bind",
+		"getsockname",
+		"exit",
+		"exit_group",
+		"getpid",
+		"tgkill",
+		"nanosleep",
+		"futex",
+		"epoll_pwait",
+		"rt_sigreturn",
+		"timerfd_settime",
+		"pwrite64",
+	}
+	// Some of the actions that we can take for accessing non-permitted system calls are:
+	// - seccomp.ActionKillThread will kill the thread that tried to use a non-permitted
+	//	system call, but the rest of the threads can still run
+	// - seccomp.ActionErrno will result to returning EPERM error in all non-permitted
+	//	system calls.
+	// - ActionTrap will cause a SIGSYS trap to the process.
+	//
+	// For the time being, we choose ActionTrap, but we can change this in the future.
+	filter := seccomp.Filter{
+		// Set the threads no_new_privs bit, disabling any new child or execve
+		// system call to grant priviledges that the parent does not have.
+		NoNewPrivs: true,
+		// Sync the filter to all threads created by the Go runtime.
+		Flag: seccomp.FilterFlagTSync,
+		Policy: seccomp.Policy{
+			DefaultAction: seccomp.ActionTrap,
+			Syscalls: []seccomp.SyscallGroup{
+				{
+					Action: seccomp.ActionAllow,
+					Names:  syscalls,
+				},
+			},
+		},
+	}
+
+	err := seccomp.LoadFilter(filter)
+	if err != nil {
+		vmmLog.Error("Could not load seccomp filters")
+		return err
+	}
+
+	vmmLog.Info("Loaded seccomp filters")
+	vmmLog.Debug("Whitelisted system calls ", syscalls)
+
+	return nil
 }
 
 // Stop is an empty function to satisfy VMM interface compatibility requirements.
@@ -55,6 +136,10 @@ func (h *HVT) Execve(args ExecArgs) error {
 	cmdString = appendNonEmpty(cmdString, " --block:rootfs=", args.BlockDevice)
 	cmdString += " " + args.UnikernelPath + " " + args.Command
 	cmdArgs := strings.Split(cmdString, " ")
+	err := applySeccompFilter()
+	if err != nil {
+		return err
+	}
 	vmmLog.WithField("hvt command", cmdString).Error("Ready to execve hvt")
 	return syscall.Exec(h.binaryPath, cmdArgs, args.Environment) //nolint: gosec
 }

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -136,9 +136,11 @@ func (h *HVT) Execve(args ExecArgs) error {
 	cmdString = appendNonEmpty(cmdString, " --block:rootfs=", args.BlockDevice)
 	cmdString += " " + args.UnikernelPath + " " + args.Command
 	cmdArgs := strings.Split(cmdString, " ")
-	err := applySeccompFilter()
-	if err != nil {
-		return err
+	if args.Seccomp {
+		err := applySeccompFilter()
+		if err != nil {
+			return err
+		}
 	}
 	vmmLog.WithField("hvt command", cmdString).Error("Ready to execve hvt")
 	return syscall.Exec(h.binaryPath, cmdArgs, args.Environment) //nolint: gosec

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -44,6 +44,9 @@ func (q *Qemu) Path() string {
 func (q *Qemu) Execve(args ExecArgs) error {
 	cmdString := q.Path() + " -cpu host -m 254 -enable-kvm -nographic -vga none"
 
+	// TODO: Add option to disable seccomp
+	cmdString += " --sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
+
 	// TODO: Check if this check causes any performance drop
 	// or explore alternative implementations
 	if runtime.GOARCH == "arm64" {

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -44,8 +44,18 @@ func (q *Qemu) Path() string {
 func (q *Qemu) Execve(args ExecArgs) error {
 	cmdString := q.Path() + " -cpu host -m 254 -enable-kvm -nographic -vga none"
 
-	// TODO: Add option to disable seccomp
-	cmdString += " --sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
+	if args.Seccomp {
+		// Enable Seccomp in QEMU
+		cmdString += " --sandbox on"
+		// Allow or Deny Obsolete system calls
+		cmdString += ",obsolete=deny"
+		// Allow or Deny set*uid|gid system calls
+		cmdString += ",elevateprivileges=deny"
+		// Allow or Deny *fork and execve
+		cmdString += ",spawn=deny"
+		// Allow or Deny process affinity and schedular priority
+		cmdString += ",resourcecontrol=deny"
+	}
 
 	// TODO: Check if this check causes any performance drop
 	// or explore alternative implementations

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -33,6 +33,7 @@ type ExecArgs struct {
 	Command       string   // The unikernel's command line
 	IPAddress     string   // The IP address of the TAP device
 	GuestMAC      string   // The MAC address of the guest network device
+	Seccomp       bool     // Enable or disable seccomp filters for the VMM
 	Environment   []string // Environment
 }
 

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -154,7 +154,14 @@ func (u *Unikontainer) Exec() error {
 		Container:     u.State.ID,
 		UnikernelPath: unikernelAbsPath,
 		InitrdPath:    initrdAbsPath,
+		Seccomp:       true, // Enable Seccomp by default
 		Environment:   os.Environ(),
+	}
+
+	// Check if container is set to unconfined -- disable seccomp
+	if u.Spec.Linux.Seccomp == nil {
+		Log.Warn("Seccomp is disabled")
+		vmmArgs.Seccomp = false
 	}
 
 	// populate unikernel params


### PR DESCRIPTION
Introduce support to enable or disable seccomp filters for the VMM process that executes the unikernel. The seccomp filters will disallow access to system calls that are not required by the VMMs.  Seccomp support is targeting Hvt, Qemu and Firecrakcer. Moreover, the seccomp filters can be deactivated by using the `--security-opt seccomp=unconfined` command line option in nerdctl.

For the time being, we do not support custom seccomp filters, since we only want to reduce the system calls the VMM can do and not the ones of the application.