### PR TITLE
ci: centralize Go version handling in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
         default: ''
+      go_version:
+        required: true
+        type: string
 
   workflow_dispatch:
 
@@ -37,7 +40,7 @@ jobs:
 
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: '1.24.1'
+        go-version: ${{ inputs.go_version }}
         cache: false
 
     - name: Display Go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: "no"
+      go_version:
+        required: false
+        type: string
+        default: "1.24.1"
 
 permissions:
   contents: read
@@ -36,6 +40,7 @@ jobs:
     uses: ./.github/workflows/lint.yml
     with:
       ref: ${{ inputs.ref }}
+      go_version: ${{ inputs.go_version }}
     secrets: inherit
 
   build:
@@ -44,6 +49,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       ref: ${{ inputs.ref }}
+      go_version: ${{ inputs.go_version }}
     secrets: inherit
 
   unit_test:
@@ -52,6 +58,7 @@ jobs:
     uses: ./.github/workflows/unit_test.yml
     with:
       ref: ${{ inputs.ref }}
+      go_version: ${{ inputs.go_version }}
     secrets: inherit
 
   vm_test:
@@ -61,6 +68,7 @@ jobs:
     uses: ./.github/workflows/vm_test.yml
     with:
       ref: ${{ inputs.ref }}
+      go_version: ${{ inputs.go_version }}
       runner-archs: '["amd64", "arm64"]'
       runc_version: '1.3.0'
       containerd_version: '2.1.3'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
         required: true
         type: string
         default: ''
+      go_version:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -34,7 +37,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24.1'
+          go-version: ${{ inputs.go_version }}
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -7,6 +7,9 @@ on:
         type: string
         default: ''
         required: true
+      go_version:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -39,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24.1'
+          go-version: ${{ inputs.go_version }}
           cache: false
 
       - name: Run unikontainers pkg unit tests

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -5,6 +5,9 @@ on:
       ref:
         type: string
         default: ''
+      go_version:
+        required: true
+        type: string
       runner:
         type: string
         default: '["base", "dind", "2204"]'
@@ -68,7 +71,7 @@ jobs:
 
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: '1.24.1'
+        go-version: ${{ inputs.go_version }}
         cache: false
 
     - name: Install base dependencies


### PR DESCRIPTION
In various workflows of our CI, Go was being installed independently 
(build, lint, unit_test, vm_test). This made upgrading Go version 
error-prone. 

With this change, the Go version is passed as an input parameter 
across workflows, so it can be controlled from a single place (ci.yml).