### PR TITLE
feat (testing): Delete container and snapshot for ctr tests

### DIFF
--- a/tests/e2e/ctr.go
+++ b/tests/e2e/ctr.go
@@ -151,6 +151,11 @@ func (i *ctrInfo) rmContainer() error {
 	if err != nil {
 		return fmt.Errorf("Failed to remove %s: %v", i.containerID, err)
 	}
+	output, err = commonRmContainer(ctrName+" s", i.testArgs.Name)
+	err = checkExpectedOut("", output, err)
+	if err != nil {
+		return fmt.Errorf("Failed to remove snapshot %s: %v", i.testArgs.Name, err)
+	}
 	return nil
 }
 

--- a/tests/e2e/tests_skeleton.go
+++ b/tests/e2e/tests_skeleton.go
@@ -77,11 +77,11 @@ func runTest(tool testTool, t *testing.T) {
 		}
 		output, err := tool.runContainer(false)
 		if err != nil {
-			t.Fatalf("Failed to run unikernel container: %s -- %v", output, err)
+			t.Errorf("Failed to run unikernel container: %s -- %v", output, err)
 		}
 		tool.setContainerID(cntrArgs.Name)
 		if !strings.Contains(string(output), cntrArgs.ExpectOut) {
-			t.Fatalf("Expected: %s, Got: %s", cntrArgs.ExpectOut, output)
+			t.Errorf("Expected: %s, Got: %s", cntrArgs.ExpectOut, output)
 		}
 		err = testCleanup(tool)
 		if err != nil {


### PR DESCRIPTION
- Additionally delete snapshot in rmContainer().
- Make errors from runContainer() and from unexpected output non-fatal, so that testCleanup() is also called in the case when running the container fails. This way artifacts are cleaned up from the previous run.

Fixes: https://github.com/urunc-dev/urunc/issues/305