### PR TITLE
fix(testing): Handle warnings during container operations

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -15,6 +15,7 @@
 package urunce2etesting
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -63,12 +64,16 @@ func commonNewContainerCmd(a containerTestArgs) string {
 }
 
 func commonCmdExec(command string) (output string, err error) {
+	var stderrBuf bytes.Buffer
+
 	params := strings.Fields(command)
 	cmd := exec.Command(params[0], params[1:]...) //nolint:gosec
-	outBytes, err := cmd.CombinedOutput()
+	cmd.Stderr = &stderrBuf
+	outBytes, err := cmd.Output()
 	output = string(outBytes)
 	output = strings.TrimSpace(output)
 	if err != nil {
+		output += strings.TrimSpace(stderrBuf.String())
 		return output, err
 	}
 	return output, nil


### PR DESCRIPTION
The tools that testing uses to spawn and manage containers, such as nerdctl docker and crictl, might print in stderr some warning messages. An example is the case of nerdctl and the use of systemd cgroups. In that scnearion, the testing code, which expects a specific output from the commands, will not work properly. For instance, when creating a new container and the warning is printed in stderr, the testing code treats this output as a container id.

TO resolve this issue, this commit removes the sue of CombinedOutput and separates stdout and stderr. If the execution of the command fails for any reason, then we combine the stdout with stderr and return the combined output.