### PR TITLE
feat(volumes): Initial implementation of bind mounts in rootfs

### DIFF
--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -349,6 +349,11 @@ func (u *Unikontainer) Exec() error {
 		return err
 	}
 
+	err = mountVolumes(rootfsDir, u.Spec.Mounts)
+	if err != nil {
+		return err
+	}
+
 	withPivot := containsNS(u.Spec.Linux.Namespaces, specs.MountNamespace)
 	err = changeRoot(rootfsDir, withPivot)
 	if err != nil {
@@ -360,7 +365,6 @@ func (u *Unikontainer) Exec() error {
 	if err != nil {
 		return err
 	}
-
 	uniklog.Debug("calling vmm execve")
 	metrics.Capture(u.State.ID, "TS18")
 	// metrics.Wait()


### PR DESCRIPTION
An initial implementation for setting up all the bind mounts, specified in the container's configuration, in the container's rootfs. This is necessary and useful for the share-fs use cases. Currently, only the bind mounts are handled with the specified mount and propagation flags.

In the future, we might want to use this functionality, only in the shared-fs use cases. Otherwise it is not that useful.