### PR TITLE
Enhance unikernel interface with functions to check supporting features

### DIFF
--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -19,7 +19,10 @@ import "errors"
 type UnikernelType string
 
 type Unikernel interface {
+	Init(UnikernelParams) error
 	CommandString() (string, error)
+	SupportsBlock() bool
+	SupportsFS(string) bool
 }
 
 // UnikernelParams holds the data required to build the unikernels commandline
@@ -33,29 +36,15 @@ type UnikernelParams struct {
 
 var ErrNotSupportedUnikernel = errors.New("unikernel is not supported")
 
-func UnikernelCommand(unikernelType UnikernelType, data UnikernelParams) (string, error) {
+func New(unikernelType UnikernelType) (Unikernel, error) {
 	switch unikernelType {
 	case RumprunUnikernel:
-		unikernel, err := newRumprun(data)
-		if err != nil {
-			return "", err
-		}
-		command, err := unikernel.CommandString()
-		if err != nil {
-			return "", err
-		}
-		return command, nil
+		unikernel := newRumprun()
+		return unikernel, nil
 	case UnikraftUnikernel:
-		unikernel, err := newUnikraft(data)
-		if err != nil {
-			return "", err
-		}
-		command, err := unikernel.CommandString()
-		if err != nil {
-			return "", err
-		}
-		return command, nil
+		unikernel := newUnikraft()
+		return unikernel, nil
 	default:
-		return "", ErrNotSupportedUnikernel
+		return nil, ErrNotSupportedUnikernel
 	}
 }


### PR DESCRIPTION
Change the way we initialize a unikernel struct reference and add three more functions in the unikernel interface.

Instead of creating a new unikernel struct directly, we split the creation and initialization of the unikernel struct. Therfore, at first, we simply create a new unikernel struct, based on the unikernel type and then we initialize it with the new Init function in the unikernel interface. The reason behind this change is to allow the use of unikernel-specific functions (e.g. SupportsBlock()) without initializing a new unikernel struct. In that way, we can use this function during the delete phase, as a check for devmapper cleaning.

Moreover, we add three more functions in the unikernel interface:
- Init(): which initializes the unikernel struct based on the unikernel arguments
- SupportsBlock(): which returns a bool value, based on the block support of the respective unikernel.
- SupportsFS(); which takes as an argument a filesystem type and checks if the unikernel supports that type.