### PR TITLE
fix(qemu): Change qemu BIOS/data paths

### DIFF
--- a/deployment/urunc-deploy/scripts/install.sh
+++ b/deployment/urunc-deploy/scripts/install.sh
@@ -58,9 +58,9 @@ function install_artifacts() {
             if which "qemu-system-$(uname -m)" >/dev/null 2>&1; then
                 echo "QEMU is already installed."
             else
-                install_artifact /urunc-artifacts/hypervisors/qemu-system-$(uname -m) /host/usr/local/bin/qemu-$(uname -m)
-                mkdir -p /host/usr/share/qemu/
-                cp -r /urunc-artifacts/opt/kata/share/kata-qemu/qemu /host/usr/share
+                install_artifact /urunc-artifacts/hypervisors/qemu-system-$(uname -m) /host/usr/local/bin/qemu-system-$(uname -m)
+                mkdir -p /host/usr/local/share/qemu/
+                cp -r /urunc-artifacts/opt/kata/share/kata-qemu/qemu /host/usr/local/share
             fi
             ;;
         firecracker)
@@ -91,10 +91,6 @@ function remove_artifacts() {
         qemu)
             if [ -e "/host/usr/local/bin/qemu-system-$(uname -m)" ]; then
                 rm -f "/host/usr/local/bin/qemu-system-$(uname -m)"
-            fi
-
-            if [ -e "/host/usr/local/bin/qemu-urunc" ]; then
-                rm -f /host/usr/local/bin/qemu-urunc
                 rm -rf /host/usr/local/share/qemu
             fi
             ;;

--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -195,8 +195,7 @@ During installation, the following steps take place:
     * Labels the Node with label `urunc.io/urunc-runtime=true`.
 - Finally, `urunc` is added as a runtime class in k8s.
 
-> Note: `urunc-deploy` will install a static version of QEMU along with the QEMU BIOS files. The QEMU BIOS files are placed
-under the `/usr/share` directory. If the host system already had installed QEMU, then QEMU binary and the BIOS files in `/usr/share`, will get overwritten.
+> Note: `urunc-deploy` will install a static version of QEMU in `/usr/local/bin/` along with the QEMU BIOS files in `/usr/local/share/`. Therefore, files with the same names under these directories will get overwritten.
 
 During cleanup, these changes are reverted:
 

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -460,6 +460,11 @@ func (u *Unikontainer) Delete() error {
 	if err != nil {
 		return fmt.Errorf("cannot remove /dev: %v", err)
 	}
+	cntrTmp := filepath.Join(rootfsDir, "/tmp")
+	err = os.RemoveAll(cntrTmp)
+	if err != nil {
+		return fmt.Errorf("cannot remove /tmp: %v", err)
+	}
 	cntrLib := filepath.Join(rootfsDir, "/lib")
 	err = os.RemoveAll(cntrLib)
 	if err != nil {


### PR DESCRIPTION
Change the location of Qemu's BIOS/data paths to `/usr/local/share` and avoid any conflicts with distro's files. Furthermore, add logic in `urunc` to find if we use the `/usr/local/share` directory or the `/usr/share` for Qemu's data files. Regardless of where they locate in the host, `urunc` will mount them under `/usr/share` in the container's rootfs.