### PR TITLE
ci: Use GH runners for build, lint, and test jobs

### DIFF
--- a/.github/workflows/add-git-trailers.yml
+++ b/.github/workflows/add-git-trailers.yml
@@ -11,7 +11,13 @@ on:
 jobs:
   git-trailers:
     name: Add Git Trailers
-    runs-on: [base-dind-2204-amd64]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+    continue-on-error: true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,41 +7,32 @@ on:
         required: true
         type: string
         default: ''
-      runner:
-        type: string
-        default: '["base", "dind", "2204"]'
-      runner-archs:
-        type: string
-        default: '["amd64", "arm64"]'
-      runner-arch-map:
-        type: string
-        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
-    secrets:
-      GIT_CLONE_PAT:
-        required: false
-
-        #pull_request:
-        #branches: [ "main" ]
-        #types:
-        #- synchronize
-        #- labeled
 
   workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
-      fail-fast: false
-    
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    continue-on-error: true
+
     steps:
 
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.24.1'
+        cache: false
 
     - name: Display Go version
       run: |
@@ -63,46 +54,22 @@ jobs:
       run: |
         make
 
-    - name: Upload urunc_arm64 to S3
-      if: matrix.archconfig == 'arm64'
+    - name: Upload urunc_${{ matrix.arch }} to S3
       uses: cloudkernels/minio-upload@v3
       with:
         url: https://s3.nbfc.io
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/urunc_static_arm64
-        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
+        local-path: dist/urunc_static_${{ matrix.arch }}
+        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.arch }}/
         policy: 1
 
-    - name: Upload urunc_amd64 to S3
-      if: matrix.archconfig == 'amd64'
+    - name: Upload containerd-shim-urunc-v2_${{ matrix.arch }} to S3
       uses: cloudkernels/minio-upload@v3
       with:
         url: https://s3.nbfc.io
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/urunc_static_amd64
-        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
-        policy: 1
-
-    - name: Upload containerd-shim-urunc-v2_arm64 to S3
-      if: matrix.archconfig == 'arm64'
-      uses: cloudkernels/minio-upload@v3
-      with:
-        url: https://s3.nbfc.io
-        access-key: ${{ secrets.AWS_ACCESS_KEY }}
-        secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/containerd-shim-urunc-v2_static_arm64
-        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
-        policy: 1
-
-    - name: Upload containerd-shim-urunc-v2_amd64 to S3
-      if: matrix.archconfig == 'amd64'
-      uses: cloudkernels/minio-upload@v3
-      with:
-        url: https://s3.nbfc.io
-        access-key: ${{ secrets.AWS_ACCESS_KEY }}
-        secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: dist/containerd-shim-urunc-v2_static_amd64
-        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
+        local-path: dist/containerd-shim-urunc-v2_static_${{ matrix.arch }}
+        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.arch }}/
         policy: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,18 +6,6 @@ on:
         required: true
         type: string
         default: ''
-      runner:
-        type: string
-        default: '["base", "dind", "2204"]'
-      runner-archs:
-        type: string
-        default: '["amd64"]'
-      runner-arch-map:
-        type: string
-        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
-    secrets:
-      GIT_CLONE_PAT:
-        required: false
 
 permissions:
   contents: read
@@ -27,11 +15,14 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
-      fail-fast: false
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+    continue-on-error: true
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -7,18 +7,6 @@ on:
         type: string
         default: ''
         required: true
-      runner:
-        type: string
-        default: '["base", "dind", "2204"]'
-      runner-archs:
-        type: string
-        default: '["amd64", "arm64"]'
-      runner-arch-map:
-        type: string
-        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
-    secrets:
-      GIT_CLONE_PAT:
-        required: false
 
 permissions:
   contents: read
@@ -27,15 +15,23 @@ permissions:
 jobs:
   unit-test:
     name: unit-test
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.archconfig) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+
       fail-fast: false
+    continue-on-error: true
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Run unikontainers pkg unit tests
         run: make unittest
 

--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -7,27 +7,19 @@ on:
         required: true
         type: string
         default: ''
-      runner:
-        type: string
-        default: '["base", "dind", "2204"]'
-      runner-archs:
-        type: string
-        default: '["amd64"]'
-      runner-arch-map:
-        type: string
-        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
-    secrets:
-      GIT_CLONE_PAT:
-        required: false
 
 jobs:
   linter-commitlint:
     name: Lint Commit Messages
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
       fail-fast: false
+    continue-on-error: true
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -39,11 +31,15 @@ jobs:
 
   linter-typos:
     name: Spell Check Repo
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
       fail-fast: false
+    continue-on-error: true
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -55,11 +51,15 @@ jobs:
 
   linter-license-eye:
     name: Check License Headers
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
       fail-fast: false
+    continue-on-error: true
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Only use our self-hosted runners for spawning a test VM to launch the end to end tests. Use generic GH runners for the rest.