### PR TITLE
Refactor the way we treat storage for unikernels

### DIFF
--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -38,6 +38,7 @@ type UnikernelConfig struct {
 	Initrd          string `json:"com.urunc.unikernel.initrd,omitempty"`
 	Block           string `json:"com.urunc.unikernel.block,omitempty"`
 	BlkMntPoint     string `json:"com.urunc.unikernel.blkMntPoint,omitempty"`
+	UseDMBlock      string `json:"com.urunc.unikernel.useDMBlock"`
 }
 
 // GetUnikernelConfig tries to get the Unikernel config from the bundle annotations.
@@ -75,6 +76,7 @@ func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 	initrd := spec.Annotations["com.urunc.unikernel.initrd"]
 	block := spec.Annotations["com.urunc.unikernel.block"]
 	blkMntPoint := spec.Annotations["com.urunc.unikernel.blkMntPoint"]
+	useDMBlock := spec.Annotations["com.urunc.unikernel.useDMBlock"]
 
 	Log.WithFields(logrus.Fields{
 		"unikernelType":   unikernelType,
@@ -84,6 +86,7 @@ func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 		"initrd":          initrd,
 		"block":           block,
 		"blkMntPoint":     blkMntPoint,
+		"useDMBlock":      useDMBlock,
 	}).Info("urunc annotations")
 
 	// TODO: We need to use a better check to see if annotations were empty
@@ -99,6 +102,7 @@ func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 		Initrd:          initrd,
 		Block:           block,
 		BlkMntPoint:     blkMntPoint,
+		UseDMBlock:      useDMBlock,
 	}, nil
 }
 
@@ -137,6 +141,7 @@ func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
 		"initrd":          conf.Initrd,
 		"block":           conf.Block,
 		"blkMntPoint":     conf.BlkMntPoint,
+		"useDMBlock":      conf.UseDMBlock,
 	}).Info("urunc.json annotations")
 	return &conf, nil
 }
@@ -185,6 +190,12 @@ func (c *UnikernelConfig) decode() error {
 	}
 	c.BlkMntPoint = string(decoded)
 
+	decoded, err = base64.StdEncoding.DecodeString(c.UseDMBlock)
+	if err != nil {
+		return fmt.Errorf("failed to decode UseDMBlock: %v", err)
+	}
+	c.UseDMBlock = string(decoded)
+
 	return nil
 }
 
@@ -212,5 +223,11 @@ func (c *UnikernelConfig) Map() map[string]string {
 	if c.BlkMntPoint != "" {
 		myMap["com.urunc.unikernel.blkMntPoint"] = c.BlkMntPoint
 	}
+	if c.UseDMBlock != "" {
+		myMap["com.urunc.unikernel.useDMBlock"] = c.UseDMBlock
+	} else {
+		myMap["com.urunc.unikernel.useDMBlock"] = os.Getenv("USE_DEVMAPPER_AS_BLOCK")
+	}
+
 	return myMap
 }

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -35,6 +35,8 @@ func TestGetConfigFromSpec(t *testing.T) {
 				"com.urunc.unikernel.binary":        "binary1",
 				"com.urunc.unikernel.hypervisor":    "hypervisor1",
 				"com.urunc.unikernel.initrd":        "initrd1",
+				"com.urunc.unikernel.block":         "block1",
+				"com.urunc.unikernel.blkMntPoint":   "point1",
 			},
 		}
 
@@ -44,6 +46,8 @@ func TestGetConfigFromSpec(t *testing.T) {
 			UnikernelCmd:    "cmd1",
 			Hypervisor:      "hypervisor1",
 			Initrd:          "initrd1",
+			Block:           "block1",
+			BlkMntPoint:     "point1",
 		}
 
 		config, err := getConfigFromSpec(spec)
@@ -95,6 +99,8 @@ func TestGetConfigFromJSON(t *testing.T) {
 			UnikernelCmd:    "cmd1",
 			Hypervisor:      "hypervisor1",
 			Initrd:          "initrd1",
+			Block:           "block1",
+			BlkMntPoint:     "point1",
 		}
 		configData, err := json.Marshal(expectedConfig)
 		assert.NoError(t, err)
@@ -223,6 +229,8 @@ func TestMap(t *testing.T) {
 			UnikernelCmd:    "cmd_value",
 			Hypervisor:      "hypervisor_value",
 			Initrd:          "initrd_value",
+			Block:           "block_value",
+			BlkMntPoint:     "point_value",
 		}
 		expectedMap := map[string]string{
 			"com.urunc.unikernel.cmdline":       "cmd_value",
@@ -230,6 +238,8 @@ func TestMap(t *testing.T) {
 			"com.urunc.unikernel.hypervisor":    "hypervisor_value",
 			"com.urunc.unikernel.binary":        "binary_value",
 			"com.urunc.unikernel.initrd":        "initrd_value",
+			"com.urunc.unikernel.block":         "block_value",
+			"com.urunc.unikernel.blkMntPoint":   "point_value",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
@@ -242,6 +252,8 @@ func TestMap(t *testing.T) {
 			UnikernelCmd:    "",
 			Hypervisor:      "",
 			Initrd:          "",
+			Block:           "",
+			BlkMntPoint:     "",
 		}
 		expectedMap := map[string]string{}
 		resultMap := config.Map()
@@ -255,11 +267,14 @@ func TestMap(t *testing.T) {
 			UnikernelCmd:    "cmd_value",
 			Hypervisor:      "",
 			Initrd:          "initrd_value",
+			Block:           "",
+			BlkMntPoint:     "point_value",
 		}
 		expectedMap := map[string]string{
-			"com.urunc.unikernel.cmdline": "cmd_value",
-			"com.urunc.unikernel.binary":  "binary_value",
-			"com.urunc.unikernel.initrd":  "initrd_value",
+			"com.urunc.unikernel.cmdline":     "cmd_value",
+			"com.urunc.unikernel.binary":      "binary_value",
+			"com.urunc.unikernel.initrd":      "initrd_value",
+			"com.urunc.unikernel.blkMntPoint": "point_value",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -37,6 +37,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 				"com.urunc.unikernel.initrd":        "initrd1",
 				"com.urunc.unikernel.block":         "block1",
 				"com.urunc.unikernel.blkMntPoint":   "point1",
+				"com.urunc.unikernel.useDMBlock":    "true",
 			},
 		}
 
@@ -48,6 +49,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 			Initrd:          "initrd1",
 			Block:           "block1",
 			BlkMntPoint:     "point1",
+			UseDMBlock:      "true",
 		}
 
 		config, err := getConfigFromSpec(spec)
@@ -101,6 +103,7 @@ func TestGetConfigFromJSON(t *testing.T) {
 			Initrd:          "initrd1",
 			Block:           "block1",
 			BlkMntPoint:     "point1",
+			UseDMBlock:      "true",
 		}
 		configData, err := json.Marshal(expectedConfig)
 		assert.NoError(t, err)
@@ -231,6 +234,7 @@ func TestMap(t *testing.T) {
 			Initrd:          "initrd_value",
 			Block:           "block_value",
 			BlkMntPoint:     "point_value",
+			UseDMBlock:      "false",
 		}
 		expectedMap := map[string]string{
 			"com.urunc.unikernel.cmdline":       "cmd_value",
@@ -240,6 +244,7 @@ func TestMap(t *testing.T) {
 			"com.urunc.unikernel.initrd":        "initrd_value",
 			"com.urunc.unikernel.block":         "block_value",
 			"com.urunc.unikernel.blkMntPoint":   "point_value",
+			"com.urunc.unikernel.useDMBlock":    "false",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
@@ -254,8 +259,11 @@ func TestMap(t *testing.T) {
 			Initrd:          "",
 			Block:           "",
 			BlkMntPoint:     "",
+			UseDMBlock:      "",
 		}
-		expectedMap := map[string]string{}
+		expectedMap := map[string]string{
+			"com.urunc.unikernel.useDMBlock": "",
+		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
 	})
@@ -269,12 +277,14 @@ func TestMap(t *testing.T) {
 			Initrd:          "initrd_value",
 			Block:           "",
 			BlkMntPoint:     "point_value",
+			UseDMBlock:      "0",
 		}
 		expectedMap := map[string]string{
 			"com.urunc.unikernel.cmdline":     "cmd_value",
 			"com.urunc.unikernel.binary":      "binary_value",
 			"com.urunc.unikernel.initrd":      "initrd_value",
 			"com.urunc.unikernel.blkMntPoint": "point_value",
+			"com.urunc.unikernel.useDMBlock":  "0",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
@@ -283,7 +293,9 @@ func TestMap(t *testing.T) {
 	t.Run("unikernelConfig map no fields", func(t *testing.T) {
 		t.Parallel()
 		config := &UnikernelConfig{}
-		expectedMap := map[string]string{}
+		expectedMap := map[string]string{
+			"com.urunc.unikernel.useDMBlock": "",
+		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
 	})

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -15,16 +15,22 @@
 package unikontainers
 
 import (
-	"strings"
+	"errors"
+	"os"
+	"path/filepath"
 
+	"github.com/moby/sys/mount"
 	"github.com/shirou/gopsutil/disk"
+	"github.com/sirupsen/logrus"
 )
+
+var ErrNotDevmapper = errors.New("Rootfs is not a devmapper device")
 
 // RootFs represents a root file system and its properties.
 type RootFs struct {
-	Path      string             // The path of the root file system.
-	IsBlock   bool               // Indicates if it's a block device.
-	BlkDevice disk.PartitionStat // Information about the block device.
+	Path   string // The path of the root file system.
+	Device string // The device which is mounted as the container rootfs
+	FsType string // The filesystem type of the mounted device
 }
 
 // getBlockDevice retrieves information about the block device associated with a given path.
@@ -32,7 +38,6 @@ type RootFs struct {
 // If the path is not a block device or there is an error, it returns an empty RootFs struct and an error.
 func getBlockDevice(path string, getPartitions func(bool) ([]disk.PartitionStat, error)) (RootFs, error) {
 	var result RootFs
-	result.IsBlock = false
 
 	// Retrieve a list of mounted partitions
 	parts, err := getPartitions(true)
@@ -45,15 +50,109 @@ func getBlockDevice(path string, getPartitions func(bool) ([]disk.PartitionStat,
 	for _, p := range parts {
 		if p.Mountpoint == path {
 			result.Path = path
-			result.BlkDevice = p
+			result.Device = p.Device
+			result.FsType = p.Fstype
 			break
 		}
 	}
 
-	// Check if the file system type is ext4 or ext2 and the device name contains "dm" (indicating a block device)
-	if (result.BlkDevice.Fstype == "ext4" || result.BlkDevice.Fstype == "ext2") && strings.Contains(result.BlkDevice.Device, "dm") {
-		result.IsBlock = true
-	}
+	Log.WithFields(logrus.Fields{
+		"mountpoint": result.Path,
+		"device":     result.Device,
+		"fstype":     result.FsType,
+	}).Debug("Found container rootfs mount")
 
 	return result, nil
+}
+
+// extractUnikernelFromBlock creates target directory inside the bundle and moves unikernel & urunc.json
+// FIXME: This approach fills up /run with unikernel binaries and urunc.json files for each unikernel we run
+func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bundle string) (string, error) {
+	// create bundle/tmp directory and moves unikernel binary and urunc.json
+	tmpDir := filepath.Join(bundle, "tmp")
+	err := os.Mkdir(tmpDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	currentUnikernelPath := filepath.Join(bundle, "rootfs", unikernel)
+	targetUnikernelPath := filepath.Join(tmpDir, unikernel)
+	targetUnikernelDir, _ := filepath.Split(targetUnikernelPath)
+	err = moveFile(currentUnikernelPath, targetUnikernelDir)
+	if err != nil {
+		err1 := os.RemoveAll(tmpDir)
+		if err1 != nil {
+			Log.Errorf("Could not remove directory %s", tmpDir)
+		}
+		return "", err
+	}
+
+	if initrd != "" {
+		currentInitrdPath := filepath.Join(bundle, "rootfs", initrd)
+		targetInitrdPath := filepath.Join(tmpDir, initrd)
+		targetInitrdDir, _ := filepath.Split(targetInitrdPath)
+		err = moveFile(currentInitrdPath, targetInitrdDir)
+		if err != nil {
+			err1 := os.RemoveAll(tmpDir)
+			if err1 != nil {
+				Log.Errorf("Could not remove directory %s", tmpDir)
+			}
+			return "", err
+		}
+	}
+
+	currentConfigPath := filepath.Join(bundle, "rootfs", uruncJSON)
+	err = moveFile(currentConfigPath, tmpDir)
+	if err != nil {
+		err1 := os.RemoveAll(tmpDir)
+		if err1 != nil {
+			Log.Errorf("Could not remove directory %s", tmpDir)
+		}
+		return "", err
+	}
+
+	return tmpDir, nil
+}
+
+// prepareDMAsBLock copies the files needed for the unikernel boot (e.g.
+// unikernel binary, initrd file) and the urunc.json file in a new temporary
+// directory. Then it unmounts the devmapper device and renames the temporary
+// directory as the container rootfs. This is needed to keep the same paths
+// for the unikernel files.
+func prepareDMAsBlock(bundle string, unikernel string, uruncJSON string, initrd string) error {
+	rootfsPath := filepath.Join(bundle, "rootfs")
+	// extract unikernel
+	// FIXME: This approach fills up /run with unikernel binaries and
+	// urunc.json files for each unikernel instance we run
+	tmpDir, err := extractFilesFromBlock(unikernel, uruncJSON, initrd, bundle)
+	if err != nil {
+		return err
+	}
+	// unmount block device
+	// FIXME: umount and rm might need some retries
+	err = mount.Unmount(rootfsPath)
+	if err != nil {
+		return err
+	}
+	// rename tmp to rootfs
+	err = os.Remove(rootfsPath)
+	if err != nil {
+		return err
+	}
+	err = os.Rename(tmpDir, rootfsPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cleanupExtractedFiles cleans up all the files that we copied to unmount
+// container's rootfs. In particular it should delete three files: the unikernel
+// binary the initrd and the urunc.json file.
+// For the time being it acts as a placeholder for future changes, where we might
+// need to do more advanced things than removing files.
+func cleanupExtractedFiles(bundle string) error {
+	rootfsPath := filepath.Join(bundle, "rootfs")
+	return os.RemoveAll(rootfsPath)
 }

--- a/pkg/unikontainers/storage_test.go
+++ b/pkg/unikontainers/storage_test.go
@@ -38,6 +38,6 @@ func TestGetBlockDevice(t *testing.T) {
 	rootFs, err := getBlockDevice("/mock/path", mockGetPartitions)
 	assert.NoError(t, err, "Expected no error in getting block device")
 	assert.Equal(t, "/mock/path", rootFs.Path, "Expected path to be /mock/path")
-	assert.True(t, rootFs.IsBlock, "Expected IsBlock to be true")
-	assert.Equal(t, "ext4", rootFs.BlkDevice.Fstype, "Expected filesystem type to be ext4")
+	assert.Equal(t, "dm-0", rootFs.Device, "Expected device to be dm-0")
+	assert.Equal(t, "ext4", rootFs.FsType, "Expected filesystem type to be ext4")
 }

--- a/pkg/unikontainers/storage_test.go
+++ b/pkg/unikontainers/storage_test.go
@@ -17,27 +17,20 @@ package unikontainers
 import (
 	"testing"
 
-	"github.com/shirou/gopsutil/disk"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetBlockDevice(t *testing.T) {
 	// Create a mock partition
-	partitions := []disk.PartitionStat{
-		{
-			Device:     "dm-0",
-			Mountpoint: "/mock/path",
-			Fstype:     "ext4",
-		},
+	tmpMnt := RootFs{
+		Path:   "/proc",
+		Device: "proc",
+		FsType: "proc",
 	}
 
-	// Mock the disk.Partitions function
-	mockGetPartitions := func(all bool) ([]disk.PartitionStat, error) {
-		return partitions, nil
-	}
-	rootFs, err := getBlockDevice("/mock/path", mockGetPartitions)
+	rootFs, err := getBlockDevice(tmpMnt.Path)
 	assert.NoError(t, err, "Expected no error in getting block device")
-	assert.Equal(t, "/mock/path", rootFs.Path, "Expected path to be /mock/path")
-	assert.Equal(t, "dm-0", rootFs.Device, "Expected device to be dm-0")
-	assert.Equal(t, "ext4", rootFs.FsType, "Expected filesystem type to be ext4")
+	assert.Equal(t, tmpMnt.Path, rootFs.Path, "Expected path to be /mock/path")
+	assert.Equal(t, tmpMnt.Device, rootFs.Device, "Expected device to be dm-0")
+	assert.Equal(t, tmpMnt.FsType, rootFs.FsType, "Expected filesystem type to be ext4")
 }

--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -32,6 +32,7 @@ type UnikernelParams struct {
 	EthDeviceMask    string // The eth device mask
 	EthDeviceGateway string // The eth device gateway
 	RootFSType       string // The rootfs type of the Unikernel
+	BlockMntPoint    string // The mount point for the block device
 }
 
 var ErrNotSupportedUnikernel = errors.New("unikernel is not supported")

--- a/tests/nerdctl/nerdctl_test.go
+++ b/tests/nerdctl/nerdctl_test.go
@@ -36,6 +36,15 @@ func TestNerdctlHvtRumprunRedis(t *testing.T) {
 	}
 }
 
+func TestNerdctlHvtRumprunRedisBlock(t *testing.T) {
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump-block:latest"
+	containerName := "hvt-rumprun-redis-block-test"
+	err := nerdctlTest(containerName, containerImage, true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func TestNerdctlHvtSeccompOn(t *testing.T) {
 	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
 	containerName := "hvt-rumprun-redis-test"


### PR DESCRIPTION
Change the way we treat block devices and storage in urunc. In particular, we:
- Add annotation for specifying a block file inside a container. If this annotation is set then urunc will use this file as a block device if the respective unikernel framework supports block devices.
- Add annotation for specifying the mountpoint of a block device inside a unikernel.
- Add annotation and an environment variable for using the container's snapshot as a block device in the unikernel 
- Refactor the way we find and treat the container's devmapper snapshot, in order  to prepare it as a block for the unikernel.