### PR TITLE
fix(docs): Update yaml in kubernetes tutorial

### DIFF
--- a/docs/Sample-images.md
+++ b/docs/Sample-images.md
@@ -9,6 +9,7 @@ We plan to create and maintain multi-platform images soon, as well as enrich thi
 - harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun-nonet:latest
 - harbor.nbfc.io/nubificus/urunc/hello-spt-rumprun-nonet:latest
 - harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest
+- harbor.nbfc.io/nubificus/urunc/nginx-hvt-rumprun:latest
 - harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
 - harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun:latest
 - harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun:latest

--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -46,10 +46,9 @@ spec:
       labels:
         run: nginx-urunc
     spec:
-      nodeName: nuc4
       runtimeClassName: urunc
       containers:
-      - image: nubificus/nginx-hvt:x86_64
+      - image: harbor.nbfc.io/nubificus/urunc/nginx-hvt-rumprun:latest
         imagePullPolicy: Always
         name: nginx-urunc
         command: ["sleep"]

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -32,7 +32,7 @@ type HVT struct {
 	binary     string
 }
 
-// applySeccompFIlter applies some secomp filters for the Hvt process.
+// applySeccompFilter applies some secomp filters for the Hvt process.
 // By default all systemcalls will cause a SIGSYS, except the ones that we whitelist
 func applySeccompFilter() error {
 	syscalls := []string{


### PR DESCRIPTION
The previous yaml was using an image that does not exist and it was also specifying the node to deploy the container. Hence, as pointed out in https://github.com/nubificus/urunc/issues/52#issuecomment-2561921038, the deployment was not successful.

This commit updates the image and removes the nodeName field. Moreover, a new nginx Rumprun image was created and addded in the list of existing images.