### PR TITLE
ci: Introduce nightly tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
         type: string
 
   workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -29,7 +34,6 @@ jobs:
     continue-on-error: true
 
     steps:
-
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
       with:
@@ -37,6 +41,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: ${{ inputs.ref }}
 
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -1,0 +1,68 @@
+name: urunc CI (nightly)
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  validate-files-and-commits:
+    name: Lint Files & commits 
+    uses: ./.github/workflows/validate-files-and-commits.yml
+    with:
+      ref: ${{ github.sha }}
+
+  lint:
+    name: Lint code
+    uses: ./.github/workflows/lint.yml
+    with:
+      ref: ${{ github.sha }}
+
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    with:
+      ref: ${{ github.sha }}
+
+  unit_test:
+    name: Unit tests
+    uses: ./.github/workflows/unit_test.yml
+    with:
+      ref: ${{ github.sha }}
+      go_version: "1.24.6"
+
+  vm_test:
+    needs: [build]
+    name: E2E test
+    uses: ./.github/workflows/vm_test.yml
+    with:
+      runner-archs: '["amd64", "arm64"]'
+      runc_version: '1.3.0'
+      containerd_version: '2.1.3'
+      cni_version: '1.7.1'
+      nerdctl_version: '2.1.3'
+      crictl_version: 'v1.30.0'
+      firecracker_version: 'v1.7.0'
+      solo5_version: 'v0.9.3'
+
+  kind_test:
+    needs: [build]
+    name:  Kubernetes test
+    uses: ./.github/workflows/kind_test.yml
+    with:
+      firecracker_version: 'v1.7.0'
+      solo5_version: 'v0.9.3'
+      runc_version: '1.3.0'


### PR DESCRIPTION
This PR introduces a CI trigger when code is merged to main, as well as a periodic trigger to see the status of the repo.

Ideally, this will end up running longer tests, cover the whole range of supported options, as well as performance metrics to check for regressions. This could also include alternative distro testing (we currently support ubuntu 22.04 / 24.04).

Currently, we ditch unit tests (as, in theory, these would have been tested prior to the PR merge).

