### PR TITLE
ci: Remove debug step in E2E test

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -73,7 +73,6 @@ jobs:
         SSH_AUTH_SOCK: /tmp/${{ github.run_id }}.sock
       run: |
         vm_client=$(yq '.${{ env.vm_profile}}.client'  ~/.kcli/profiles.yml)
-        kcli -c $vm_client list vm
         kcli -c $vm_client create vm -p ${{ env.vm_profile }} ${{ env.vm_profile }}_${{ github.run_id }}
         echo "get spanwed vm info"
         output="fail"


### PR DESCRIPTION
When we spawn a VM to test urunc on a fresh installation we should not list the VMs already available on the host node.