### PR TITLE
Restructure CI jobs

### DIFF
--- a/.github/linters/actionlint.yml
+++ b/.github/linters/actionlint.yml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - '*-*-amd64'
+    - '*-dind-*-amd64'
+    - '*-*-arm*'
+    - '*-dind-*-arm*'

--- a/.github/linters/commitlint.config.mjs
+++ b/.github/linters/commitlint.config.mjs
@@ -1,0 +1,13 @@
+export default {
+	extends: ['@commitlint/config-conventional'],
+	helpUrl: 'https://www.conventionalcommits.org/',
+	ignores: [
+		(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg),
+	],
+	rules: {
+		'header-max-length': [2, 'always', 72],
+		'body-max-line-length': [2, 'always', 80],
+		'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+		'trailer-exists': [2, 'always', 'Signed-off-by:'],
+	},
+}

--- a/.github/linters/licenserc.yml
+++ b/.github/linters/licenserc.yml
@@ -1,0 +1,52 @@
+header:
+  license:
+    spdx-id: Apache-2.0-short
+    copyright-owner: "Nubificus LTD"
+    copyright-year: "2024"
+    software-name: urunc
+    content: |
+      Copyright (c) 2023-2024, Nubificus LTD
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  paths-ignore:
+    - '**/.*'
+    - '**/*.md'
+    - '**/*.txt'
+    - '**/*.build'
+    - '**/*.options'
+    - '**/*.cmake'
+    - '**/*.cmake.in'
+    - '**/*.pc.in'
+    - '**/*.toml'
+    - '**/*.service'
+    - '.github'
+    - '**/go.mod'
+    - '**/go.sum'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'VERSION'
+    - 'build*'
+
+  language:
+    Go:
+      extensions:
+        - ".go"
+    bash:
+      extensions:
+        - ".sh"
+    python:
+      extensions:
+        - ".py"
+
+  comment: on-failure

--- a/.github/linters/typos.toml
+++ b/.github/linters/typos.toml
@@ -1,0 +1,12 @@
+[default.extend-words]
+SEH = "SEH"
+ser = "ser"
+nd = "nd"
+
+[files]
+extend-exclude = [
+  "subprojects/*",
+  "third-party/*",
+  "test/catch2/*",
+  "test/fff/*"
+]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,39 +1,42 @@
 name: Build
 
 on:
-  pull_request:
-    branches: [ "main" ]
-    types:
-      - synchronize
-      - labeled
-      
-  
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: '["go", "dind", "2204"]'
+      runner-archs:
+        type: string
+        default: '["amd64", "arm64"]'
+      runner-arch-map:
+        type: string
+        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
+    secrets:
+      GIT_CLONE_PAT:
+        required: false
+
+        #pull_request:
+        #branches: [ "main" ]
+        #types:
+        #- synchronize
+        #- labeled
+
   workflow_dispatch:
-
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 
 jobs:
   build:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    runs-on: ${{ format('{0}-{1}', join(fromJSON('["go", "dind", "2204"]'), '-'), matrix.archconfig) }}
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
     strategy:
       matrix:
-        archconfig: [ amd64, arm64 ]
+        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
       fail-fast: false
     
     steps:
-    - name: Cleanup previous jobs
-      run: |
-        echo "Cleaning up previous runs"
-        sudo rm -rf ${{ github.workspace }}/*
-        sudo rm -rf ${{ github.workspace }}/.??*
-        
+
     - name: Checkout code
       uses: actions/checkout@v3
+
     - name: Display Go version
       run: |
         go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-files-and-commits:
+    name: Lint Files & commits 
+    if: | 
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-lint')
+    uses: ./.github/workflows/validate-files-and-commits.yml
+    secrets: inherit
+
+  lint:
+    name: Lint code
+    if: | 
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-lint')
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
+
+  build:
+    #needs: [validate-files-and-commits, lint]
+    name: Build
+    if: | 
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-build')
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  unit_test:
+    #needs: [validate-files-and-commits, lint]
+    name: Unit tests
+    if: | 
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-build')
+    uses: ./.github/workflows/unit_test.yml
+    secrets: inherit
+
+  #FIXME: run for arm64
+  vm_test:
+    needs: [build,unit_test]
+    name: E2E test
+    if: | 
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-build')
+    uses: ./.github/workflows/vm_test.yml
+    secrets: inherit
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,26 +1,33 @@
 name: Code linting
 on:
-  pull_request:
-    branches: [ "main" ]
-    types:
-      - synchronize
-      - labeled
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: '["gcc", "dind", "2204"]'
+      runner-archs:
+        type: string
+        default: '["amd64"]'
+      runner-arch-map:
+        type: string
+        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
+    secrets:
+      GIT_CLONE_PAT:
+        required: false
 
 permissions:
   contents: read
   # allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
 
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   golangci:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     name: lint
-    runs-on: gcc-dind-2204-amd64
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
+    strategy:
+      matrix:
+        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/pr-approve.yml
+++ b/.github/workflows/pr-approve.yml
@@ -12,12 +12,6 @@ jobs:
     if: ${{ github.event.review.state == 'approved' }}
 
     steps:
-      - name: Cleanup previous jobs
-        run: |
-          echo "Cleaning up previous runs"
-          sudo rm -rf ${{ github.workspace }}/*
-          sudo rm -rf ${{ github.workspace }}/.??*
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,27 +1,34 @@
 name: Run unit tests
 
 on:
-  pull_request:
-    branches: [ "main" ]
-    types:
-      - synchronize
-      - labeled
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: '["gcc", "dind", "2204"]'
+      runner-archs:
+        type: string
+        default: '["amd64"]'
+      runner-arch-map:
+        type: string
+        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
+    secrets:
+      GIT_CLONE_PAT:
+        required: false
 
 permissions:
   contents: read
   # allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-
 jobs:
   unit-test:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     name: unit-test
-    runs-on: gcc-dind-2204-amd64
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
+    strategy:
+      matrix:
+        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -1,0 +1,106 @@
+name: Validate Files and Commit Messages
+
+on:
+  workflow_call:
+    inputs:
+      actions-repo:
+        type: string
+        default: 'nubificus/vaccel'
+      actions-rev:
+        type: string
+        default: 'main'
+      runner:
+        type: string
+        default: '["gcc", "dind", "2204"]'
+      runner-archs:
+        type: string
+        default: '["amd64"]'
+      runner-arch-map:
+        type: string
+        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
+    secrets:
+      GIT_CLONE_PAT:
+        required: false
+
+jobs:
+  linter-commitlint:
+    name: Lint Commit Messages
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    strategy:
+      matrix:
+        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
+    steps:
+      - name: Checkout .github directory
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          repository: ${{ inputs.actions-repo }}
+          ref: ${{ inputs.actions-rev }}
+
+      - name: Initialize workspace
+        uses: ./.github/actions/initialize-workspace
+        with:
+          submodules: 'false'
+          remote-actions-repo: ${{ inputs.actions-repo }}
+          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .github/linters/commitlint.config.mjs
+
+  linter-typos:
+    name: Spell Check Repo
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    strategy:
+      matrix:
+        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
+    steps:
+      - name: Checkout .github directory
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          repository: ${{ inputs.actions-repo }}
+          ref: ${{ inputs.actions-rev }}
+
+      - name: Initialize workspace
+        uses: ./.github/actions/initialize-workspace
+        with:
+          submodules: 'false'
+          remote-actions-repo: ${{ inputs.actions-repo }}
+          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+
+      - name: Spell check
+        uses: crate-ci/typos@master
+        with:
+          config: .github/linters/typos.toml
+
+  linter-license-eye:
+    name: Check License Headers
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    strategy:
+      matrix:
+        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
+    steps:
+      - name: Checkout .github directory
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          repository: ${{ inputs.actions-repo }}
+          ref: ${{ inputs.actions-rev }}
+
+      - name: Initialize workspace
+        uses: ./.github/actions/initialize-workspace
+        with:
+          submodules: 'false'
+          remote-actions-repo: ${{ inputs.actions-repo }}
+          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+
+      - name: Run license-eye
+        uses: apache/skywalking-eyes/header@main
+        with:
+          config: .github/linters/licenserc.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -1,37 +1,34 @@
 name: custom VM spawner 
 on:
-  pull_request:
-    branches: [ "main" ]
-    types:
-      - synchronize
-      - labeled
-  
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: '["gcc", "dind", "2204"]'
+      runner-archs:
+        type: string
+        default: '["amd64"]'
+      runner-arch-map:
+        type: string
+        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
+    secrets:
+      GIT_CLONE_PAT:
+        required: false
+
   workflow_dispatch:
   
 env:
   vm_profile: ubuntufat
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-
 jobs:
   prepare:
     name: VM test
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    #runs-on: [ self-hosted, gcc, lite, "x86_64" ]
-    runs-on: ${{ format('{0}-{1}', join(fromJSON('["gcc","dind","2204"]'), '-'), 'amd64') }}
-    # outputs:
-
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
+    strategy:
+      matrix:
+        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
     steps:
-    - name: Cleanup previous jobs
-      run: |
-        echo "Cleaning up previous runs"
-        sudo rm -rf ${{ github.workspace }}/*
-        sudo rm -rf ${{ github.workspace }}/.??*
-        sudo rm -rf ~/.kcli
-
     - name: Checkout
       uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Versioning variables
 COMMIT         := $(shell git describe --dirty --long --always)
 VERSION        := $(shell cat $(CURDIR)/VERSION)-$(COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ LINT_CNTR_OPTS ?= run --rm -it -v $(CURDIR):/app -w /app
 LINT_CNTR_IMG  ?= golangci/golangci-lint:v1.53.3
 LINT_CNTR_CMD  ?= golangci-lint run -v --timeout=5m
 
-# Install dependecies variables
+# Install dependencies variables
 #
 # If we have already built either static or dynamic version of urunc
 # we do not have to rebuild it, but instead we can use whichever
@@ -127,7 +127,7 @@ $(VENDOR_DIR):
 
 # Add tidy and as order-only prerequisite. In that way, since tidy and
 # vendor do notproduce any file and execute all the time,
-# we avoid the rebuilding of urunc if it has previsouly built and the
+# we avoid the rebuilding of urunc if it has previously built and the
 # source files have not changed.
 $(URUNC_BIN)_static_%: $(URUNC_SRC) | prepare
 	$(GO_FLAGS) GOARCH=$* $(GO) build \

--- a/cmd/containerd-shim-urunc-v2/main.go
+++ b/cmd/containerd-shim-urunc-v2/main.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/run.go
+++ b/cmd/urunc/run.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/start.go
+++ b/cmd/urunc/start.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -26,7 +26,7 @@ sudo apt-get upgrade -y
 
 ### Install required apt packages
 
-The following apt packages are required to complete the installation. Depending on your specific needs, some of them may not be neccessary in your use case.
+The following apt packages are required to complete the installation. Depending on your specific needs, some of them may not be necessary in your use case.
 
 ```bash
 sudo apt-get install git wget bc make build-essential -y

--- a/docs/Performance-timestamping.md
+++ b/docs/Performance-timestamping.md
@@ -93,7 +93,7 @@ cat /tmp/urunc.zlog | grep TS
 
 ## Using the Python utilities
 
-There are 3 Python utilites inside the `script/performance` directory to help gather the timestamps.
+There are 3 Python utilities inside the `script/performance` directory to help gather the timestamps.
 
 ### Measure single container execution
 

--- a/docs/Seccomp.md
+++ b/docs/Seccomp.md
@@ -42,7 +42,7 @@ calls for 'Solo5-hvt' execution.
 
 Nevertheless, 'Solo5-hvt' with seccomp in 'urunc' has been tested in Ubuntu 20.04
 and Ubuntu 22.04. Using 'urunc' and solo5-hvt on different platforms might result
-in failed execution. For that reason, we strongly recomend running the seccomp
+in failed execution. For that reason, we strongly recommend running the seccomp
 test first, by `make test_nerdctl_Seccomp`. In case the test fails, the seccomp
 profile for 'Solo5-hvt' needs to get updated.
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/internal/constants/network_constants.go
+++ b/internal/constants/network_constants.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -218,7 +218,7 @@ func addRedirectFilter(source netlink.Link, target netlink.Link) error {
 	})
 }
 
-func networkSetup(tapName string, ipAdrress string, redirectLink netlink.Link, addTCRules bool) (netlink.Link, error) {
+func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, addTCRules bool) (netlink.Link, error) {
 	err := ensureEth0Exists()
 	// if eth0 does not exist in the namespace, the unikernel was spawned using ctr, so we skip the network setup
 	if err != nil {
@@ -259,7 +259,7 @@ func networkSetup(tapName string, ipAdrress string, redirectLink netlink.Link, a
 			return nil, err
 		}
 	}
-	ipn, err := netlink.ParseAddr(ipAdrress)
+	ipn, err := netlink.ParseAddr(ipAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -41,7 +41,7 @@ func (n DynamicNetwork) NetworkSetup() (*UnikernelNetworkInfo, error) {
 		return nil, err
 	}
 	if tapIndex > 0 {
-		return nil, fmt.Errorf("unsupported opreation: can't spawn multiple unikernels in the same network namespace")
+		return nil, fmt.Errorf("unsupported operation: can't spawn multiple unikernels in the same network namespace")
 	}
 	redirectLink, err := netlink.LinkByName(DefaultInterface)
 	if err != nil {

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -60,7 +60,7 @@ type UnikernelConfig struct {
 
 // GetUnikernelConfig tries to get the Unikernel config from the bundle annotations.
 // If that fails, it gets the Unikernel config from the urunc.json file inside the rootfs.
-// FIXME: custom annotations are unreachable, we nned to investigate why to skip adding the urunc.json file
+// FIXME: custom annotations are unreachable, we need to investigate why to skip adding the urunc.json file
 // For more details, see: https://github.com/nubificus/urunc/issues/12
 func GetUnikernelConfig(bundleDir string, spec *specs.Spec) (*UnikernelConfig, error) {
 	conf, err := getConfigFromSpec(spec)

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -90,7 +90,7 @@ func applySeccompFilter() error {
 	// For the time being, we choose ActionTrap, but we can change this in the future.
 	filter := seccomp.Filter{
 		// Set the threads no_new_privs bit, disabling any new child or execve
-		// system call to grant priviledges that the parent does not have.
+		// system call to grant privileges that the parent does not have.
 		NoNewPrivs: true,
 		// Sync the filter to all threads created by the Go runtime.
 		Flag: seccomp.FilterFlagTSync,

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/ipc.go
+++ b/pkg/unikontainers/ipc.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/ipc_test.go
+++ b/pkg/unikontainers/ipc_test.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/storage_test.go
+++ b/pkg/unikontainers/storage_test.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/unikernels/utils.go
+++ b/pkg/unikontainers/unikernels/utils.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -240,12 +240,12 @@ func (u *Unikontainer) Exec() error {
 	// environment variable. However, if none of them is set, we do not take them
 	// into consideration, meaning that if the rest of the checks are valid (e.g.
 	// no block device in the container, devmapper is in use, unikernel supports
-	// block/FS of devmapper) then we wiil use the devmapper as a block device
+	// block/FS of devmapper) then we will use the devmapper as a block device
 	// for the unikernel.
 	useDevmapper := false
 	useDevmapper, err = strconv.ParseBool(u.State.Annotations[annotUseDMBlock])
 	if err != nil {
-		Log.Errorf("Invalide value in useDMBlock: %s. Urunc will try to use it",
+		Log.Errorf("Invalid value in useDMBlock: %s. Urunc will try to use it",
 			u.State.Annotations[annotUseDMBlock])
 		useDevmapper = true
 	}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -1,11 +1,11 @@
-// Copyright 2023 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -1,11 +1,11 @@
-// Copyright 2024 Nubificus LTD.
-
+// Copyright (c) 2023-2024, Nubificus LTD
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/script/dm_create.sh
+++ b/script/dm_create.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 DATA_DIR=/var/lib/containerd/io.containerd.snapshotter.v1.devmapper
 POOL_NAME=containerd-pool

--- a/script/dm_reload.sh
+++ b/script/dm_reload.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 set -ex
 
 DATA_DIR=/var/lib/containerd/io.containerd.snapshotter.v1.devmapper

--- a/script/performance/__modules__.py
+++ b/script/performance/__modules__.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from json import loads, dump
 from typing import List, Tuple, Dict
 from subprocess import run, PIPE

--- a/script/performance/measure.py
+++ b/script/performance/measure.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __modules__ import *
 from sys import argv
 from time import sleep

--- a/script/performance/measure_single.py
+++ b/script/performance/measure_single.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __modules__ import *
 from sys import argv
 

--- a/script/performance/measure_to_json.py
+++ b/script/performance/measure_to_json.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023-2024, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __modules__ import *
 from sys import argv
 from time import sleep

--- a/tests/benchmarks/benchmark_test.go
+++ b/tests/benchmarks/benchmark_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023-2024, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/tests/crictl/crictl_test.go
+++ b/tests/crictl/crictl_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023-2024, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package urunc
 
 import (

--- a/tests/ctr/ctr_test.go
+++ b/tests/ctr/ctr_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023-2024, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package urunc
 
 import (

--- a/tests/nerdctl/nerdctl_test.go
+++ b/tests/nerdctl/nerdctl_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023-2024, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package urunc
 
 import (

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023-2024, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tests
 
 import (


### PR DESCRIPTION
As we have done a lot of work in the CI setup for vAccel, it makes sense to re-use most of the functionality in urunc as well. 

This patchset restructures the CI jobs, adding extra linting and dependency-based CI job spawning.

Specifically, we structure the CI jobs as follows:
- Basic commit message linting, code/docs spellcheck/linting, and license check [validate-files-and-commits.yml] 
- Golang code linting [lint.yml]
- Build project [build.yml]
- Unit testing [unit_test.yml]
- End-to-end test [vm_test.yml] (depends on Build & unit tests)

We define two new labels: `skip-lint` and `skip-build` where the first one skips the linting jobs and the second one skips the rest of the jobs. The rationale for the first one is to facilitate people during the dev phase (no need to lint, when being on a draft PR), and for the second one to skip build tests when updating documentation. 

Note: As we define all checks to be required for merging PRs, these labels should be removed for the tests to get triggered and succeed prior to PR approvals.  