### PR TITLE
Changes in the VMM's CWD and devmapper handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# Vim swap files
+*.swp
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -89,8 +88,7 @@ func (fc *Firecracker) Execve(args ExecArgs, _ unikernels.Unikernel) error {
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
 	cmdString := fc.Path() + " --no-api --config-file "
-	JSONConfigDir := filepath.Dir(args.UnikernelPath)
-	JSONConfigFile := filepath.Join(JSONConfigDir, FCJsonFilename)
+	JSONConfigFile := FCJsonFilename
 	cmdString += JSONConfigFile
 	if !args.Seccomp {
 		cmdString += " --no-seccomp"

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -79,15 +79,16 @@ func getBlockDevice(path string) (RootFs, error) {
 
 // extractUnikernelFromBlock creates target directory inside the bundle and moves unikernel & urunc.json
 // FIXME: This approach fills up /run with unikernel binaries and urunc.json files for each unikernel we run
-func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bundle string) (string, error) {
+func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, rootfsPath string) (string, error) {
 	// create bundle/tmp directory and moves unikernel binary and urunc.json
-	tmpDir := filepath.Join(bundle, "tmp")
+	rootBase := filepath.Dir(rootfsPath)
+	tmpDir := filepath.Join(rootBase, "/tmp")
 	err := os.Mkdir(tmpDir, 0755)
 	if err != nil {
 		return "", err
 	}
 
-	currentUnikernelPath := filepath.Join(bundle, rootfsDirName, unikernel)
+	currentUnikernelPath := filepath.Join(rootfsPath, unikernel)
 	targetUnikernelPath := filepath.Join(tmpDir, unikernel)
 	targetUnikernelDir, _ := filepath.Split(targetUnikernelPath)
 	err = moveFile(currentUnikernelPath, targetUnikernelDir)
@@ -100,7 +101,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 	}
 
 	if initrd != "" {
-		currentInitrdPath := filepath.Join(bundle, rootfsDirName, initrd)
+		currentInitrdPath := filepath.Join(rootfsPath, initrd)
 		targetInitrdPath := filepath.Join(tmpDir, initrd)
 		targetInitrdDir, _ := filepath.Split(targetInitrdPath)
 		err = moveFile(currentInitrdPath, targetInitrdDir)
@@ -113,7 +114,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 		}
 	}
 
-	currentConfigPath := filepath.Join(bundle, rootfsDirName, uruncJSON)
+	currentConfigPath := filepath.Join(rootfsPath, uruncJSON)
 	err = moveFile(currentConfigPath, tmpDir)
 	if err != nil {
 		err1 := os.RemoveAll(tmpDir)
@@ -131,12 +132,11 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, bu
 // directory. Then it unmounts the devmapper device and renames the temporary
 // directory as the container rootfs. This is needed to keep the same paths
 // for the unikernel files.
-func prepareDMAsBlock(bundle string, unikernel string, uruncJSON string, initrd string) error {
-	rootfsPath := filepath.Join(bundle, rootfsDirName)
+func prepareDMAsBlock(rootfsPath string, unikernel string, uruncJSON string, initrd string) error {
 	// extract unikernel
 	// FIXME: This approach fills up /run with unikernel binaries and
 	// urunc.json files for each unikernel instance we run
-	tmpDir, err := extractFilesFromBlock(unikernel, uruncJSON, initrd, bundle)
+	tmpDir, err := extractFilesFromBlock(unikernel, uruncJSON, initrd, rootfsPath)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,6 @@ func prepareDMAsBlock(bundle string, unikernel string, uruncJSON string, initrd 
 // binary the initrd and the urunc.json file.
 // For the time being it acts as a placeholder for future changes, where we might
 // need to do more advanced things than removing files.
-func cleanupExtractedFiles(bundle string) error {
-	rootfsPath := filepath.Join(bundle, rootfsDirName)
+func cleanupExtractedFiles(rootfsPath string) error {
 	return os.RemoveAll(rootfsPath)
 }


### PR DESCRIPTION
Fix the handling of `devmapper` preparation as a block device for the VM. The main issue was the assumption that the rootfs directory of the container lies under the bundle directory.

Furthermore, use the container's rootfs as the CWD for the VMM execution. 