### PR TITLE
ci: Add action for unit testing

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,28 @@
+name: Run unit tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types:
+      - synchronize
+      - labeled
+
+permissions:
+  contents: read
+  # allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  unit-test:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    name: unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18'
+          cache: false
+      - name: Run unikontainers pkg unit tests
+        run: make unittest
+

--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,5 @@ test_unikontainers:
 unittest: test_unikontainers
 	-@echo "unit tests: DONE"
 
-test: test_nerdctl test_ctr test_crictl unittest
+test: test_nerdctl test_ctr test_crictl
 	-@echo "DONE"


### PR DESCRIPTION
This PR adds a separate workflow to perform any unit tests, since there is no need to perform them inside the VM used for end-to-end tests.