### PR TITLE
chore(docs): Update Linux tutorial to note that urunit is needed in K8s

### DIFF
--- a/docs/tutorials/existing-container-linux.md
+++ b/docs/tutorials/existing-container-linux.md
@@ -55,17 +55,23 @@ However, this is not always reliable:
 - CLI argument handling may be incorrect: Linux does not natively support
   multi-word arguments via kernel boot parameters. Each space-separated word is
   treated as a separate argument.
+- A few necessary operations (such as mount /proc, set default route) might be
+  required before executing the application.
 
-To tackle this, `urunc` follows a simple convention. All multi-word CLI arguments
-are wrapped in single quotes and the init process (or application) is expected
-to reconstruct them properly.
+Especially, for CLI argument handing, `urunc` follows a simple convention. All
+multi-word CLI arguments are wrapped in single quotes and the init process (or
+application) is expected to reconstruct them properly.
 
-For these reasons, we recommend introducing a dedicated init process. We provide
-[urunit](https://github.com/nubificus/urunit#); a lightweight init designed
-specifically for `urunc`. It performs two key roles:
+For all the above reasons, we recommend using a dedicated init process. We
+provide [urunit](https://github.com/nubificus/urunit#); a lightweight init
+designed specifically for `urunc`. It performs the following actions:
 
-1. Groups multi-word arguments correctly.
-2. Acts as a reaper, cleaning up zombie processes.
+1. Sets default route through eth0. This is necessary when we deploy
+   the container in a Kubernetes cluster, where there is a high chance that
+   the gateway of the container might be in a different subnet than the IP.
+   As a result, Linux kernel will fail to set the gateway.
+2. Groups multi-word arguments correctly.
+3. Acts as a reaper, cleaning up zombie processes.
 
 You can obtain [urunit](https://github.com/nubificus/urunit) in two ways:
 

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -117,7 +117,6 @@ func (r *Rumprun) CommandString() (string, error) {
 		finalJSONString += "," + blkJSONString
 	}
 	finalJSONString += "}"
-	fmt.Println(finalJSONString)
 	return finalJSONString, nil
 }
 


### PR DESCRIPTION
When we deploy a Linux container with urunc in Kubernetes, we face the
issue where the gateway might be in a different subnet than the IP.
In such cases, Linux will fail to set the default gateway and as such,
the VM will not have network access. Since urunc uses kernel boot
parameters to set up the network configuration of the VM, there is no
way to properly handle such issues.

As a result, we can only overcome this by an init process running inside
the VM. That is what urunit does, by setting the default route through
eth0. However, this makes urunit necessary when we deploy
such containers in K8s. Therefore, we need to mention this in our tutorial.

With this opportunity remove the rumprun debug message for the JSON
construction.
