### PR TITLE
Update the unikernel interface and allow the use of unikernel-specific cli options when we spawn the Monitor

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -22,6 +22,8 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+
+	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 )
 
 const (
@@ -79,7 +81,13 @@ func (fc *Firecracker) Path() string {
 	return fc.binaryPath
 }
 
-func (fc *Firecracker) Execve(args ExecArgs) error {
+func (fc *Firecracker) Execve(args ExecArgs, _ unikernels.Unikernel) error {
+	// FIXME: Note for getting unikernel specific options.
+	// Due to the way FC operates, we have not encountered any guest specific
+	// options yet. However, we need to revisit how we can use guest specific
+	// options in FC, since the string return value of the Monitor related
+	// functions in the unikernel interface do not integrate well with FC's
+	// json configuration.
 	cmdString := fc.Path() + " --no-api --config-file "
 	JSONConfigDir := filepath.Dir(args.UnikernelPath)
 	JSONConfigFile := filepath.Join(JSONConfigDir, FCJsonFilename)

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	hedge "github.com/nubificus/hedge_cli/hedge_api"
+	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 )
 
 const (
@@ -29,18 +30,18 @@ const (
 type Hedge struct{}
 
 func (h *Hedge) Ok() error {
-	return hedge.Status()
+	return fmt.Errorf("hedge not implemented yet")
 }
 
-func (h *Hedge) Stop(t string) error {
-	return hedge.StopVM(t)
+func (h *Hedge) Stop(_ string) error {
+	return fmt.Errorf("hedge not implemented yet")
 }
 
 func (h *Hedge) Path() string {
 	return ""
 }
 
-func (h *Hedge) Execve(_ ExecArgs) error {
+func (h *Hedge) Execve(_ ExecArgs, _ unikernels.Unikernel) error {
 	return fmt.Errorf("hedge not implemented yet")
 }
 

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 
 	seccomp "github.com/elastic/go-seccomp-bpf"
+	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 )
 
 const (
@@ -136,11 +137,13 @@ func (h *HVT) Ok() error {
 	return nil
 }
 
-func (h *HVT) Execve(args ExecArgs) error {
+func (h *HVT) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
+	hvtString := string(HvtVmm)
 	hvtMem := bytesToStringMB(args.MemSizeB)
 	cmdString := h.binaryPath + " --mem=" + hvtMem
-	cmdString = appendNonEmpty(cmdString, " --net:tap=", args.TapDevice)
-	cmdString = appendNonEmpty(cmdString, " --block:rootfs=", args.BlockDevice)
+	cmdString = appendNonEmpty(cmdString, " "+ukernel.MonitorNetCli(hvtString), args.TapDevice)
+	cmdString = appendNonEmpty(cmdString, " "+ukernel.MonitorBlockCli(hvtString), args.BlockDevice)
+	cmdString = appendNonEmpty(cmdString, " ", ukernel.MonitorCli(hvtString))
 	cmdString += " " + args.UnikernelPath + " " + args.Command
 	cmdArgs := strings.Split(cmdString, " ")
 	if args.Seccomp {

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -18,6 +18,8 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+
+	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 )
 
 const (
@@ -41,7 +43,8 @@ func (q *Qemu) Path() string {
 	return q.binaryPath
 }
 
-func (q *Qemu) Execve(args ExecArgs) error {
+func (q *Qemu) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
+	qemuString := string(QemuVmm)
 	qemuMem := bytesToStringMB(args.MemSizeB)
 	cmdString := q.binaryPath + " -m " + qemuMem + "M"
 	cmdString += " -cpu host"            // Choose CPU
@@ -70,17 +73,26 @@ func (q *Qemu) Execve(args ExecArgs) error {
 
 	cmdString += " -kernel " + args.UnikernelPath
 	if args.TapDevice != "" {
-		cmdString += " -net nic,model=virtio -net tap,script=no,ifname=" + args.TapDevice
+		netcli := ukernel.MonitorNetCli(qemuString)
+		if netcli == "" {
+			netcli += " -net nic,model=virtio"
+			netcli += " -net tap,script=no,ifname=" + args.TapDevice
+		}
+		cmdString += netcli
 	}
 	if args.BlockDevice != "" {
 		// TODO: For the time being, we only have support for initrd with
 		// QEMU and Unikraft. We will need to add support for block device
 		// and other storage options in QEMU (e.g. shared fs)
 		vmmLog.Warn("Block device is currently not supported in QEMU execution")
+		blockCli := ukernel.MonitorBlockCli(qemuString)
+		// TODO: Add default cli option if empty.
+		cmdString += blockCli
 	}
 	if args.InitrdPath != "" {
 		cmdString += " -initrd " + args.InitrdPath
 	}
+	cmdString = appendNonEmpty(cmdString, " ", ukernel.MonitorCli(qemuString))
 	exArgs := strings.Split(cmdString, " ")
 	exArgs = append(exArgs, "-append", args.Command)
 	vmmLog.WithField("qemu command", exArgs).Info("Ready to execve qemu")

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -81,12 +81,11 @@ func (q *Qemu) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
 		cmdString += netcli
 	}
 	if args.BlockDevice != "" {
-		// TODO: For the time being, we only have support for initrd with
-		// QEMU and Unikraft. We will need to add support for block device
-		// and other storage options in QEMU (e.g. shared fs)
-		vmmLog.Warn("Block device is currently not supported in QEMU execution")
 		blockCli := ukernel.MonitorBlockCli(qemuString)
-		// TODO: Add default cli option if empty.
+		if blockCli == "" {
+			blockCli += " -device virtio-blk-pci,id=blk0,drive=hd0,scsi=off"
+			blockCli += " -drive format=raw,if=none,id=hd0,file=" + args.BlockDevice
+		}
 		cmdString += blockCli
 	}
 	if args.InitrdPath != "" {

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -18,6 +18,8 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 )
 
 const (
@@ -49,11 +51,13 @@ func (s *SPT) Ok() error {
 	return nil
 }
 
-func (s *SPT) Execve(args ExecArgs) error {
+func (s *SPT) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
+	sptString := string(SptVmm)
 	sptMem := bytesToStringMB(args.MemSizeB)
 	cmdString := s.binaryPath + " --mem=" + sptMem
-	cmdString = appendNonEmpty(cmdString, " --net:tap=", args.TapDevice)
-	cmdString = appendNonEmpty(cmdString, " --block:rootfs=", args.BlockDevice)
+	cmdString = appendNonEmpty(cmdString, " "+ukernel.MonitorNetCli(sptString), args.TapDevice)
+	cmdString = appendNonEmpty(cmdString, " "+ukernel.MonitorBlockCli(sptString), args.BlockDevice)
+	cmdString = appendNonEmpty(cmdString, " ", ukernel.MonitorCli(sptString))
 	cmdString += " " + args.UnikernelPath + " " + args.Command
 	cmdArgs := strings.Split(cmdString, " ")
 	vmmLog.WithField("spt command", cmdString).Error("Ready to execve spt")

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,7 +47,7 @@ var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "hypervisors")
 
 type VMM interface {
-	Execve(args ExecArgs) error
+	Execve(args ExecArgs, ukernel unikernels.Unikernel) error
 	Stop(t string) error
 	Path() string
 	Ok() error

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -89,6 +89,30 @@ func (r *Rumprun) SupportsFS(fsType string) bool {
 	}
 }
 
+func (r *Rumprun) MonitorNetCli(monitor string) string {
+	switch monitor {
+	case "hvt", "spt":
+		return "--net:tap="
+	default:
+		return ""
+	}
+}
+
+func (r *Rumprun) MonitorBlockCli(monitor string) string {
+	switch monitor {
+	case "hvt", "spt":
+		return "--block:rootfs="
+	default:
+		return ""
+	}
+}
+
+// Rumprun can execute only on top of Solo5 and currently there
+// are no generic Solo5-specific arguments that Rumprun requires
+func (r *Rumprun) MonitorCli(_ string) string {
+	return ""
+}
+
 func (r *Rumprun) Init(data UnikernelParams) error {
 	// if EthDeviceMask is empty, there is no network support
 	if data.EthDeviceMask != "" {

--- a/pkg/unikontainers/unikernels/unikernel.go
+++ b/pkg/unikontainers/unikernels/unikernel.go
@@ -14,13 +14,18 @@
 
 package unikernels
 
-import "errors"
+import (
+	"errors"
+)
 
 type Unikernel interface {
 	Init(UnikernelParams) error
 	CommandString() (string, error)
 	SupportsBlock() bool
 	SupportsFS(string) bool
+	MonitorNetCli(string) string
+	MonitorBlockCli(string) string
+	MonitorCli(string) string
 }
 
 // UnikernelParams holds the data required to build the unikernels commandline

--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -63,6 +63,21 @@ func (u *Unikraft) SupportsFS(_ string) bool {
 	return false
 }
 
+// There is no need for any changes here yet.
+func (u *Unikraft) MonitorNetCli(_ string) string {
+	return ""
+}
+
+// We have not managed to make Unikraft run with block yet.
+func (u *Unikraft) MonitorBlockCli(_ string) string {
+	return ""
+}
+
+// There are no generic CLI hypervisor options for Unikraft yet.
+func (u *Unikraft) MonitorCli(_ string) string {
+	return ""
+}
+
 func (u *Unikraft) Init(data UnikernelParams) error {
 	// if there are no spaces in the command line, then
 	// we assume that there was one word (appname) in the command line

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -310,7 +310,7 @@ func (u *Unikontainer) Exec() error {
 	metrics.Capture(u.State.ID, "TS19")
 
 	// metrics.Wait()
-	return vmm.Execve(vmmArgs)
+	return vmm.Execve(vmmArgs, unikernel)
 }
 
 // Kill stops the VMM process, first by asking the VMM struct to stop

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -16,7 +16,6 @@ package unikontainers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -232,7 +231,7 @@ func TestMoveFile(t *testing.T) {
 		// Verify the file was moved
 		_, filename := filepath.Split(srcFile.Name())
 		movedFilePath := filepath.Join(targetDir, filename)
-		movedContent, err := ioutil.ReadFile(movedFilePath)
+		movedContent, err := os.ReadFile(movedFilePath)
 		assert.NoError(t, err, "Expected no error in reading moved file")
 		assert.Equal(t, content, string(movedContent), "Expected moved content to match original")
 


### PR DESCRIPTION
As we want to add more and more unikernel frameworks and guests to urunc, there will be cases where a guest requires specific cli options to run on top of a monitor. The cli options might be related to network, block or other kinds of devices support. For that reason, we update the unikernel interface to include the following three more functions:
- MontirorBlockCli: For block specific cli options
- MontirorNetCli: For net specific cli options
- MontirorCli: For other monitor cli options

Also, we update the code before spawning the monitor, to allow the unikernels to define any specific cli options.
