### PR TITLE
ci: Fix hardcoded repo name for VM test

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -80,7 +80,7 @@ jobs:
         export VM_NAME="${{ env.INCUS_CLUSTER }}:${{ env.VM_NAME }}"
         export INCUS_RUN="incus exec $VM_NAME --project ${{ env.INCUS_PROJECT }} -- sh -c "
         $INCUS_RUN "rm -f /usr/local/bin/urunc"
-        $INCUS_RUN "git clone https://github.com/nubificus/urunc.git /root/develop/urunc"
+        $INCUS_RUN "git clone https://github.com/${{ github.repository }} /root/develop/urunc"
         $INCUS_RUN "cd /root/develop/urunc && git reset --hard ${{github.event.pull_request.head.sha}}"
         $INCUS_RUN "PATH=/usr/local/go/bin:$PATH make -C /root/develop/urunc"
         $INCUS_RUN "make -C /root/develop/urunc install"


### PR DESCRIPTION
To enable the VM test action to work on forks/different orgs/renamed repos, we should clone the code using the `github.repository` variable, instead of the hardcoded entry.