### PR TITLE
Update test workflow and test VM image

### DIFF
--- a/.github/resources/profiles.yml
+++ b/.github/resources/profiles.yml
@@ -25,7 +25,7 @@ ubuntuurunc:
 
 ubuntufat:
   client: fuji00
-  image: ubuntuuruncdocker
+  image: newubuntuuruncdocker_0.qcow2
   numcpus: 2
   memory: 4096
   nets:

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -221,7 +221,7 @@ jobs:
         sudo rm -rf /home/runner/.ssh/${{ github.run_id }}_ubuntu*
 
     - name: upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
         name: ${{ github.run_id }}_artifacts


### PR DESCRIPTION
From January 30, Github stopped support for artifact@v3 and hence we need to update to v4.
For more information see: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Also, update the image we use for the end-to-end testing of `urunc` in order to use the latest Solo5.