### PR TITLE
ci(deps): Update cosign

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -129,7 +129,7 @@ jobs:
           jq -r '.[0].Id')" >> $GITHUB_ENV
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # main
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # main (v3)
 
       - name: Sign the published Docker image
         env:
@@ -212,7 +212,7 @@ jobs:
           echo "manifest_sha=$VAR" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # main
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # main (v3)
 
       - name: Sign the published Docker image
         env:


### PR DESCRIPTION
It seems that cosign has moved to a new format by default (in v3.x) so this breaks the way harbor translates the signature. Until this is fixed, we can still use the updated cosign binary but we need to keep the old format:

https://github.com/goharbor/harbor/issues/22401#issuecomment-3385797174