### PR TITLE
Rename `aarch64` to `arm64` on binary upload jobs and correct docs broken link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
       run: |
         make
 
-    - name: Upload urunc_aarch64 to S3
-      if: matrix.archconfig == 'aarch64'
+    - name: Upload urunc_arm64 to S3
+      if: matrix.archconfig == 'arm64'
       uses: cloudkernels/minio-upload@v3
       with:
         url: https://s3.nbfc.io
@@ -77,8 +77,8 @@ jobs:
         remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
         policy: 1
 
-    - name: Upload containerd-shim-urunc-v2_aarch64 to S3
-      if: matrix.archconfig == 'aarch64'
+    - name: Upload containerd-shim-urunc-v2_arm64 to S3
+      if: matrix.archconfig == 'arm64'
       uses: cloudkernels/minio-upload@v3
       with:
         url: https://s3.nbfc.io

--- a/docs/developer-guide/security.md
+++ b/docs/developer-guide/security.md
@@ -24,10 +24,10 @@ the private vulnerability reporting of the `urunc`'s Github repository. In
 particular, in `urunc`'s repository page, navigate to the [Security
 tab](https://github.com/nubificus/urunc/security), click
 [`Advisories`](https://github.com/nubificus/urunc/security/advisories) and then
-[`Report a vulnerability`]
-(https://github.com/nubificus/urunc/security/advisories/new). Alternatively, the
-report can be filed via email at `security@urunc.io`. This address delivers
-your message securely to all maintainers.
+[`Report a
+vulnerability`](https://github.com/nubificus/urunc/security/advisories/new).
+Alternatively, the report can be filed via email at `security@urunc.io`. This
+address delivers your message securely to all maintainers.
 
 ### Vulnerability handling process
 


### PR DESCRIPTION
Rename `aarch64` to `arm64` for consistency (and to re-enable the upload) of `arm64` binaries