### PR TITLE
Unikraft FC boot on arm64 and default memory

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 )
@@ -107,6 +108,13 @@ func (fc *Firecracker) Execve(args ExecArgs) error {
 	// Block config for Firecracker
 	// TODO: Add support for block devices in FIrecracker
 	FCDrives := make([]FirecrackerDrive, 0)
+
+	// TODO: Check if this check causes any performance drop
+	// or explore alternative implementations
+	if runtime.GOARCH == "arm64" {
+		consoleStr := " console=ttyS0"
+		args.Command += consoleStr
+	}
 
 	FCSource := FirecrackerBootSource{
 		ImagePath:  args.UnikernelPath,

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -137,7 +137,7 @@ func (h *HVT) Ok() error {
 }
 
 func (h *HVT) Execve(args ExecArgs) error {
-	cmdString := h.binaryPath + " --mem=512"
+	cmdString := h.binaryPath + " --mem=256"
 	cmdString = appendNonEmpty(cmdString, " --net:tap=", args.TapDevice)
 	cmdString = appendNonEmpty(cmdString, " --block:rootfs=", args.BlockDevice)
 	cmdString += " " + args.UnikernelPath + " " + args.Command

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -42,7 +42,7 @@ func (q *Qemu) Path() string {
 }
 
 func (q *Qemu) Execve(args ExecArgs) error {
-	cmdString := q.Path() + " -cpu host -m 254 -enable-kvm -nographic -vga none"
+	cmdString := q.Path() + " -cpu host -m 256 -enable-kvm -nographic -vga none"
 
 	if args.Seccomp {
 		// Enable Seccomp in QEMU

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -50,7 +50,7 @@ func (s *SPT) Ok() error {
 }
 
 func (s *SPT) Execve(args ExecArgs) error {
-	cmdString := s.binaryPath + " --mem=512"
+	cmdString := s.binaryPath + " --mem=256"
 	cmdString = appendNonEmpty(cmdString, " --net:tap=", args.TapDevice)
 	cmdString = appendNonEmpty(cmdString, " --block:rootfs=", args.BlockDevice)
 	cmdString += " " + args.UnikernelPath + " " + args.Command


### PR DESCRIPTION
We need to append a cmdline option for Unikraft to boot on FC.

Also reduce the default memory for all hypervisors.