### PR TITLE
Blockfile Snapshotter for urunc Integration

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -345,3 +345,5 @@ macaddr
 copyMountfiles
 govet
 DEFROUTE
+blockfile
+thinpool


### PR DESCRIPTION
Blockfile offers a simple, block-based alternative to devmapper with easier setup. Its straightforward implementation makes it worth investigating as a complementary snapshotter option for urunc environments.

