### PR TITLE
spellcheck: Let the user disable/enable spellcheck with comments

### DIFF
--- a/.github/linters/typos.toml
+++ b/.github/linters/typos.toml
@@ -1,3 +1,9 @@
+[default]
+extend-ignore-re = [
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on"
+]
+
 [default.extend-words]
 SEH = "SEH"
 ser = "ser"


### PR DESCRIPTION
Allow the user to be able to exclude either a line or a block of code from the spellcheck linter.