### PR TITLE
unikontainers: Add configurable memory

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -89,9 +90,21 @@ func (fc *Firecracker) Execve(args ExecArgs) error {
 	}
 
 	// VM config for Firecracker
+	parsedDefaultMemory, _ := strconv.Atoi(DefaultMemory)
+	mem := uint(parsedDefaultMemory)
+	if args.MemSizeMiB != "" {
+		memInt, err := strconv.Atoi(args.MemSizeMiB)
+		if err != nil {
+			return fmt.Errorf("failed to parse memory size %w", err)
+			// vmmLog.WithError(err).Errorf("Failed to parse memory size, using default value %sM", DefaultMemory)
+		}
+		mem = uint(memInt)
+	}
+
+	memory := bytesToMiB(int64(mem))
 	FCMachine := FirecrackerMachine{
-		VcpuCount:       1,   // TODO: Use value from configuration or Environment variable
-		MemSizeMiB:      256, // TODO: Use value from configuration or Environment variable
+		VcpuCount:       1,            // TODO: Use value from configuration or Environment variable
+		MemSizeMiB:      uint(memory), // TODO: Use value from configuration or Environment variable
 		Smt:             false,
 		TrackDirtyPages: false,
 	}

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -15,7 +15,9 @@
 package hypervisors
 
 import (
+	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -42,7 +44,17 @@ func (q *Qemu) Path() string {
 }
 
 func (q *Qemu) Execve(args ExecArgs) error {
-	cmdString := q.Path() + " -cpu host -m 256 -enable-kvm -nographic -vga none"
+	var cmdString string
+	if args.MemSizeMiB != "" {
+		memory, err := strconv.ParseInt(args.MemSizeMiB, 10, 64)
+		if err != nil {
+			return fmt.Errorf("%s failed to parse memory size %w", args.MemSizeMiB, err)
+		}
+		memory = int64(bytesToMB(memory))
+		cmdString = fmt.Sprintf("%s -cpu host -m %d -enable-kvm -nographic -vga none", q.Path(), memory)
+	} else {
+		cmdString = fmt.Sprintf("%s -cpu host -m %s -enable-kvm -nographic -vga none", q.Path(), DefaultMemory)
+	}
 
 	if args.Seccomp {
 		// Enable Seccomp in QEMU

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -33,3 +33,13 @@ func appendNonEmpty(body, prefix, value string) string {
 	}
 	return body
 }
+
+func bytesToMiB(bytes int64) float64 {
+	const bytesInMiB = 1024 * 1024
+	return float64(bytes) / float64(bytesInMiB)
+}
+
+func bytesToMB(bytes int64) float64 {
+	const bytesInMB = 1000 * 1000
+	return float64(bytes) / float64(bytesInMB)
+}

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -22,6 +22,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const DefaultMemory string = "256"
+
 // ExecArgs holds the data required by Execve to start the VMM
 // FIXME: add extra fields if required by additional VMM's
 type ExecArgs struct {
@@ -34,6 +36,7 @@ type ExecArgs struct {
 	IPAddress     string   // The IP address of the TAP device
 	GuestMAC      string   // The MAC address of the guest network device
 	Seccomp       bool     // Enable or disable seccomp filters for the VMM
+	MemSizeMiB    string   // The size of the memory provided to the VM
 	Environment   []string // Environment
 }
 

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -174,6 +174,9 @@ func (u *Unikontainer) Exec() error {
 		initrdAbsPath = filepath.Join(rootfsDir, initrdPath)
 	}
 
+	linuxMemory := *u.Spec.Linux.Resources.Memory
+	memoryLimit := *linuxMemory.Limit
+
 	// populate vmm args
 	vmmArgs := hypervisors.ExecArgs{
 		Container:     u.State.ID,
@@ -181,6 +184,7 @@ func (u *Unikontainer) Exec() error {
 		InitrdPath:    initrdAbsPath,
 		BlockDevice:   "",
 		Seccomp:       true, // Enable Seccomp by default
+		MemSizeMiB:    fmt.Sprintf("%d", memoryLimit),
 		Environment:   os.Environ(),
 	}
 


### PR DESCRIPTION
This PR introduces the ability for users to specify the desired memory allocation for each workload. The specified memory is then passed as a parameter to the VMMs before launching a new Unikernel VM.