### PR TITLE
ci: Add step to fetch go packages

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -203,6 +203,16 @@ jobs:
         sudo udevadm trigger --name-match=kvm
         sudo usermod -a -G kvm $USER
 
+    - name: Prepare urunc folder
+      id: prepare
+      if: ${{ !cancelled() }}
+      run: |
+        export GOROOT=$(go env GOROOT)
+        export PATH="$GOROOT/bin:$PATH"
+        go version
+        go env GOROOT
+        make prepare
+
     - name: Run ${{ matrix.test }}
       id: test
       if: ${{ !cancelled() }}


### PR DESCRIPTION
To avoid non-predictable pkg fetching at the time of the test, we add an extra step to prepare the directory for running the tests.