### PR TITLE
Update unikraft kernel arguments for initrd and app's arguments

### DIFF
--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -67,13 +67,14 @@ func (u *Unikraft) Init(data UnikernelParams) error {
 	// if there are no spaces in the command line, then
 	// we assume that there was one word (appname) in the command line
 	// Otherwise, we use the first word as the name of the app
-	appName := u.Command
-	firstSpace := strings.Index(data.CmdLine, " ")
+	u.Command = strings.TrimSpace(data.CmdLine)
+	firstSpace := strings.Index(u.Command, " ")
 	if firstSpace > 0 {
-		appName = data.CmdLine[:firstSpace]
-		u.Command = strings.TrimLeft(data.CmdLine, appName)
+		u.AppName = u.Command[:firstSpace]
+		u.Command = strings.TrimLeft(u.Command, u.AppName)
+	} else {
+		u.AppName = "unikraft"
 	}
-	u.AppName = appName
 	u.Version = data.Version
 
 	// TODO: We need to add support for actual block devices (e.g. virtio-blk)


### PR DESCRIPTION
Unikraft, except of the network kernel arguments, changed the format for the kernel arguments regarding initrd. Therefore, similarly with the changes for the network arguments we change the arguments for initrd too.

In addition, we change the way we treat single word command line options, since we were not handling that case correctly. 