### PR TITLE
ci: Fix lint for PRs

### DIFF
--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:


### PR DESCRIPTION
We have missed checking out the correct SHA for the linting workflow. This patch makes sure that we run the lint tests on the correct version of the code.