### PR TITLE
Change Unikraft code to follow the unikernel interface

### DIFF
--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -46,7 +46,11 @@ func UnikernelCommand(unikernelType UnikernelType, data UnikernelParams) (string
 		}
 		return command, nil
 	case UnikraftUnikernel:
-		command, err := newUnikraftCli(data)
+		unikernel, err := newUnikraft(data)
+		if err != nil {
+			return "", err
+		}
+		command, err := unikernel.CommandString()
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Unikraft was not following the unikontainer's unikernel interface. This commit aims to change that, by rewriting parts of the unikraft code to follow the interface that unikontainers defines for the various unikernels