### PR TITLE
refactor(cli): Migrate from urfave/cli v1 to v3 #Issue Number 132

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -20,6 +20,9 @@ users:
   zyfy29:
     name: zyfy29
     email: wasuremono127@gmail.com
+  codesmith25103:
+    name: sankalp
+    email: sankalp25103@gmail.com
   copilot-pull-request-reviewerbot:
     name: copilot[bot]
     email: copilot[bot]@users.noreply.github.com

--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -15,14 +15,15 @@
 package main
 
 import (
+	"context"
 	"os"
 	"runtime"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
-var deleteCommand = cli.Command{
+var deleteCommand = &cli.Command{
 	Name:  "delete",
 	Usage: "delete any resources held by the container often used with detached container",
 	ArgsUsage: `<container-id>
@@ -34,27 +35,28 @@ For example, if the container id is "ubuntu01" and runc list currently shows the
 status of "ubuntu01" as "stopped" the following will delete resources held for
 "ubuntu01" removing "ubuntu01" from the runc list of containers:
 
-       # runc delete ubuntu01`,
+	# urunc delete ubuntu01`,
 	Flags: []cli.Flag{
-		cli.BoolFlag{
-			Name:  "force, f",
-			Usage: "Forcibly deletes the container if it is still running (uses SIGKILL)",
+		&cli.BoolFlag{
+			Name:    "force",
+			Aliases: []string{"f"},
+			Usage:   "Forcibly deletes the container if it is still running (uses SIGKILL)",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(_ context.Context, cmd *cli.Command) error {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
 		logrus.WithField("command", "DELETE").WithField("args", os.Args).Debug("urunc INVOKED")
-		if err := checkArgs(context, 1, exactArgs); err != nil {
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
 			return err
 		}
 
 		// get Unikontainer data from state.json
-		unikontainer, err := getUnikontainer(context)
+		unikontainer, err := getUnikontainer(cmd)
 		if err != nil {
 			return err
 		}
-		if context.Bool("force") {
+		if cmd.Bool("force") {
 			err := unikontainer.Kill()
 			if err != nil {
 				return err

--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -15,14 +15,15 @@
 package main
 
 import (
+	"context"
 	"os"
 	"runtime"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
-var killCommand = cli.Command{
+var killCommand = &cli.Command{
 	Name:  "kill",
 	Usage: "kill sends the specified signal (default: SIGTERM) to the container's init process",
 	ArgsUsage: `<container-id> [signal]
@@ -34,26 +35,27 @@ EXAMPLE:
 For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
 
-       # runc kill ubuntu01 KILL`,
+	# urunc kill ubuntu01 KILL`,
 	Flags: []cli.Flag{
-		cli.BoolFlag{
-			Name:  "all, a",
-			Usage: "send the specified signal to all processes inside the container",
+		&cli.BoolFlag{
+			Name:    "all",
+			Aliases: []string{"a"},
+			Usage:   "send the specified signal to all processes inside the container",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(_ context.Context, cmd *cli.Command) error {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
 		logrus.WithField("command", "KILL").WithField("args", os.Args).Debug("urunc INVOKED")
-		if err := checkArgs(context, 1, minArgs); err != nil {
+		if err := checkArgs(cmd, 1, minArgs); err != nil {
 			return err
 		}
-		if err := checkArgs(context, 2, maxArgs); err != nil {
+		if err := checkArgs(cmd, 2, maxArgs); err != nil {
 			return err
 		}
 
 		// get Unikontainer data from state.json
-		unikontainer, err := getUnikontainer(context)
+		unikontainer, err := getUnikontainer(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/urunc/run.go
+++ b/cmd/urunc/run.go
@@ -15,11 +15,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
 var runUsage = `<container-id>
@@ -37,40 +38,41 @@ to specify command(s) that get run when the container is started. To change the
 command(s) that get executed on start, edit the args parameter of the spec. See
 "runc spec --help" for more explanation.`
 
-var runCommand = cli.Command{
+var runCommand = &cli.Command{
 	Name:        "run",
 	Usage:       "create and run a container",
 	ArgsUsage:   runUsage,
 	Description: runDescription,
 	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "bundle, b",
-			Value: "",
-			Usage: `path to the root of the bundle directory, defaults to the current directory`,
+		&cli.StringFlag{
+			Name:    "bundle",
+			Aliases: []string{"b"},
+			Value:   "",
+			Usage:   `path to the root of the bundle directory, defaults to the current directory`,
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "console-socket",
 			Value: "",
 			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "pid-file",
 			Value: "",
 			Usage: "specify the file to write the process id to",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(_ context.Context, cmd *cli.Command) error {
 		logrus.WithField("command", "RUN").WithField("args", os.Args).Debug("urunc INVOKED")
-		if err := checkArgs(context, 1, exactArgs); err != nil {
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
 			return err
 		}
 
 		// FIXME: This is a refactor of what the previous code did, however I have a feeling
 		// that it will not work...
-		if err := reexecUnikontainer(context); err != nil {
+		if err := reexecUnikontainer(cmd); err != nil {
 			return err
 		}
-		if err := startUnikontainer(context); err != nil {
+		if err := startUnikontainer(cmd); err != nil {
 			return err
 		}
 		return fmt.Errorf("urunc run failed: %w", nil)

--- a/cmd/urunc/start.go
+++ b/cmd/urunc/start.go
@@ -15,13 +15,14 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
-var startCommand = cli.Command{
+var startCommand = &cli.Command{
 	Name:  "start",
 	Usage: "executes the user defined process in a created container",
 	ArgsUsage: `<container-id>
@@ -30,25 +31,25 @@ Where "<container-id>" is your name for the instance of the container that you
 are starting. The name you provide for the container instance must be unique on
 your host.`,
 	Description: `The start command executes the user defined process in a created container.`,
-	Action: func(context *cli.Context) error {
+	Action: func(_ context.Context, cmd *cli.Command) error {
 		logrus.WithField("command", "START").WithField("args", os.Args).Debug("urunc INVOKED")
-		if err := checkArgs(context, 1, exactArgs); err != nil {
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
 			return err
 		}
-		return startUnikontainer(context)
+		return startUnikontainer(cmd)
 	},
 }
 
 // We keep it as a separate function, since it is also called from
 // the run command
-func startUnikontainer(context *cli.Context) error {
+func startUnikontainer(cmd *cli.Command) error {
 	// No need to check if containerID is valid, because it will get
 	// checked later. We just want it for the metrics
-	containerID := context.Args().First()
+	containerID := cmd.Args().First()
 	metrics.Capture(containerID, "TS11")
 
 	// get Unikontainer data from state.json
-	unikontainer, err := getUnikontainer(context)
+	unikontainer, err := getUnikontainer(cmd)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli v1.22.17
+	github.com/urfave/cli/v3 v3.4.1
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
 	golang.org/x/sys v0.36.0
@@ -43,7 +43,6 @@ require (
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/go-events v0.0.0-20250808211157-605354379745 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -64,7 +63,6 @@ require (
 	github.com/opencontainers/selinux v1.12.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/net v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWSeaA=
@@ -44,8 +43,6 @@ github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsx
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
 github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
-github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
-github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
@@ -173,8 +170,6 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/seccomp/libseccomp-golang v0.10.0 h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY=
 github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -190,12 +185,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
-github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
+github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=
+github.com/urfave/cli/v3 v3.4.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
@@ -309,7 +302,6 @@ google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This commit refactors the entire command-line interface layer to support the breaking changes introduced in urfave/cli v3. The migration modernizes the API usage and aligns the codebase with the new library conventions.