### PR TITLE
Refactor and enhance Makefile targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         url: https://s3.nbfc.io
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/urunc_aarch64
+        local-path: dist/urunc_static_arm64
         remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
         policy: 1
 
@@ -63,7 +63,7 @@ jobs:
         url: https://s3.nbfc.io
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/urunc_amd64
+        local-path: dist/urunc_static_amd64
         remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
         policy: 1
 
@@ -74,7 +74,7 @@ jobs:
         url: https://s3.nbfc.io
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/containerd-shim-urunc-v2_aarch64
+        local-path: dist/containerd-shim-urunc-v2_arm64
         remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
         policy: 1
 

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -134,7 +134,7 @@ jobs:
         SSH_AUTH_SOCK: /tmp/${{ github.run_id }}.sock
       run: |
         if [[ $vm_spawn_result == "success" ]]; then
-          ssh -oStrictHostKeyChecking=no root@$vm_spawn_ip 'cd /root/develop/urunc && PATH=$PATH:/usr/local/go/bin GOFLAGS="-count=1" go test /root/develop/urunc/tests/ctr -v'
+          ssh -oStrictHostKeyChecking=no root@$vm_spawn_ip 'cd /root/develop/urunc && PATH=$PATH:/usr/local/go/bin make test_ctr'
         else
           exit 1
         fi
@@ -146,7 +146,7 @@ jobs:
         SSH_AUTH_SOCK: /tmp/${{ github.run_id }}.sock
       run: |
         if [[ $vm_spawn_result == "success" ]]; then
-          ssh -oStrictHostKeyChecking=no root@$vm_spawn_ip 'cd /root/develop/urunc && PATH=$PATH:/usr/local/go/bin GOFLAGS="-count=1" go test /root/develop/urunc/tests/nerdctl -v'
+          ssh -oStrictHostKeyChecking=no root@$vm_spawn_ip 'cd /root/develop/urunc && PATH=$PATH:/usr/local/go/bin make test_nerdctl'
         else
           exit 1
         fi
@@ -158,7 +158,7 @@ jobs:
         SSH_AUTH_SOCK: /tmp/${{ github.run_id }}.sock
       run: |
         if [[ $vm_spawn_result == "success" ]]; then
-          ssh -oStrictHostKeyChecking=no root@$vm_spawn_ip 'cd /root/develop/urunc && PATH=$PATH:/usr/local/go/bin GOFLAGS="-count=1" go test /root/develop/urunc/tests/crictl -v'
+          ssh -oStrictHostKeyChecking=no root@$vm_spawn_ip 'cd /root/develop/urunc && PATH=$PATH:/usr/local/go/bin make test_crictl'
         else
           exit 1
         fi

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,5 @@ Dockerfile
 # dir for test bundles
 bundles/
 
-# 
-dev.md
-
 # python-related directories
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,74 +1,229 @@
-COMMIT := $(shell git describe --dirty --long --always)
-VERSION := $(shell cat ./VERSION)
-VERSION := $(VERSION)-$(COMMIT)
-ARCH := $(shell dpkg --print-architecture)
+# Versioning variables
+COMMIT         := $(shell git describe --dirty --long --always)
+VERSION        := $(shell cat $(CURDIR)/VERSION)-$(COMMIT)
 
-default: build ;
+# Path variables
+#
+# Use absolute paths just for sanity.
+#? BUILD_DIR Directory to place produced binaries (default: ${CWD}/dist)
+BUILD_DIR      ?= ${CURDIR}/dist
+VENDOR_DIR     := ${CURDIR}/vendor
+#? PREFIX Directory to install urunc and shim (default: /usr/local/bin)
+PREFIX         ?= /usr/local/bin
 
-prepare:
-	@go mod tidy
-	@go mod vendor
-	
-urunc: prepare
-	GOOS=linux CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-w" -ldflags "-linkmode 'external' -extldflags '-static'" \
-          -ldflags "-X main.version=${VERSION}" -o dist/urunc_${ARCH} ./cmd/urunc
+# Architecture specific variables
+#
+# Do not allow building of unsupported or untested host architectures
+#? ARCH Target architecture (default: Host arch)
+ifeq ($(origin ARCH), undefined)
+    UNAME_ARCH := $(shell uname -m)
+    ifeq ($(UNAME_ARCH),x86_64)
+        ARCH := amd64
+    else ifeq ($(UNAME_ARCH),aarch64)
+        ARCH := arm64
+    else
+        $(error Unsupported architecture: $(UNAME_ARCH))
+    endif
+endif
 
-shim: prepare
-	@sed -i 's/DefaultCommand = "runc"/DefaultCommand = "urunc"/g' vendor/github.com/containerd/go-runc/runc.go
-	go build -o dist/containerd-shim-urunc-v2_${ARCH} ./cmd/containerd-shim-urunc-v2
+# Binary variables
+URUNC_BIN      := $(BUILD_DIR)/urunc
+SHIM_BIN       := $(BUILD_DIR)/containerd-shim-urunc-v2
 
-build: urunc shim
+# Golang variables
+#? GO go binary to use (default: go)
+GO             ?= go
+GO_FLAGS       := GOOS=linux
+GO_FLAGS       += CGO_ENABLED=0
+TEST_FLAGS     := "-count=1"
+TEST_OPTS      += -timeout 3m
 
-install:
-	mv dist/urunc_${ARCH} /usr/local/bin/urunc
-	mv dist/containerd-shim-urunc-v2_${ARCH} /usr/local/bin/containerd-shim-urunc-v2
+# Linking variables
+LDFLAGS_COMMON := -X main.version=$(VERSION)
+LDFLAGS_STATIC := --extldflags -static
+LDFLAGS_OPT    := -s -w
 
-clean:
-	@rm -fr dist/
-	@rm -fr vendor/
+# Source files variables
+#
+# Add all urunc specific go packages as dependency for building
+# or the shimAny change ina go file will result to rebuilding urunc
+URUNC_SRC      := $(wildcard $(CURDIR)/cmd/urunc/*.go)
+URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/*.go)
+URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/hypervisors/*.go)
+URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/unikernels/*.go)
+URUNC_SRC      += $(wildcard $(CURDIR)/pkg/network/*.go)
+SHIM_SRC       := $(wildcard $(CURDIR)/cmd/containerd-shim-urunc-v2/*.go)
 
+# Linking variables
+#? LINT_CNTR_TOOL Tool to run the linter container (default: nerdctl)
+LINT_CNTR_TOOL ?= nerdctl
+LINT_CNTR_OPTS ?= run --rm -it -v $(CURDIR):/app -w /app
+#? LINT_IMG The linter image to use (default: golangci/golangci-lint:v1.53.3)
+LINT_CNTR_IMG  ?= golangci/golangci-lint:v1.53.3
+LINT_CNTR_CMD  ?= golangci-lint run -v --timeout=5m
+
+# Install dependecies variables
+#
+# If we have already built either static or dynamic version of urunc
+# we do not have to rebuild it, but instead we can use whichever
+# version is available to install it. However, the dynamic version
+# has always a preference.
+INSTALL_DEPS   =  $(shell test -e $(URUNC_BIN)_static_$(ARCH) \
+                          && echo $(URUNC_BIN)_static_$(ARCH) && exit \
+                          || test -e $(URUNC_BIN)_dynamic_$(ARCH) \
+                             && echo $(URUNC_BIN)_dynamic_$(ARCH) \
+                             || echo $(URUNC_BIN)_static_$(ARCH))
+
+# Main Building rules
+#
+# By default we opt to build static binaries targeting the host archiotecture.
+# However, we build shim as a dynamically-linked binary.
+
+## default Build shim and urunc statically for host arch.(default).
+.PHONY: default
+default: static shim
+
+## shim Build only the shim for host arch..
+.PHONY: shim
+shim:  $(SHIM_BIN)_$(ARCH)
+
+## static Build urunc statically for host arch.
+.PHONY: static
+static: $(URUNC_BIN)_static_$(ARCH)
+
+## dynamic Build urunc as dynamically-linked binary for host arch.
+.PHONY: dynamic
+dynamic: $(URUNC_BIN)_dynamic_$(ARCH)
+
+## all Build shim and urunc statically for all amd64 and aarch64
+.PHONY: all
+all: $(SHIM_BIN)_arm64 $(SHIM_BIN)_amd64 $(URUNC_BIN)_static_amd64 $(URUNC_BIN)_static_arm64
+
+# Just an alias for $(VENDOR_DIR) for easie invocation
+## prepare Run go mod vendor and veridy.
+prepare: $(VENDOR_DIR)
+
+# Add tidy as order-only prerequisite. In that way, since tidy does not
+# produce any file and executes all the time, we avoid the execution
+# of $(VENDOR_DIR) rule, if the file already exists
+$(VENDOR_DIR):
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify
+
+# Add tidy and as order-only prerequisite. In that way, since tidy and
+# vendor do notproduce any file and execute all the time,
+# we avoid the rebuilding of urunc if it has previsouly built and the
+# source files have not changed.
+$(URUNC_BIN)_static_%: $(URUNC_SRC) | prepare
+	$(GO_FLAGS) GOARCH=$* $(GO) build \
+		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS_STATIC) $(LDFLAGS_OPT)" \
+		-o $(URUNC_BIN)_static_$* $(CURDIR)/cmd/urunc
+
+$(URUNC_BIN)_dynamic_%: $(URUNC_SRC) | prepare
+	$(GO_FLAGS) GOARCH=$* $(GO) build \
+		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS_OPT)" \
+		-o $(URUNC_BIN)_dynamic_$* $(CURDIR)/cmd/urunc
+
+$(SHIM_BIN)_%: $(SHIM_SRC) | prepare
+	@sed -i 's/DefaultCommand = "runc"/DefaultCommand = "urunc"/g' \
+		$(VENDOR_DIR)/github.com/containerd/go-runc/runc.go
+	$(GO_FLAGS) GOARCH=$* $(GO) build \
+		-o $(SHIM_BIN)_$* $(CURDIR)/cmd/containerd-shim-urunc-v2
+
+## install Install urunc and shim in PREFIX
+.PHONY: install
+install: $(SHIM_BIN)_$(ARCH) $(INSTALL_DEPS)
+	install -D -m0755 $(word 2,$^) $(PREFIX)/urunc
+	install -D -m0755 $< $(PREFIX)/containerd-shim-urunc-v2
+
+## uninstall Remove urunc and shim from PREFIX
+.PHONY: uninstall
 uninstall:
-	rm -f /usr/local/bin/urunc
-	rm -f /usr/local/bin/containerd-shim-urunc-v2
+	rm -f $(PREFIX)/urunc
+	rm -f $(PREFIX)/containerd-shim-urunc-v2
 
-urunc_aarch64: prepare
-	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-w" -ldflags "-linkmode 'external' -extldflags '-static'" \
-			-ldflags "-X main.version=${VERSION}" -o dist/urunc_aarch64 ./cmd/urunc
+## distclean Remove build and vendor directories
+.PHONY: distclean
+distclean: clean
+	rm -fr $(VENDOR_DIR)
 
-shim_aarch64: prepare
-	@sed -i 's/DefaultCommand = "runc"/DefaultCommand = "urunc"/g' vendor/github.com/containerd/go-runc/runc.go
-	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o dist/containerd-shim-urunc-v2_aarch64 ./cmd/containerd-shim-urunc-v2
+## clean build directory
+.PHONY: clean
+clean:
+	rm -fr $(BUILD_DIR)
 
-urunc_amd64: prepare
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-w" -ldflags "-linkmode 'external' -extldflags '-static'" \
-			-ldflags "-X main.version=${VERSION}" -o dist/urunc_amd64 ./cmd/urunc
+# Linting targets
+## lint Run the lint test using a golang container
+.PHONY: lint
+lint:
+	$(LINT_CNTR_TOOL) $(LINT_CNTR_OPTS) $(LINT_CNTR_IMG) $(LINT_CNTR_CMD)
 
-shim_amd64: prepare
-	@sed -i 's/DefaultCommand = "runc"/DefaultCommand = "urunc"/g' vendor/github.com/containerd/go-runc/runc.go
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/containerd-shim-urunc-v2_amd64 ./cmd/containerd-shim-urunc-v2
+# Testing targets
+## test Run all tests
+.PHONY: test
+test: unittest e2etest
 
-all: urunc_aarch64 shim_aarch64 urunc_amd64 shim_amd64
+## unittest Run all unit tests
+.PHONY: unittest
+unittest: test_unikontainers
 
+## e2etest Run all end-to-end tests
+.PHONY: e2etest
+e2etest: test_nerdctl test_ctr test_crictl
+
+## test_unikontainers Run unit tests for unikontainers package
+test_unikontainers:
+	@echo "Unit testing in unikontainers"
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/unikontainers -v
+	@echo " "
+
+## test_nerdctl Run all end-to-end tests with nerdctl
+.PHONY: test_nerdctl
 test_nerdctl:
 	@echo "Testing nerdctl"
-	-@sudo GOFLAGS="-count=1" $$(which go) test ./tests/nerdctl -v
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/nerdctl -v
 	@echo " "
 
+## test_ctr Run all end-to-end tests with ctr
+.PHONY: test_ctr
 test_ctr:
 	@echo "Testing ctr"
-	-@sudo GOFLAGS="-count=1" $$(which go) test ./tests/ctr -v
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/ctr -v
 	@echo " "
 
+## test_crictl Run all end-to-end tests with crictl
+.PHONY: test_crictl
 test_crictl:
 	@echo "Testing crictl"
-	-@sudo GOFLAGS="-count=1" $$(which go) test ./tests/crictl -v
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/crictl -v
 	@echo " "
 
-test_unikontainers:
-	@GOFLAGS="-count=1" $$(which go) test -timeout 30s ./pkg/unikontainers -v
+## test_nerdctl_[pattern] Run all end-to-end tests with nerdctl that match pattern
+.PHONY: test_nerdctl_%
+test_nerdctl_%:
+	@echo "Testing nerdctl"
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/nerdctl -v -run "$*"
+	@echo " "
 
-unittest: test_unikontainers
-	-@echo "unit tests: DONE"
+## test_ctr_[pattern] Run all end-to-end tests with ctr that match pattern
+.PHONY: test_ctr_%
+test_ctr_%:
+	@echo "Testing ctr"
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/ctr -v -run $*
+	@echo " "
 
-test: test_nerdctl test_ctr test_crictl
-	-@echo "DONE"
+## test_crictl_[pattern] Run all end-to-end tests with crictl that match pattern
+.PHONY: test_crictl_%
+test_crictl_%:
+	@echo "Testing crictl"
+	-@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/crictl -v -run $*
+	@echo " "
+
+## help Show this help message
+help:
+	@echo 'Usage: make <target> <flags>'
+	@echo 'Targets:'
+	@grep -w "^##" $(MAKEFILE_LIST) | sed -n 's/^## /\t/p' | sed -n 's/ /\@/p' | column -s '\@' -t
+	@echo 'Flags:'
+	@grep -w "^#?" $(MAKEFILE_LIST) | sed -n 's/^#? /\t/p' | sed -n 's/ /\@/p' | column -s '\@' -t


### PR DESCRIPTION
Change the Makefile to enable the use of variables and flags for easier development. Moreover, enable the use of flags when invoking make, use the proper prerequisities for each target, remove the use of sudo inside the Makefile and add a help message. In addition, add more targets for building and testing:
- Dynamically-linked binaries
- Specific end-to-end tests
- Linting