### PR TITLE
Refactor handling of normal containers and replaces constants in paths and annotations

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -242,24 +242,17 @@ func createUnikontainer(context *cli.Context) error {
 // waits StartExecve message on urunc.sock,
 // executes Prestart hooks and finally execve's the unikernel vmm.
 func reexecUnikontainer(context *cli.Context) error {
+	// No need to check if containerID is valid, because it will get
+	// checked later. We just want it for the metrics
 	containerID := context.Args().First()
-	if containerID == "" {
-		return fmt.Errorf("container id cannot be empty")
-	}
 	metrics.Capture(containerID, "TS04")
 
-	// We have already made sure in main.go that root is not nil
-	rootDir := context.GlobalString("root")
-
 	// get Unikontainer data from state.json
-	unikontainer, err := unikontainers.Get(containerID, rootDir)
+	unikontainer, err := getUnikontainer(context)
 	if err != nil {
-		if errors.Is(err, unikontainers.ErrNotUnikernel) {
-			// Exec runc to handle non unikernel containers
-			return runcExec()
-		}
 		return err
 	}
+
 	metrics.Capture(containerID, "TS05")
 
 	// send ReexecStarted message to init.sock to parent process

--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -15,10 +15,8 @@
 package main
 
 import (
-	"errors"
 	"os"
 
-	"github.com/nubificus/urunc/pkg/unikontainers"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -48,33 +46,17 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 			return err
 		}
 
-		return deleteUnikernelContainer(context)
-	},
-}
-
-func deleteUnikernelContainer(context *cli.Context) error {
-	containerID := context.Args().First()
-	if containerID == "" {
-		return ErrContainerID
-	}
-
-	// We have already made sure in main.go that root is not nil
-	rootDir := context.GlobalString("root")
-
-	// get Unikontainer data from state.json
-	unikontainer, err := unikontainers.Get(containerID, rootDir)
-	if err != nil {
-		if errors.Is(err, unikontainers.ErrNotUnikernel) {
-			// Exec runc to handle non unikernel containers
-			return runcExec()
-		}
-		return err
-	}
-	if context.Bool("force") {
-		err := unikontainer.Kill()
+		// get Unikontainer data from state.json
+		unikontainer, err := getUnikontainer(context)
 		if err != nil {
 			return err
 		}
-	}
-	return unikontainer.Delete()
+		if context.Bool("force") {
+			err := unikontainer.Kill()
+			if err != nil {
+				return err
+			}
+		}
+		return unikontainer.Delete()
+	},
 }

--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -15,10 +15,8 @@
 package main
 
 import (
-	"errors"
 	"os"
 
-	"github.com/nubificus/urunc/pkg/unikontainers"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -52,27 +50,11 @@ signal to the init process of the "ubuntu01" container:
 			return err
 		}
 
-		return killUnikontainer(context)
-	},
-}
-
-func killUnikontainer(context *cli.Context) error {
-	containerID := context.Args().First()
-	if containerID == "" {
-		return ErrContainerID
-	}
-
-	// We have already made sure in main.go that root is not nil
-	rootDir := context.GlobalString("root")
-
-	// get Unikontainer data from state.json
-	unikontainer, err := unikontainers.Get(containerID, rootDir)
-	if err != nil {
-		if errors.Is(err, unikontainers.ErrNotUnikernel) {
-			// Exec runc to handle non unikernel containers
-			return runcExec()
+		// get Unikontainer data from state.json
+		unikontainer, err := getUnikontainer(context)
+		if err != nil {
+			return err
 		}
-		return err
-	}
-	return unikontainer.Kill()
+		return unikontainer.Kill()
+	},
 }

--- a/cmd/urunc/run.go
+++ b/cmd/urunc/run.go
@@ -66,10 +66,6 @@ var runCommand = cli.Command{
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}
-		err := handleNonBimaContainer(context)
-		if err != nil {
-			return err
-		}
 
 		// FIXME: This is a refactor of what the previous code did, however I have a feeling
 		// that it will not work...

--- a/docs/Performance-timestamping.md
+++ b/docs/Performance-timestamping.md
@@ -13,7 +13,7 @@ The timestamps currently depicting each unikernel container execution are the fo
 | TS02         | create  | initial setup completed                       |
 | TS03         | create  | start reexec process (with or without pty)    |
 | TS04         | reexec  | `urunc create --reexec` was invoked           |
-| TS05         | reexec  | unikontainer struct created for spec          |
+| TS05         | reexec  | unikontainer struct created from spec         |
 | TS06         | reexec  | sent `BOOTED` IPC message to `create` process |
 | TS07         | create  | received `BOOTED` message from `reexec`       |
 | TS08         | create  | executed `CreateRuntime` hooks                |
@@ -21,20 +21,13 @@ The timestamps currently depicting each unikernel container execution are the fo
 | TS10         | reexec  | received `ACK` message from `create`          |
 | TS11         | create  | `urunc create` terminated                     |
 | TS12         | start   | `urunc start` was invoked                     |
-| TS13         | start   | unikontainer struct created for spec          |
+| TS13         | start   | unikontainer struct created from spec         |
 | TS14         | start   | sent `START` IPC message to `reexec`          |
 | TS15         | reexec  | received `START` message from `start`         |
 | TS16         | reexec  | joined sandbox network namespace              |
 | TS17         | reexec  | network setup completed                       |
 | TS18         | reexec  | disk setup completed                          |
 | TS19         | reexec  | `execve` the hypervisor process               |
-
-In addition to these timestamps, two more are added to measure the delay caused by the `handleNonBimaContainer` function that is run every time `urunc` is invoked:
-
-| Timestamp ID | Description                               |
-|--------------|-------------------------------------------|
-| cTS00        | before invoking  `handleNonBimaContainer` |
-| cTS01        | after invoking  `handleNonBimaContainer`  |
 
 ## Timestamping logging method
 

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -29,6 +29,23 @@ import (
 
 var ErrEmptyAnnotations = errors.New("spec annotations are empty")
 
+// Important: Unfortunately GOlang does not allow to use constant values for
+// struct tagsAs a result, please always keep the constant definitions and the
+// UnikernelConfig struct below in sync.
+
+// Urunc specific annotations
+// ALways keep it in sync with the struct UnikernelConfig struct
+const (
+	annotType          = "com.urunc.unikernel.unikernelType"
+	annotBinary        = "com.urunc.unikernel.binary"
+	annotCmdLine       = "com.urunc.unikernel.cmdline"
+	annotHypervisor    = "com.urunc.unikernel.hypervisor"
+	annotInitrd        = "com.urunc.unikernel.initrd"
+	annotBlock         = "com.urunc.unikernel.block"
+	annotBlockMntPoint = "com.urunc.unikernel.blkMntPoint"
+	annotUseDMBlock    = "com.urunc.unikernel.useDMBlock"
+)
+
 // A UnikernelConfig struct holds the info provided by bima image on how to execute our unikernel
 type UnikernelConfig struct {
 	UnikernelType   string `json:"com.urunc.unikernel.unikernelType"`
@@ -69,14 +86,14 @@ func GetUnikernelConfig(bundleDir string, spec *specs.Spec) (*UnikernelConfig, e
 
 // getConfigFromSpec retrieves the urunc specific annotations from the spec and populates the Unikernel config.
 func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
-	unikernelType := spec.Annotations["com.urunc.unikernel.unikernelType"]
-	unikernelCmd := spec.Annotations["com.urunc.unikernel.cmdline"]
-	unikernelBinary := spec.Annotations["com.urunc.unikernel.binary"]
-	hypervisor := spec.Annotations["com.urunc.unikernel.hypervisor"]
-	initrd := spec.Annotations["com.urunc.unikernel.initrd"]
-	block := spec.Annotations["com.urunc.unikernel.block"]
-	blkMntPoint := spec.Annotations["com.urunc.unikernel.blkMntPoint"]
-	useDMBlock := spec.Annotations["com.urunc.unikernel.useDMBlock"]
+	unikernelType := spec.Annotations[annotType]
+	unikernelCmd := spec.Annotations[annotCmdLine]
+	unikernelBinary := spec.Annotations[annotBinary]
+	hypervisor := spec.Annotations[annotHypervisor]
+	initrd := spec.Annotations[annotInitrd]
+	block := spec.Annotations[annotBlock]
+	blkMntPoint := spec.Annotations[annotBlockMntPoint]
+	useDMBlock := spec.Annotations[annotUseDMBlock]
 
 	Log.WithFields(logrus.Fields{
 		"unikernelType":   unikernelType,
@@ -108,7 +125,7 @@ func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 
 // getConfigFromJSON retrieves the Unikernel config parameters from the urunc.json file inside the rootfs.
 func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
-	jsonFilePath := filepath.Join(bundleDir, rootfsDirName, uruncJsonFilename)
+	jsonFilePath := filepath.Join(bundleDir, rootfsDirName, uruncJSONFilename)
 	file, err := os.Open(jsonFilePath)
 	if err != nil {
 		return nil, err
@@ -120,7 +137,7 @@ func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
 		return nil, err
 	}
 	if fileInfo.IsDir() {
-		return nil, errors.New(uruncJsonFilename + " is a directory")
+		return nil, errors.New(uruncJSONFilename + " is a directory")
 	}
 
 	byteData, err := io.ReadAll(file)
@@ -142,7 +159,7 @@ func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
 		"block":           conf.Block,
 		"blkMntPoint":     conf.BlkMntPoint,
 		"useDMBlock":      conf.UseDMBlock,
-	}).Info(uruncJsonFilename + " annotations")
+	}).Info(uruncJSONFilename + " annotations")
 	return &conf, nil
 }
 
@@ -203,30 +220,30 @@ func (c *UnikernelConfig) decode() error {
 func (c *UnikernelConfig) Map() map[string]string {
 	myMap := make(map[string]string)
 	if c.UnikernelCmd != "" {
-		myMap["com.urunc.unikernel.cmdline"] = c.UnikernelCmd
+		myMap[annotCmdLine] = c.UnikernelCmd
 	}
 	if c.UnikernelType != "" {
-		myMap["com.urunc.unikernel.unikernelType"] = c.UnikernelType
+		myMap[annotType] = c.UnikernelType
 	}
 	if c.Hypervisor != "" {
-		myMap["com.urunc.unikernel.hypervisor"] = c.Hypervisor
+		myMap[annotHypervisor] = c.Hypervisor
 	}
 	if c.UnikernelBinary != "" {
-		myMap["com.urunc.unikernel.binary"] = c.UnikernelBinary
+		myMap[annotBinary] = c.UnikernelBinary
 	}
 	if c.Initrd != "" {
-		myMap["com.urunc.unikernel.initrd"] = c.Initrd
+		myMap[annotInitrd] = c.Initrd
 	}
 	if c.Block != "" {
-		myMap["com.urunc.unikernel.block"] = c.Block
+		myMap[annotBlock] = c.Block
 	}
 	if c.BlkMntPoint != "" {
-		myMap["com.urunc.unikernel.blkMntPoint"] = c.BlkMntPoint
+		myMap[annotBlockMntPoint] = c.BlkMntPoint
 	}
 	if c.UseDMBlock != "" {
-		myMap["com.urunc.unikernel.useDMBlock"] = c.UseDMBlock
+		myMap[annotUseDMBlock] = c.UseDMBlock
 	} else {
-		myMap["com.urunc.unikernel.useDMBlock"] = os.Getenv("USE_DEVMAPPER_AS_BLOCK")
+		myMap[annotUseDMBlock] = os.Getenv("USE_DEVMAPPER_AS_BLOCK")
 	}
 
 	return myMap

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -108,7 +108,7 @@ func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 
 // getConfigFromJSON retrieves the Unikernel config parameters from the urunc.json file inside the rootfs.
 func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
-	jsonFilePath := filepath.Join(bundleDir, "rootfs", "urunc.json")
+	jsonFilePath := filepath.Join(bundleDir, rootfsDirName, uruncJsonFilename)
 	file, err := os.Open(jsonFilePath)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
 		return nil, err
 	}
 	if fileInfo.IsDir() {
-		return nil, errors.New("urunc.json is a directory")
+		return nil, errors.New(uruncJsonFilename + " is a directory")
 	}
 
 	byteData, err := io.ReadAll(file)
@@ -142,7 +142,7 @@ func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
 		"block":           conf.Block,
 		"blkMntPoint":     conf.BlkMntPoint,
 		"useDMBlock":      conf.UseDMBlock,
-	}).Info("urunc.json annotations")
+	}).Info(uruncJsonFilename + " annotations")
 	return &conf, nil
 }
 

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -107,11 +107,11 @@ func TestGetConfigFromJSON(t *testing.T) {
 		configData, err := json.Marshal(expectedConfig)
 		assert.NoError(t, err)
 
-		rootfsDir := filepath.Join(tempDir, "rootfs")
+		rootfsDir := filepath.Join(tempDir, rootfsDirName)
 		err = os.Mkdir(rootfsDir, 0755)
 		assert.NoError(t, err)
 
-		configPath := filepath.Join(rootfsDir, "urunc.json")
+		configPath := filepath.Join(rootfsDir, uruncJsonFilename)
 		err = os.WriteFile(configPath, configData, 0600)
 		assert.NoError(t, err)
 
@@ -128,7 +128,8 @@ func TestGetConfigFromJSON(t *testing.T) {
 
 		// Call the function with a missing urunc.json file
 		_, err := getConfigFromJSON(tempDir)
-		assert.Error(t, err, "Expected an error for missing urunc.json file")
+		assert.Error(t, err, "Expected an error for missing "+
+			uruncJsonFilename+" file")
 		assert.Contains(t, err.Error(), "no such file or directory", "Expected specific error message")
 	})
 
@@ -138,17 +139,17 @@ func TestGetConfigFromJSON(t *testing.T) {
 		tempDir := t.TempDir()
 
 		// Create a directory instead of a urunc.json file
-		rootfsDir := filepath.Join(tempDir, "rootfs")
+		rootfsDir := filepath.Join(tempDir, rootfsDirName)
 		err := os.Mkdir(rootfsDir, 0755)
 		assert.NoError(t, err)
-		configDirPath := filepath.Join(rootfsDir, "urunc.json")
+		configDirPath := filepath.Join(rootfsDir, uruncJsonFilename)
 		err = os.Mkdir(configDirPath, 0755)
 		assert.NoError(t, err)
 
 		// Call the function
 		_, err = getConfigFromJSON(tempDir)
-		assert.Error(t, err, "Expected an error for urunc.json being a directory")
-		assert.Contains(t, err.Error(), "urunc.json is a directory", "Expected specific error message")
+		assert.Error(t, err, "Expected an error for "+uruncJsonFilename+" being a directory")
+		assert.Contains(t, err.Error(), uruncJsonFilename+" is a directory", "Expected specific error message")
 	})
 
 	t.Run("get config from invalid JSON", func(t *testing.T) {
@@ -157,17 +158,17 @@ func TestGetConfigFromJSON(t *testing.T) {
 		tempDir := t.TempDir()
 
 		// Create an invalid urunc.json file
-		rootfsDir := filepath.Join(tempDir, "rootfs")
+		rootfsDir := filepath.Join(tempDir, rootfsDirName)
 		err := os.Mkdir(rootfsDir, 0755)
 		assert.NoError(t, err)
 
-		configPath := filepath.Join(rootfsDir, "urunc.json")
+		configPath := filepath.Join(rootfsDir, uruncJsonFilename)
 		err = os.WriteFile(configPath, []byte("invalid json"), 0600)
 		assert.NoError(t, err)
 
 		// Call the function
 		_, err = getConfigFromJSON(tempDir)
-		assert.Error(t, err, "Expected an error for invalid urunc.json file")
+		assert.Error(t, err, "Expected an error for invalid "+uruncJsonFilename+" file")
 		assert.Contains(t, err.Error(), "invalid character", "Expected specific error message")
 	})
 }

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -30,14 +30,14 @@ func TestGetConfigFromSpec(t *testing.T) {
 		t.Parallel()
 		spec := &specs.Spec{
 			Annotations: map[string]string{
-				"com.urunc.unikernel.unikernelType": "type1",
-				"com.urunc.unikernel.cmdline":       "cmd1",
-				"com.urunc.unikernel.binary":        "binary1",
-				"com.urunc.unikernel.hypervisor":    "hypervisor1",
-				"com.urunc.unikernel.initrd":        "initrd1",
-				"com.urunc.unikernel.block":         "block1",
-				"com.urunc.unikernel.blkMntPoint":   "point1",
-				"com.urunc.unikernel.useDMBlock":    "true",
+				annotType:          "type1",
+				annotCmdLine:       "cmd1",
+				annotBinary:        "binary1",
+				annotHypervisor:    "hypervisor1",
+				annotInitrd:        "initrd1",
+				annotBlock:         "block1",
+				annotBlockMntPoint: "point1",
+				annotUseDMBlock:    "true",
 			},
 		}
 
@@ -73,7 +73,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 		t.Parallel()
 		spec := &specs.Spec{
 			Annotations: map[string]string{
-				"com.urunc.unikernel.unikernelType": "type1",
+				annotType: "type1",
 			},
 		}
 
@@ -111,7 +111,7 @@ func TestGetConfigFromJSON(t *testing.T) {
 		err = os.Mkdir(rootfsDir, 0755)
 		assert.NoError(t, err)
 
-		configPath := filepath.Join(rootfsDir, uruncJsonFilename)
+		configPath := filepath.Join(rootfsDir, uruncJSONFilename)
 		err = os.WriteFile(configPath, configData, 0600)
 		assert.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestGetConfigFromJSON(t *testing.T) {
 		// Call the function with a missing urunc.json file
 		_, err := getConfigFromJSON(tempDir)
 		assert.Error(t, err, "Expected an error for missing "+
-			uruncJsonFilename+" file")
+			uruncJSONFilename+" file")
 		assert.Contains(t, err.Error(), "no such file or directory", "Expected specific error message")
 	})
 
@@ -142,14 +142,14 @@ func TestGetConfigFromJSON(t *testing.T) {
 		rootfsDir := filepath.Join(tempDir, rootfsDirName)
 		err := os.Mkdir(rootfsDir, 0755)
 		assert.NoError(t, err)
-		configDirPath := filepath.Join(rootfsDir, uruncJsonFilename)
+		configDirPath := filepath.Join(rootfsDir, uruncJSONFilename)
 		err = os.Mkdir(configDirPath, 0755)
 		assert.NoError(t, err)
 
 		// Call the function
 		_, err = getConfigFromJSON(tempDir)
-		assert.Error(t, err, "Expected an error for "+uruncJsonFilename+" being a directory")
-		assert.Contains(t, err.Error(), uruncJsonFilename+" is a directory", "Expected specific error message")
+		assert.Error(t, err, "Expected an error for "+uruncJSONFilename+" being a directory")
+		assert.Contains(t, err.Error(), uruncJSONFilename+" is a directory", "Expected specific error message")
 	})
 
 	t.Run("get config from invalid JSON", func(t *testing.T) {
@@ -162,13 +162,13 @@ func TestGetConfigFromJSON(t *testing.T) {
 		err := os.Mkdir(rootfsDir, 0755)
 		assert.NoError(t, err)
 
-		configPath := filepath.Join(rootfsDir, uruncJsonFilename)
+		configPath := filepath.Join(rootfsDir, uruncJSONFilename)
 		err = os.WriteFile(configPath, []byte("invalid json"), 0600)
 		assert.NoError(t, err)
 
 		// Call the function
 		_, err = getConfigFromJSON(tempDir)
-		assert.Error(t, err, "Expected an error for invalid "+uruncJsonFilename+" file")
+		assert.Error(t, err, "Expected an error for invalid "+uruncJSONFilename+" file")
 		assert.Contains(t, err.Error(), "invalid character", "Expected specific error message")
 	})
 }
@@ -237,14 +237,14 @@ func TestMap(t *testing.T) {
 			UseDMBlock:      "false",
 		}
 		expectedMap := map[string]string{
-			"com.urunc.unikernel.cmdline":       "cmd_value",
-			"com.urunc.unikernel.unikernelType": "type_value",
-			"com.urunc.unikernel.hypervisor":    "hypervisor_value",
-			"com.urunc.unikernel.binary":        "binary_value",
-			"com.urunc.unikernel.initrd":        "initrd_value",
-			"com.urunc.unikernel.block":         "block_value",
-			"com.urunc.unikernel.blkMntPoint":   "point_value",
-			"com.urunc.unikernel.useDMBlock":    "false",
+			annotCmdLine:       "cmd_value",
+			annotType:          "type_value",
+			annotHypervisor:    "hypervisor_value",
+			annotBinary:        "binary_value",
+			annotInitrd:        "initrd_value",
+			annotBlock:         "block_value",
+			annotBlockMntPoint: "point_value",
+			annotUseDMBlock:    "false",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
@@ -262,7 +262,7 @@ func TestMap(t *testing.T) {
 			UseDMBlock:      "",
 		}
 		expectedMap := map[string]string{
-			"com.urunc.unikernel.useDMBlock": "",
+			annotUseDMBlock: "",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
@@ -280,11 +280,11 @@ func TestMap(t *testing.T) {
 			UseDMBlock:      "0",
 		}
 		expectedMap := map[string]string{
-			"com.urunc.unikernel.cmdline":     "cmd_value",
-			"com.urunc.unikernel.binary":      "binary_value",
-			"com.urunc.unikernel.initrd":      "initrd_value",
-			"com.urunc.unikernel.blkMntPoint": "point_value",
-			"com.urunc.unikernel.useDMBlock":  "0",
+			annotCmdLine:       "cmd_value",
+			annotBinary:        "binary_value",
+			annotInitrd:        "initrd_value",
+			annotBlockMntPoint: "point_value",
+			annotUseDMBlock:    "0",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)
@@ -294,7 +294,7 @@ func TestMap(t *testing.T) {
 		t.Parallel()
 		config := &UnikernelConfig{}
 		expectedMap := map[string]string{
-			"com.urunc.unikernel.useDMBlock": "",
+			annotUseDMBlock: "",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -26,6 +26,7 @@ import (
 const (
 	FirecrackerVmm    VmmType = "firecracker"
 	FirecrackerBinary string  = "firecracker"
+	FCJsonFilename    string  = "fc.json"
 )
 
 type Firecracker struct {
@@ -80,7 +81,7 @@ func (fc *Firecracker) Path() string {
 func (fc *Firecracker) Execve(args ExecArgs) error {
 	cmdString := fc.Path() + " --no-api --config-file "
 	JSONConfigDir := filepath.Dir(args.UnikernelPath)
-	JSONConfigFile := filepath.Join(JSONConfigDir, "fc.json")
+	JSONConfigFile := filepath.Join(JSONConfigDir, FCJsonFilename)
 	cmdString += JSONConfigFile
 	if !args.Seccomp {
 		cmdString += " --no-seccomp"

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -87,7 +87,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 		return "", err
 	}
 
-	currentUnikernelPath := filepath.Join(bundle, "rootfs", unikernel)
+	currentUnikernelPath := filepath.Join(bundle, rootfsDirName, unikernel)
 	targetUnikernelPath := filepath.Join(tmpDir, unikernel)
 	targetUnikernelDir, _ := filepath.Split(targetUnikernelPath)
 	err = moveFile(currentUnikernelPath, targetUnikernelDir)
@@ -100,7 +100,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 	}
 
 	if initrd != "" {
-		currentInitrdPath := filepath.Join(bundle, "rootfs", initrd)
+		currentInitrdPath := filepath.Join(bundle, rootfsDirName, initrd)
 		targetInitrdPath := filepath.Join(tmpDir, initrd)
 		targetInitrdDir, _ := filepath.Split(targetInitrdPath)
 		err = moveFile(currentInitrdPath, targetInitrdDir)
@@ -113,7 +113,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 		}
 	}
 
-	currentConfigPath := filepath.Join(bundle, "rootfs", uruncJSON)
+	currentConfigPath := filepath.Join(bundle, rootfsDirName, uruncJSON)
 	err = moveFile(currentConfigPath, tmpDir)
 	if err != nil {
 		err1 := os.RemoveAll(tmpDir)
@@ -132,7 +132,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 // directory as the container rootfs. This is needed to keep the same paths
 // for the unikernel files.
 func prepareDMAsBlock(bundle string, unikernel string, uruncJSON string, initrd string) error {
-	rootfsPath := filepath.Join(bundle, "rootfs")
+	rootfsPath := filepath.Join(bundle, rootfsDirName)
 	// extract unikernel
 	// FIXME: This approach fills up /run with unikernel binaries and
 	// urunc.json files for each unikernel instance we run
@@ -165,6 +165,6 @@ func prepareDMAsBlock(bundle string, unikernel string, uruncJSON string, initrd 
 // For the time being it acts as a placeholder for future changes, where we might
 // need to do more advanced things than removing files.
 func cleanupExtractedFiles(bundle string) error {
-	rootfsPath := filepath.Join(bundle, "rootfs")
+	rootfsPath := filepath.Join(bundle, rootfsDirName)
 	return os.RemoveAll(rootfsPath)
 }

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -20,6 +20,7 @@ import (
 )
 
 const RumprunUnikernel UnikernelType = "rumprun"
+const SubnetMask125 = "128.0.0.0"
 
 type Rumprun struct {
 	Command string     `json:"cmdline"`
@@ -94,7 +95,7 @@ func (r *Rumprun) Init(data UnikernelParams) error {
 		// FIXME: in the case of rumprun & k8s, we need to explicitly set the mask
 		// to an inclusive value (eg 1 or 0), as NetBSD complains and does not set the default gw
 		// if it is not reachable from the IP address directly.
-		mask, err := subnetMaskToCIDR(data.EthDeviceMask)
+		mask, err := subnetMaskToCIDR(SubnetMask125)
 		if err != nil {
 			return err
 		}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -111,6 +111,9 @@ func Get(containerID string, rootDir string) (*Unikontainer, error) {
 	if err != nil {
 		return nil, err
 	}
+	if state.Annotations["com.urunc.unikernel.unikernelType"] == "" {
+		return nil, ErrNotUnikernel
+	}
 	u.State = state
 
 	spec, err := loadSpec(state.Bundle)

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -31,7 +31,7 @@ const (
 	configFilename    = "config.json"
 	stateFilename     = "state.json"
 	initPidFilename   = "init.pid"
-	uruncJsonFilename = "urunc.json"
+	uruncJSONFilename = "urunc.json"
 	rootfsDirName     = "rootfs"
 )
 

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -163,19 +163,6 @@ func handleQueueProxy(spec specs.Spec, configFile string) error {
 	return nil
 }
 
-// isBimaContainer attempts to find any bima related annotations
-// in the given bundle to verify the image is compatible with urunc
-func IsBimaContainer(bundle string) bool {
-	spec, err := loadSpec(bundle)
-	if err != nil {
-		Log.WithError(err).WithField("bundle", bundle).Error("Couldn't load spec from bundle")
-		return false
-	}
-
-	_, err = GetUnikernelConfig(bundle, spec)
-	return err == nil
-}
-
 func remove(s []string, i int) []string {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -27,6 +27,14 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const (
+	configFilename    = "config.json"
+	stateFilename     = "state.json"
+	initPidFilename   = "init.pid"
+	uruncJsonFilename = "urunc.json"
+	rootfsDirName     = "rootfs"
+)
+
 // getInitPid extracts "init_process_pid" value from the given JSON file
 func getInitPid(filePath string) (float64, error) {
 	// Open the JSON file for reading
@@ -92,17 +100,22 @@ func moveFile(sourceFile string, targetDir string) error {
 // loadSpec returns the Spec found in the given bundle directory
 func loadSpec(bundleDir string) (*specs.Spec, error) {
 	var spec specs.Spec
-	absDir, err := filepath.Abs(bundleDir)
+
+	absBundleDir, err := filepath.Abs(bundleDir)
 	if err != nil {
-		return &spec, fmt.Errorf("failed to find absolute bundle path: %w", err)
+		return nil, fmt.Errorf("failed to find absolute path of bundle: %w", err)
 	}
-	data, err := os.ReadFile(filepath.Join(absDir, "config.json"))
+
+	configFile := filepath.Join(absBundleDir, configFilename)
+	specData, err := os.ReadFile(configFile)
 	if err != nil {
-		return &spec, fmt.Errorf("failed to read config.json: %w", err)
+		return nil, fmt.Errorf("failed to read specification file: %w", err)
 	}
-	if err := json.Unmarshal(data, &spec); err != nil {
-		return &spec, fmt.Errorf("failed to parse config.json: %w", err)
+
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return nil, fmt.Errorf("failed to parse specification json: %w", err)
 	}
+
 	return &spec, nil
 }
 

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -320,7 +320,7 @@ func TestLoadSpec(t *testing.T) {
 		configData, err := json.Marshal(spec)
 		assert.NoError(t, err)
 
-		configPath := filepath.Join(tempDir, "config.json")
+		configPath := filepath.Join(tempDir, configFilename)
 		err = os.WriteFile(configPath, configData, 0600)
 		assert.NoError(t, err)
 
@@ -345,8 +345,8 @@ func TestLoadSpec(t *testing.T) {
 
 		// Call the function with a valid bundle path but without config.json
 		_, err := loadSpec(tempDir)
-		assert.Error(t, err, "Expected an error for missing config.json file")
-		assert.Contains(t, err.Error(), "failed to read config.json", "Expected specific error message")
+		assert.Error(t, err, "Expected an error for missing "+configFilename+" file")
+		assert.Contains(t, err.Error(), "failed to read specification file", "Expected specific error message")
 	})
 
 	t.Run("load spec invalid config file", func(t *testing.T) {
@@ -355,13 +355,13 @@ func TestLoadSpec(t *testing.T) {
 		tempDir := t.TempDir()
 
 		// Create an invalid config.json file
-		configPath := filepath.Join(tempDir, "config.json")
+		configPath := filepath.Join(tempDir, configFilename)
 		err := os.WriteFile(configPath, []byte("invalid json"), 0600)
 		assert.NoError(t, err)
 
 		// Call the function
 		_, err = loadSpec(tempDir)
-		assert.Error(t, err, "Expected an error for invalid config.json file")
-		assert.Contains(t, err.Error(), "failed to parse config.json", "Expected specific error message")
+		assert.Error(t, err, "Expected an error for invalid "+configFilename+" file")
+		assert.Contains(t, err.Error(), "failed to parse specification json", "Expected specific error message")
 	})
 }


### PR DESCRIPTION
`urunc` needs to recognize normal containers from unikernel ones, since it can not handle them properly. For that reason, `urunc` check for specific annotations inside the container. If `urunc` specific annotations do not exist then `urunc` forwards the container handling in `runc`, otherwise, `urunc` handles the container.

However, the process of identifying the containers can be integrated with the process of getting information from the container (e.g. spec/state). Therefore, this PR merges these code paths, reducing the code, reading files etc.

Furthermore, this PR replaces hardcoded values in paths and annotations. Instead, constant values are introduced making easier to change values and reducing bugs.

The above changes fix issues such as the k3s issue (https://github.com/nubificus/urunc/issues/50), where `urunc` was trying to read the container bundle from an incorrect path.

Also fixes https://github.com/nubificus/urunc/issues/32