### PR TITLE
ci(deploy): Fix generic Incus client name conflict

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Setup Incus remote
-      uses: nubificus/incus-remote-setup-action@a6eab5a6fcd48f80daea157968d73a3e2a898ac4
+      uses: nubificus/incus-remote-setup-action@v2
       with:
         ssh_user: ${{ env.SSH_USER }}
         ssh_key: ${{ secrets.INCUS_ID_ED25519 }}

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -23,6 +23,7 @@ env:
   INCUS_CLUSTER: 'nbfc'
   INCUS_PROJECT: 'nbfc-ci'
   VM_NAME: 'test-vm'
+  INCUS_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}'
 
 jobs:
   prepare:
@@ -34,12 +35,13 @@ jobs:
       fail-fast: false
     steps:
     - name: Setup Incus remote
-      uses: nubificus/incus-remote-setup-action@v1
+      uses: nubificus/incus-remote-setup-action@a6eab5a6fcd48f80daea157968d73a3e2a898ac4
       with:
         ssh_user: ${{ env.SSH_USER }}
         ssh_key: ${{ secrets.INCUS_ID_ED25519 }}
         remote_host: ${{ secrets.INCUS_IP_ADDR }}
         friendly_name: ${{ env.INCUS_CLUSTER }}
+        incus_client_name: '${{ env.INCUS_NAME }}'
     
     - name: Generate Names
       id: generate-names

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -42,6 +42,7 @@ jobs:
         remote_host: ${{ secrets.INCUS_IP_ADDR }}
         friendly_name: ${{ env.INCUS_CLUSTER }}
         incus_client_name: '${{ env.INCUS_NAME }}'
+        cleanup: false
     
     - name: Generate Names
       id: generate-names


### PR DESCRIPTION
When spawning multiple concurrent runners that use the incus-remote-setup-action, the client name was shared across the runners. As a result, the first runner to reach the cleanup step would mark the client as unauthorized for all other runners. This commit fixes the issue by using a unique name for each client.