### PR TITLE
ci(timeout): Increase tests' timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ GO_FLAGS       := GOOS=linux
 CGO            := CGO_ENABLED=1
 NOCGO          := CGO_ENABLED=0
 TEST_FLAGS     := "-count=1"
-TEST_OPTS      += -timeout 8m
+TEST_OPTS      += -timeout 15m
 BUILD_TAGS     ?= netgo osusergo
 
 # Linking variables


### PR DESCRIPTION
Pending the implementation of #325 (setup step for e2e tests), we increase the timeout for tests, to make PR checks smoother