### PR TITLE
ci: Transition to ARC runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,19 @@ on:
   
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   build:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    runs-on: [ self-hosted, "${{ matrix.archconfig }}", go]
+    runs-on: ${{ format('{0}-{1}', join(fromJSON('["go", "dind", "2204"]'), '-'), matrix.archconfig) }}
     strategy:
       matrix:
-        archconfig: [ x86_64, aarch64 ]
+        archconfig: [ amd64, arm64 ]
       fail-fast: false
     
     steps:
@@ -57,7 +63,7 @@ jobs:
         policy: 1
 
     - name: Upload urunc_amd64 to S3
-      if: matrix.archconfig == 'x86_64'
+      if: matrix.archconfig == 'amd64'
       uses: cloudkernels/minio-upload@v3
       with:
         url: https://s3.nbfc.io
@@ -79,7 +85,7 @@ jobs:
         policy: 1
 
     - name: Upload containerd-shim-urunc-v2_amd64 to S3
-      if: matrix.archconfig == 'x86_64'
+      if: matrix.archconfig == 'amd64'
       uses: cloudkernels/minio-upload@v3
       with:
         url: https://s3.nbfc.io

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,16 @@ permissions:
   # allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: gcc-dind-2204-amd64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/pr-approve.yml
+++ b/.github/workflows/pr-approve.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   git-trailers:
-    runs-on: [self-hosted, x86_64]
+    runs-on: gcc-dind-2204-amd64
     if: ${{ github.event.review.state == 'approved' }}
 
     steps:
@@ -34,7 +34,7 @@ jobs:
           curl -X DELETE \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: Bearer ${{ secrets.ORG_PAT}}" \
-              "https://api.github.com/repos/${{ github.repository }}/labels/ok-to-test"
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ok-to-test"
           sleep 5
           curl -X POST \
               -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,11 +12,16 @@ permissions:
   # allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   unit-test:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     name: unit-test
-    runs-on: ubuntu-latest
+    runs-on: gcc-dind-2204-amd64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -11,11 +11,17 @@ on:
 env:
   vm_profile: ubuntufat
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   prepare:
     name: VM test
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    runs-on: [ self-hosted, gcc, lite, "x86_64" ]
+    #runs-on: [ self-hosted, gcc, lite, "x86_64" ]
+    runs-on: ${{ format('{0}-{1}', join(fromJSON('["gcc","dind","2204"]'), '-'), 'amd64') }}
     # outputs:
 
     steps:
@@ -29,10 +35,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: get & install kcli
+    - name: get & install kcli & ssh
       id: kcli-install
       run: |
         curl -s https://raw.githubusercontent.com/karmab/kcli/main/install.sh | bash
+        sudo apt update && sudo apt install -y ssh genisoimage
 
     - name: 'Setup yq'
       uses: dcarbone/install-yq-action@v1.1.1


### PR DESCRIPTION
As part of our CI update, we transition to github ARC runners. 

Base runner images are from https://github.com/some-natalie/kubernoodles, with some tweaks to account for the different flavors we require: https://github.com/nubificus/kubernoodles

This PR also updates the architecture abbrev (amd64 for x86_64 and arm64 for aarch64), so we should change the required tests in the repo settings.

Also addresses a bug in the PR-trailers workflow, where all labels 'ok-to-test' were removed when a PR was getting approved.