### PR TITLE
unikernels: Add annotation and config field for unikernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To run a simple `urunc` example locally, you need to address a few dependencies:
 If you already have these requirements, you can run a test container using `nerdctl`:
 
 ```bash
-sudo nerdctl run --rm -ti --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest unikernel
+sudo nerdctl run --rm -ti --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest unikernel
 ```
 
 ![demo](docs/img/urunc-nerdctl-example.gif)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -217,5 +217,5 @@ sudo cp tenders/spt/solo5-spt /usr/local/bin
 Now, let's run a unikernel image:
 
 ```bash
-sudo nerdctl run --rm -ti --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest unikernel
+sudo nerdctl run --rm -ti --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest unikernel
 ```

--- a/docs/Performance-timestamping.md
+++ b/docs/Performance-timestamping.md
@@ -74,7 +74,7 @@ Now we need to run a unikernel using the new container runtime `uruncts`:
 
 ```bash
 sudo nerdctl run --rm --snapshotter devmapper --runtime io.containerd.uruncts.v2 \
-    harbor.nbfc.io/nubificus/urunc/hello-hvt-rump:latest
+    harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun:latest
 ```
 
 The timestamp logs are located at `/tmp/urunc.zlog`:

--- a/docs/Sample-images.md
+++ b/docs/Sample-images.md
@@ -1,0 +1,19 @@
+# Sample Unikernel OCI images
+
+In this document, you can find the images used to perform `urunc`'s end-to-end tests.
+This might be helpful for anyone looking to spawn some example unikernels using `urunc`.
+
+The naming convention used for these images is $APPLICATION-$HYPERVISOR-$UNIKERNEL-$ADDITIONAL_INFO:tag
+We plan to create and maintain multi-platform images soon, as well as enrich this list with new images.
+
+- harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun-nonet:latest
+- harbor.nbfc.io/nubificus/urunc/hello-spt-rumprun-nonet:latest
+- harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest
+- harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
+- harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun:latest
+- harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest
+- harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun-block:latest
+- harbor.nbfc.io/nubificus/urunc/redis-spt-rumprun:latest
+- harbor.nbfc.io/nubificus/urunc/redis-qemu-unikraft-initrd:latest
+- harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
+- harbor.nbfc.io/nubificus/urunc/httpreply-firecracker-unikraft:latest

--- a/docs/Urunc-Hypervisors.md
+++ b/docs/Urunc-Hypervisors.md
@@ -31,7 +31,7 @@ Next, we need to configure the [devmapper snapshotter](https://github.com/nubifi
 Now we can run a test unikernel:
 
 ```bash
-sudo nerdctl run --rm -ti --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest unikernel
+sudo nerdctl run --rm -ti --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest unikernel
 ```
 
 ## urunc with qemu
@@ -45,7 +45,7 @@ sudo apt-get install qemu-kvm -y
 Now we can run a test unikernel:
 
 ```bash
-sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest unikernel
+sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest unikernel
 ```
 
 ## urunc with firecracker
@@ -67,5 +67,5 @@ rm -fr release-${latest}-$(uname -m)
 Now we can run a test unikernel:
 
 ```bash
-sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-fc-unik:latest unikernel
+sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest unikernel
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/elastic/go-seccomp-bpf v1.4.0
 	github.com/go-ping/ping v1.1.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/jackpal/gateway v1.0.10
 	github.com/moby/sys/mount v0.3.3
 	github.com/nubificus/hedge_cli v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -37,6 +37,7 @@ var ErrEmptyAnnotations = errors.New("spec annotations are empty")
 // ALways keep it in sync with the struct UnikernelConfig struct
 const (
 	annotType          = "com.urunc.unikernel.unikernelType"
+	annotVersion       = "com.urunc.unikernel.unikernelVersion"
 	annotBinary        = "com.urunc.unikernel.binary"
 	annotCmdLine       = "com.urunc.unikernel.cmdline"
 	annotHypervisor    = "com.urunc.unikernel.hypervisor"
@@ -48,14 +49,15 @@ const (
 
 // A UnikernelConfig struct holds the info provided by bima image on how to execute our unikernel
 type UnikernelConfig struct {
-	UnikernelType   string `json:"com.urunc.unikernel.unikernelType"`
-	UnikernelCmd    string `json:"com.urunc.unikernel.cmdline,omitempty"`
-	UnikernelBinary string `json:"com.urunc.unikernel.binary"`
-	Hypervisor      string `json:"com.urunc.unikernel.hypervisor"`
-	Initrd          string `json:"com.urunc.unikernel.initrd,omitempty"`
-	Block           string `json:"com.urunc.unikernel.block,omitempty"`
-	BlkMntPoint     string `json:"com.urunc.unikernel.blkMntPoint,omitempty"`
-	UseDMBlock      string `json:"com.urunc.unikernel.useDMBlock"`
+	UnikernelType    string `json:"com.urunc.unikernel.unikernelType"`
+	UnikernelVersion string `json:"com.urunc.unikernel.unikernelVersion"`
+	UnikernelCmd     string `json:"com.urunc.unikernel.cmdline,omitempty"`
+	UnikernelBinary  string `json:"com.urunc.unikernel.binary"`
+	Hypervisor       string `json:"com.urunc.unikernel.hypervisor"`
+	Initrd           string `json:"com.urunc.unikernel.initrd,omitempty"`
+	Block            string `json:"com.urunc.unikernel.block,omitempty"`
+	BlkMntPoint      string `json:"com.urunc.unikernel.blkMntPoint,omitempty"`
+	UseDMBlock       string `json:"com.urunc.unikernel.useDMBlock"`
 }
 
 // GetUnikernelConfig tries to get the Unikernel config from the bundle annotations.
@@ -87,6 +89,7 @@ func GetUnikernelConfig(bundleDir string, spec *specs.Spec) (*UnikernelConfig, e
 // getConfigFromSpec retrieves the urunc specific annotations from the spec and populates the Unikernel config.
 func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 	unikernelType := spec.Annotations[annotType]
+	unikernelVersion := spec.Annotations[annotVersion]
 	unikernelCmd := spec.Annotations[annotCmdLine]
 	unikernelBinary := spec.Annotations[annotBinary]
 	hypervisor := spec.Annotations[annotHypervisor]
@@ -96,30 +99,32 @@ func getConfigFromSpec(spec *specs.Spec) (*UnikernelConfig, error) {
 	useDMBlock := spec.Annotations[annotUseDMBlock]
 
 	Log.WithFields(logrus.Fields{
-		"unikernelType":   unikernelType,
-		"unikernelCmd":    unikernelCmd,
-		"unikernelBinary": unikernelBinary,
-		"hypervisor":      hypervisor,
-		"initrd":          initrd,
-		"block":           block,
-		"blkMntPoint":     blkMntPoint,
-		"useDMBlock":      useDMBlock,
+		"unikernelType":    unikernelType,
+		"unikernelVersion": unikernelVersion,
+		"unikernelCmd":     unikernelCmd,
+		"unikernelBinary":  unikernelBinary,
+		"hypervisor":       hypervisor,
+		"initrd":           initrd,
+		"block":            block,
+		"blkMntPoint":      blkMntPoint,
+		"useDMBlock":       useDMBlock,
 	}).Info("urunc annotations")
 
 	// TODO: We need to use a better check to see if annotations were empty
-	conf := fmt.Sprintf("%s%s%s%s%s%s%s", unikernelType, unikernelCmd, unikernelBinary, hypervisor, initrd, block, blkMntPoint)
+	conf := fmt.Sprintf("%s%s%s%s%s%s%s%s", unikernelType, unikernelVersion, unikernelCmd, unikernelBinary, hypervisor, initrd, block, blkMntPoint)
 	if conf == "" {
 		return nil, ErrEmptyAnnotations
 	}
 	return &UnikernelConfig{
-		UnikernelBinary: unikernelBinary,
-		UnikernelType:   unikernelType,
-		UnikernelCmd:    unikernelCmd,
-		Hypervisor:      hypervisor,
-		Initrd:          initrd,
-		Block:           block,
-		BlkMntPoint:     blkMntPoint,
-		UseDMBlock:      useDMBlock,
+		UnikernelBinary:  unikernelBinary,
+		UnikernelVersion: unikernelVersion,
+		UnikernelType:    unikernelType,
+		UnikernelCmd:     unikernelCmd,
+		Hypervisor:       hypervisor,
+		Initrd:           initrd,
+		Block:            block,
+		BlkMntPoint:      blkMntPoint,
+		UseDMBlock:       useDMBlock,
 	}, nil
 }
 
@@ -151,14 +156,15 @@ func getConfigFromJSON(bundleDir string) (*UnikernelConfig, error) {
 		return nil, err
 	}
 	Log.WithFields(logrus.Fields{
-		"unikernelType":   conf.UnikernelType,
-		"unikernelCmd":    conf.UnikernelCmd,
-		"unikernelBinary": conf.UnikernelBinary,
-		"hypervisor":      conf.Hypervisor,
-		"initrd":          conf.Initrd,
-		"block":           conf.Block,
-		"blkMntPoint":     conf.BlkMntPoint,
-		"useDMBlock":      conf.UseDMBlock,
+		"unikernelType":    conf.UnikernelType,
+		"unikernelVersion": conf.UnikernelVersion,
+		"unikernelCmd":     conf.UnikernelCmd,
+		"unikernelBinary":  conf.UnikernelBinary,
+		"hypervisor":       conf.Hypervisor,
+		"initrd":           conf.Initrd,
+		"block":            conf.Block,
+		"blkMntPoint":      conf.BlkMntPoint,
+		"useDMBlock":       conf.UseDMBlock,
 	}).Info(uruncJSONFilename + " annotations")
 	return &conf, nil
 }
@@ -182,6 +188,12 @@ func (c *UnikernelConfig) decode() error {
 		return fmt.Errorf("failed to decode UnikernelType: %v", err)
 	}
 	c.UnikernelType = string(decoded)
+
+	decoded, err = base64.StdEncoding.DecodeString(c.UnikernelVersion)
+	if err != nil {
+		return fmt.Errorf("failed to decode UnikernelVersion: %v", err)
+	}
+	c.UnikernelVersion = string(decoded)
 
 	decoded, err = base64.StdEncoding.DecodeString(c.UnikernelBinary)
 	if err != nil {
@@ -224,6 +236,9 @@ func (c *UnikernelConfig) Map() map[string]string {
 	}
 	if c.UnikernelType != "" {
 		myMap[annotType] = c.UnikernelType
+	}
+	if c.UnikernelVersion != "" {
+		myMap[annotVersion] = c.UnikernelVersion
 	}
 	if c.Hypervisor != "" {
 		myMap[annotHypervisor] = c.Hypervisor

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 )
 
-const RumprunUnikernel UnikernelType = "rumprun"
+const RumprunUnikernel string = "rumprun"
 const SubnetMask125 = "128.0.0.0"
 
 type Rumprun struct {

--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -16,8 +16,6 @@ package unikernels
 
 import "errors"
 
-type UnikernelType string
-
 type Unikernel interface {
 	Init(UnikernelParams) error
 	CommandString() (string, error)
@@ -33,11 +31,12 @@ type UnikernelParams struct {
 	EthDeviceGateway string // The eth device gateway
 	RootFSType       string // The rootfs type of the Unikernel
 	BlockMntPoint    string // The mount point for the block device
+	Version          string // The version of the unikernel
 }
 
 var ErrNotSupportedUnikernel = errors.New("unikernel is not supported")
 
-func New(unikernelType UnikernelType) (Unikernel, error) {
+func New(unikernelType string) (Unikernel, error) {
 	switch unikernelType {
 	case RumprunUnikernel:
 		unikernel := newRumprun()

--- a/script/performance/__modules__.py
+++ b/script/performance/__modules__.py
@@ -128,7 +128,7 @@ def emptyFile(filename: str) -> None:
 
 
 def spawnContainer() -> str:
-    command = "nerdctl run --name redis-test -d --snapshotter devmapper --runtime io.containerd.uruncts.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+    command = "nerdctl run --name redis-test -d --snapshotter devmapper --runtime io.containerd.uruncts.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest"
     cmdParts = command.split(" ")
     cmd = run(cmdParts,
               stdout=PIPE,

--- a/script/performance/measure_to_json.py
+++ b/script/performance/measure_to_json.py
@@ -69,7 +69,7 @@ def main():
     saveToJsonFile(outputFile, result)
     emptyFile(filename=LOGFILE)
 
-    # nerdctl run --name redis-test -d --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest
+    # nerdctl run --name redis-test -d --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest
     # nerdctl rm --force redis-test
 
     # data = parseSingleContainerTimestamps(

--- a/tests/crictl/crictl_test.go
+++ b/tests/crictl/crictl_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestCrictlHvtRumprunRedis(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest"
 	procName := "solo5-hvt"
 	podConfig := crictlSandboxConfig("hvt-rumprun-redis-sandbox")
 	containerConfig := crictlContainerConfig("hvt-rumprun-redis", containerImage)
@@ -124,7 +124,7 @@ func TestCrictlHvtRumprunRedis(t *testing.T) {
 }
 
 func TestCrictlSptRumprunRedis(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-spt-rump:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-spt-rumprun:latest"
 	procName := "solo5-spt"
 	podConfig := crictlSandboxConfig("spt-rumprun-redis-sandbox")
 	containerConfig := crictlContainerConfig("spt-rumprun-redis", containerImage)
@@ -303,7 +303,7 @@ func TestCrictlQemuUnikraftRedis(t *testing.T) {
 }
 
 func TestCrictlFCUnikraftNginx(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-fc-unik:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest"
 	procName := "firecracker"
 	podConfig := crictlSandboxConfig("fc-unikraft-nginx-sandbox")
 	containerConfig := crictlContainerConfig("fc-unikraft-nginx", containerImage)
@@ -414,7 +414,7 @@ func TestCrictlFCUnikraftNginx(t *testing.T) {
 }
 
 func TestCrictlHTTPStaticNet(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/httpreply-fc:x86_64"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/httpreply-firecracker-unikraft:latest"
 	procName := "firecracker"
 	podConfig := crictlSandboxConfig("fc-unikraft-knative-sandbox")
 

--- a/tests/ctr/ctr_test.go
+++ b/tests/ctr/ctr_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCtrHvtRumprun(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/hello-hvt-nonet:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun-nonet:latest"
 	containerName := "hvt-rumprun-hello"
 	procName := "solo5-hvt"
 	pullParams := strings.Fields("ctr image pull " + containerImage)
@@ -47,7 +47,7 @@ func TestCtrHvtRumprun(t *testing.T) {
 }
 
 func TestCtrSptRumprun(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/hello-spt-nonet:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/hello-spt-rumprun-nonet:latest"
 	containerName := "spt-rumprun-hello"
 	procName := "solo5-spt"
 	pullParams := strings.Fields("ctr image pull " + containerImage)
@@ -70,7 +70,7 @@ func TestCtrSptRumprun(t *testing.T) {
 }
 
 func TestCtrQemuUnikraftNginx(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest"
 	containerName := "qemu-unikraft-nginx"
 	procName := "qemu-system"
 	pullParams := strings.Fields("ctr image pull " + containerImage)
@@ -118,7 +118,7 @@ func TestCtrQemuUnikraftNginx(t *testing.T) {
 }
 
 func TestCtrFCUnikraftNginx(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-fc-unik:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest"
 	containerName := "fc-unikraft-nginx"
 	procName := "firecracker"
 	pullParams := strings.Fields("ctr image pull " + containerImage)

--- a/tests/nerdctl/nerdctl_test.go
+++ b/tests/nerdctl/nerdctl_test.go
@@ -30,7 +30,7 @@ import (
 const NotImplemented = "Not implemented"
 
 func TestNerdctlHvtRumprunHello(t *testing.T) {
-	params := strings.Fields("nerdctl run --name hello --rm --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/hello-hvt-rump:latest")
+	params := strings.Fields("nerdctl run --name hello --rm --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun:latest")
 	cmd := exec.Command(params[0], params[1:]...) //nolint:gosec
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -42,7 +42,7 @@ func TestNerdctlHvtRumprunHello(t *testing.T) {
 }
 
 func TestNerdctlHvtRumprunRedis(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest"
 	containerName := "hvt-rumprun-redis-test"
 	err := nerdctlTest(containerName, containerImage, true)
 	if err != nil {
@@ -51,7 +51,7 @@ func TestNerdctlHvtRumprunRedis(t *testing.T) {
 }
 
 func TestNerdctlHvtRumprunRedisBlock(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump-block:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun-block:latest"
 	containerName := "hvt-rumprun-redis-block-test"
 	err := nerdctlTest(containerName, containerImage, true)
 	if err != nil {
@@ -60,7 +60,7 @@ func TestNerdctlHvtRumprunRedisBlock(t *testing.T) {
 }
 
 func TestNerdctlHvtSeccompOn(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest"
 	containerName := "hvt-rumprun-redis-test"
 	err := nerdctlSeccompTest(containerName, containerImage, true, true)
 	if err != nil {
@@ -69,7 +69,7 @@ func TestNerdctlHvtSeccompOn(t *testing.T) {
 }
 
 func TestNerdctlHvtSeccompOff(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rump:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest"
 	containerName := "hvt-rumprun-redis-test"
 	err := nerdctlSeccompTest(containerName, containerImage, true, false)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestNerdctlHvtSeccompOff(t *testing.T) {
 }
 
 func TestNerdctlSptRumprunRedis(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-spt-rump:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/redis-spt-rumprun:latest"
 	containerName := "spt-rumprun-redis-test"
 	err := nerdctlTest(containerName, containerImage, true)
 	if err != nil {
@@ -96,7 +96,7 @@ func TestNerdctlQemuUnikraftRedis(t *testing.T) {
 }
 
 func TestNerdctlQemuUnikraftNginx(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest"
 	containerName := "qemu-unik-nginx-test"
 	err := nerdctlTest(containerName, containerImage, false)
 	if err != nil {
@@ -123,7 +123,7 @@ func TestNerdctlQemuSeccompOff(t *testing.T) {
 }
 
 func TestNerdctlFCUnikraftNginx(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-fc-unik:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest"
 	containerName := "fc-unik-nginx-test"
 	err := nerdctlTest(containerName, containerImage, false)
 	if err != nil {
@@ -132,7 +132,7 @@ func TestNerdctlFCUnikraftNginx(t *testing.T) {
 }
 
 func TestNerdctlFCSeccompOn(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-fc-unik:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest"
 	containerName := "fc-unik-nginx-test"
 	err := nerdctlSeccompTest(containerName, containerImage, true, true)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestNerdctlFCSeccompOn(t *testing.T) {
 }
 
 func TestNerdctlFCSeccompOff(t *testing.T) {
-	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-fc-unik:latest"
+	containerImage := "harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest"
 	containerName := "fc-unik-nginx-test"
 	err := nerdctlSeccompTest(containerName, containerImage, true, false)
 	if err != nil {


### PR DESCRIPTION
This allows us to support multiple unikraft versions, since unikraft v0.16.1 introduced breaking changes.