### PR TITLE
feat(update initrd): Copy files from mount struct inside initrd

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -359,3 +359,7 @@ vhost
 libexec
 sonarcloud
 NOSONAR
+cavaliergopher
+Msec
+Mtim
+Nsec

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/*.go)
 URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/hypervisors/*.go)
 URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/unikernels/*.go)
 URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/types/*.go)
+URUNC_SRC      += $(wildcard $(CURDIR)/pkg/unikontainers/initrd/*.go)
 URUNC_SRC      += $(wildcard $(CURDIR)/pkg/network/*.go)
 SHIM_SRC       := $(wildcard $(CURDIR)/cmd/containerd-shim-urunc-v2/*.go)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.6
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
+	github.com/cavaliergopher/cpio v1.0.1
 	github.com/containerd/containerd v1.7.27
 	github.com/creack/pty v1.1.24
 	github.com/elastic/go-seccomp-bpf v1.6.0
@@ -55,6 +56,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWS
 github.com/Microsoft/hcsshim v0.13.0/go.mod h1:9KWJ/8DgU+QzYGupX4tzMhRQE8h6w90lH6HAaclpEok=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/cavaliergopher/cpio v1.0.1 h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7av2KM=
+github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/checkpoint-restore/go-criu/v6 v6.3.0 h1:mIdrSO2cPNWQY1truPg6uHLXyKHk3Z5Odx4wjKOASzA=
 github.com/checkpoint-restore/go-criu/v6 v6.3.0/go.mod h1:rrRTN/uSwY2X+BPRl/gkulo9gsKOSAeVp9/K2tv7xZI=
@@ -126,8 +128,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
-github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
-github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
+github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
+github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/moby/sys/capability v0.4.0 h1:4D4mI6KlNtWMCM1Z/K0i7RV1FkX+DBDHKVJpCndZoHk=
 github.com/moby/sys/capability v0.4.0/go.mod h1:4g9IK291rVkms3LKCDOoYlnV8xKwoDTpIrNEE35Wq0I=
 github.com/moby/sys/mount v0.3.4 h1:yn5jq4STPztkkzSKpZkLcmjue+bZJ0u2AuQY1iNI1Ww=

--- a/pkg/unikontainers/initrd/initrd.go
+++ b/pkg/unikontainers/initrd/initrd.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package initrd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/cavaliergopher/cpio"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func AddInitrdRecord(w *cpio.Writer, content []byte, fileInfo *syscall.Stat_t, name string) error {
+	hdr := &cpio.Header{
+		Name:    name,
+		Mode:    cpio.FileMode(fileInfo.Mode),
+		Uid:     int(fileInfo.Uid),
+		Guid:    int(fileInfo.Gid),
+		ModTime: time.Unix(fileInfo.Mtim.Sec, fileInfo.Mtim.Nsec),
+		Size:    fileInfo.Size,
+	}
+	err := w.WriteHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("could not write header in initrd: %v", err)
+	}
+	_, err = w.Write(content)
+	if err != nil {
+		return fmt.Errorf("could not write contents in initrd: %v", err)
+	}
+
+	return nil
+}
+
+func AddFileToInitrd(w *cpio.Writer, srcFile string, destFile string) error {
+	// Get the info of the original file
+	fi, err := os.Stat(srcFile)
+	if err != nil {
+		return fmt.Errorf("Could not Stat file %s: %w", srcFile, err)
+	}
+	fileInfo := fi.Sys().(*syscall.Stat_t)
+	if fi.Mode().IsRegular() {
+		content, err := os.ReadFile(srcFile)
+		if err != nil {
+			return fmt.Errorf("could not read file %s: %w", srcFile, err)
+		}
+		err = AddInitrdRecord(w, content, fileInfo, destFile)
+		if err != nil {
+			return fmt.Errorf("could not add record for %s: %w", srcFile, err)
+		}
+	}
+
+	return nil
+}
+
+func CopyFileMountsToInitrd(oldInitrd string, mounts []specs.Mount) error {
+	f, err := os.OpenFile(oldInitrd, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("Could not open %s: %v", oldInitrd, err)
+	}
+	defer f.Close()
+
+	w := cpio.NewWriter(f)
+	for _, m := range mounts {
+		if m.Type != "bind" {
+			continue
+		}
+		err = AddFileToInitrd(w, m.Source, m.Destination)
+		if err != nil {
+			return fmt.Errorf("Could not add file %s to initrd: %v", m.Source, err)
+		}
+	}
+	err = w.Close()
+	if err != nil {
+		return fmt.Errorf("Could not close initrd %v", err)
+	}
+
+	return nil
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/urunc-dev/urunc/pkg/network"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/hypervisors"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/initrd"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 	"github.com/vishvananda/netlink/nl"
@@ -337,6 +338,13 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		blockArgs, err = handleBlockBasedRootfs(rootfsParams, unikernelType, unikernelPath, uruncJSONFilename, initrdPath, u.Spec.Mounts)
 		if err != nil {
 			uniklog.Errorf("could not setup block based rootfs: %v", err)
+			return err
+		}
+	case "initrd":
+		initrdHostFullPath := filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path)
+		err = initrd.CopyFileMountsToInitrd(initrdHostFullPath, u.Spec.Mounts)
+		if err != nil {
+			uniklog.Errorf("could not update guest's initrd: %v", err)
 			return err
 		}
 	case "virtiofs":


### PR DESCRIPTION
The Linux kernel is able to properly read and unpack multiple initrds that are concatenated in a single file. This commit takes advantage of this feature and in the case the Linux guest is using initrd, it appends the files from the mount struct in the container's spec inside the given initrd.