### PR TITLE
Update go x/net submodule and docs

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -62,7 +62,7 @@ should be run. The metadata can be passed to `urunc` either in the form of
 [annotations](https://github.com/opencontainers/runtime-spec/blob/main/config.md#annotations)
 or as a specific file in the container's rootfs. For a detailed explanation and
 an up-to-date list of the currently supported annotations take alook at the
-[packaging unikernels page](../image-building#annotations).
+[packaging unikernels page](../package/#annotations).
 
 Although `urunc`-formatted unikernel images are not designed to be executed by
 other container runtimes, they can still be stored and distributed via generic

--- a/docs/package/index.md
+++ b/docs/package/index.md
@@ -178,7 +178,7 @@ If we want to package a locally built Nginx Unikraft unikernel, we
 can define the a Dockerfile-like syntax file as:
 
 ```Dockerfile
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM scratch
 
 COPY nginx-qemu-x86_64-initrd_qemu-x86_64 /unikernel/kernel
@@ -197,7 +197,7 @@ If we want to package the same unikernel, using `bunnyfile`, we have to
 define the file as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 version: v0.1
 
 platforms:

--- a/docs/package/pre-built.md
+++ b/docs/package/pre-built.md
@@ -31,7 +31,7 @@ In order to package an existing pre-built unikernel image with [bunny](https://g
 `bunnyfile` we can define the `bunnyfile` as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 version: v0.1
 
 platforms:
@@ -67,7 +67,7 @@ In order to package an existing pre-built unikernel image with
 we can define the `Containerfile` as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM scratch
 
 COPY network.hvt /unikernel/network.hvt

--- a/docs/package/reuse.md
+++ b/docs/package/reuse.md
@@ -24,7 +24,7 @@ In order to append `urunc` annotations in an existing [Unikraft](https://unikraf
 we can define the `bunnyfile` as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 version: v0.1
 
 platforms:
@@ -61,7 +61,7 @@ In the case of the Dockerfile-like syntax file, we need to manually specify the
 above `bunnyfile` to the equivalent `Containerfile`:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM unikraft.org/nginx:1.15
 
 LABEL com.urunc.unikernel.binary="/unikraft/bin/kernel"

--- a/docs/package/rootfs.md
+++ b/docs/package/rootfs.md
@@ -45,7 +45,7 @@ Let's take a look at it using a Redis [Unikraft](https://unikraft.org) unikernel
 [Qemu](https://qemu.org). We will define the `bunnyfile` as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 version: v0.1
 
 platforms:
@@ -114,7 +114,7 @@ In order to package an existing pre-built unikernel image and any other files
 with [bunny](https://github.com/nubificus/bunny) and a `bunnyfile` we can define the `bunnyfile` as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 version: v0.1
 
 platforms:
@@ -261,7 +261,7 @@ In order to package an existing pre-built unikernel and its rootfs
 with [bunny](https://github.com/nubificus/bunny) and a `bunnyfile` we can define the `bunnyfile` as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 version: v0.1
 
 platforms:
@@ -301,7 +301,7 @@ docker build -f bunnyfile -t urunc/prebuilt/chttp-unikraft-qemu:test .
 We can do all the above using a Dockerfile-like syntax file as:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:0.0.2
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM scratch
 
 COPY app-elfloader-qemu-x86_64-initrd_qemu-x86_64 /unikernel/kernel

--- a/docs/unikernel-support.md
+++ b/docs/unikernel-support.md
@@ -49,7 +49,7 @@ this.
 
 [Unikraft](https://unikraft.org/) maintains a
 [catalog](https://github.com/unikraft/catalog) with available applications as
-unikernel images. Check out our [packaging](../image-building) page on how to
+unikernel images. Check out our [packaging](../package) page on how to
 get these images and run them on top of `urunc`.
 
 An example of [Unikraft](https://unikraft.org/) on top of Qemu with `urunc`:
@@ -116,7 +116,7 @@ execution should be placed inside the container image.
 
 For more information on packaging
 [MirageOS](https://github.com/mirage/mirage) unikernels for `urunc` take
-a look at our [packaging](../image-building/) page.
+a look at our [packaging](../package/) page.
 
 An example of [MirageOS](https://github.com/mirage/mirage) on top of
 Solo5-hvt using a block image inside the container's rootfs with 'urunc':
@@ -187,7 +187,7 @@ inside the container image and attaching it to
 
 For more information on packaging
 [Rumprun](https://github.com/cloudkernels/rumprun) unikernels for `urunc` take
-a look at our [packaging](../image-building/) page.
+a look at our [packaging](../package/) page.
 
 An example of [Rumprun](https://github.com/cloudkernels/rumprun) on top of
 Solo5-hvt using a block image inside the container's rootfs with 'urunc':
@@ -246,7 +246,7 @@ network access to [Mewz](https://github.com/Mewz-project/Mewz) unikernels.
 
 For more information on packaging
 [Mewz](https://github.com/Mewz-project/Mewz) unikernels for `urunc` take
-a look at our [packaging](../image-building/) page.
+a look at our [packaging](../package/) page.
 
 An example of [Mewz](https://github.com/Mewz-project/Mewz) on top of
 Qemu using with 'urunc':

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto v0.0.0-20250313205543-e70fdf4c4cb4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Update the x/net submodule of Go to cover CVE-2025-22872.

Furthermore, fix the dead links regarding the packaging page in the docs and update all bunnyfile snippets to use the latest version of bunny. 