### PR TITLE
ci: Fix trigger when removing a label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches: ["main"]
-    types: [synchronize, labeled]
+    types: [synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Since we added `skip-build` / `skip-lint` labels, we want to trigger the CI jobs on label removal as well.