### PR TITLE
docs: update nginx image reference in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ sudo apt install -y qemu-kvm
 Now we are ready to run nginx as a Unikraft unikernel using Docker and `urunc`:
 
 ```bash
-$ docker run --rm -d --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest
+$ docker run --rm -d --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest 
 67bec5ab9a748e35faf7c2079002177b9bdc806220e59b6b413836db1d6e4018
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,7 +60,7 @@ sudo apt install -y qemu-system
 Now we are ready to run Nginx as a Unikraft unikernel using [docker](https://docs.docker.com/engine/install/ubuntu/) and `urunc`:
 
 ```console
-$ docker run --rm -d --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest
+$ docker run --rm -d --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest
 67bec5ab9a748e35faf7c2079002177b9bdc806220e59b6b413836db1d6e4018
 ```
 


### PR DESCRIPTION
The current image harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest is built using an older version of bunny/urunc. This leads to errors when running nginx, as shown in the provided logs. Updating the docs removes the outdated reference and avoids confusion for users.

Fixes: #273