### PR TITLE
add vAccel support to urunc

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -375,3 +375,6 @@ derr
 ldconfig
 vfsd
 crun
+vaccel
+VACCEL
+vsock

--- a/docs/tutorials/Running-vaccel-with-urunc.md
+++ b/docs/tutorials/Running-vaccel-with-urunc.md
@@ -1,0 +1,125 @@
+# Running vAccel-enabled Containers with `urunc`
+In this tutorial, we describe how to run vAccel-enabled Linux containers 
+with `urunc` using **QEMU** or **Firecracker** as the underlying
+hypervisor.
+
+## **QEMU**
+When running under QEMU, communication between the guest and the host agent is established 
+using vsock. The RPC agent listens on a vsock address on the host, and the guest connects to 
+it using the same address.
+
+### Host side
+Start the vAccel RPC agent on the host and configure it to listen on a vsock address:
+```bash
+export VACCEL_PLUGINS=libvaccel-noop.so
+export VACCEL_LOG_LEVEL=4
+vaccel-rpc-agent -a vsock://2:2049
+```
+This spawns the RPC agent and makes it available to guests via vsock port `2049`.
+
+### Guest side
+Run the container image with the appropriate runtime annotations:
+```bash 
+sudo docker run --runtime io.containerd.urunc.v2 --rm -it --annotation com.urunc.unikernel.vAccel="vsock" --annotation com.urunc.unikernel.RPCAddress="vsock://2:2049" --pull always harbor.nbfc.io/nubificus/ubuntu-vaccel-urunc-qemu:x86_64
+```
+Inside the container, execute an example vAccel workload:
+```bash 
+classify /usr/share/vaccel/images/example.jpg 1
+```
+
+### Expected output
+```bash
+2025.12.11-15:02:16.45 - <info> vAccel 0.7.1-51-499fc2f7
+2025.12.11-15:02:16.50 - <info> Registered plugin rpc 0.2.1-10-3d4d748c
+Initialized session with id: 1
+classification tags: This is a dummy classification tag!
+classification imagename: This is a dummy imgname!
+```
+If you rerun the command with a higher log level:
+```bash
+export VACCEL_LOG_LEVEL=4
+classify /usr/share/vaccel/images/example.jpg 1
+```
+The expected output is:
+```bash
+2025.12.11-15:03:04.72 - <debug> Initializing vAccel
+2025.12.11-15:03:04.72 - <info> vAccel 0.7.1-51-499fc2f7
+2025.12.11-15:03:04.72 - <debug> Config:
+2025.12.11-15:03:04.72 - <debug>   plugins = libvaccel-rpc.so
+2025.12.11-15:03:04.72 - <debug>   log_level = debug
+2025.12.11-15:03:04.72 - <debug>   log_file = (null)
+2025.12.11-15:03:04.72 - <debug>   profiling_enabled = false
+2025.12.11-15:03:04.72 - <debug>   version_ignore = false
+2025.12.11-15:03:04.74 - <debug> Created top-level rundir: /run/user/0/vaccel/oMcLeO
+2025.12.11-15:03:04.75 - <info> Registered plugin rpc 0.2.1-10-3d4d748c
+2025.12.11-15:03:04.76 - <debug> rpc is a VirtIO module
+2025.12.11-15:03:04.76 - <debug> Registered op exec from plugin rpc
+2025.12.11-15:03:04.77 - <debug> Registered op exec_with_resource from plugin rpc
+2025.12.11-15:03:04.77 - <debug> Registered op image_classify from plugin rpc
+2025.12.11-15:03:04.77 - <debug> Registered op image_detect from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op image_segment from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op image_depth from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op image_pose from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op tflite_model_load from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op tflite_model_unload from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op tflite_model_run from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op torch_model_load from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op torch_model_run from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op blas_sgemm from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op fpga_arraycopy from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op fpga_mmult from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op fpga_parallel from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op fpga_vectoradd from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op minmax from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op opencv from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op tf_model_load from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op tf_model_unload from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Registered op tf_model_run from plugin rpc
+2025.12.11-15:03:04.78 - <debug> Loaded plugin rpc from libvaccel-rpc.so
+2025.12.11-15:03:04.79 - <debug> [rpc] Initializing new remote session
+2025.12.11-15:03:04.86 - <debug> [rpc] Initialized remote session 2
+2025.12.11-15:03:04.86 - <debug> New rundir for session 1: /run/user/0/vaccel/oMcLe1
+2025.12.11-15:03:04.87 - <debug> Initialized session 1 with plugin rpc (remote id: )
+Initialized session with id: 1
+2025.12.11-15:03:04.88 - <debug> session:1 Looking for func implementing op image_cy
+2025.12.11-15:03:04.88 - <debug> Returning func for op image_classify from plugin rc
+2025.12.11-15:03:04.89 - <debug> [rpc] session:2 Executing op image_classify
+classification tags: This is a dummy classification tag!
+classification imagename: This is a dummy imgname!
+2025.12.11-15:03:04.90 - <debug> [rpc] Releasing remote session 2
+2025.12.11-15:03:04.91 - <debug> Released session 1
+2025.12.11-15:03:04.91 - <debug> Cleaning up vAccel
+2025.12.11-15:03:04.91 - <debug> Cleaning up sessions
+2025.12.11-15:03:04.92 - <debug> Cleaning up resources
+2025.12.11-15:03:04.92 - <debug> Cleaning up plugins
+2025.12.11-15:03:04.93 - <debug> Unregistered plugin rpc
+```
+## **Firecracker**
+For Firecracker, the guest still uses vsock, but the host-side agent listens on a unix 
+socket instead. urunc automatically translates the unix socket address into a vsock 
+address and bind-mounts the socket path into the guest.
+
+### Host side
+Start the RPC agent using a unix socket:
+```bash
+export VACCEL_PLUGINS=libvaccel-noop.so
+export VACCEL_LOG_LEVEL=4
+sudo mkdir /vaccel  # if does not exist
+sudo chown <user> /vaccel
+vaccel-rpc-agent -a unix:///vaccel/vaccel.sock_2049
+```
+The socket directory must be accessible so it can be bind-mounted into the guest.
+
+### Guest side
+Run the container using `nerdctl` and the `devmapper` snapshotter:
+```bash 
+sudo nerdctl run --runtime io.containerd.urunc.v2 --rm -it --snapshotter devmapper --annotation com.urunc.unikernel.vAccel="vsock" --annotation com.urunc.unikernel.RPCAddress="unix:///vaccel/vaccel.sock_2049" --pull always harbor.nbfc.io/nubificus/ubuntu-vaccel-urunc-fc:x86_64
+```
+
+Run the same example workload:
+```bash
+classify /usr/share/vaccel/images/example.jpg 1
+```
+
+### Expected output
+The expected output is identical to the QEMU execution.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -6,3 +6,4 @@ In this section we include some end-to-end tutorials on deploying
 - [Knative integration](../tutorials/knative)
 - [Non root monitor execution](../tutorials/Non-root-monitor-execution)
 - [Running existing containers over Linux](../tutorials/existing-container-linux)
+- [Running vAccel-enabled Containers with `urunc`](../tutorials/Running-vaccel-with-urunc.md)

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -130,6 +130,11 @@ func (q *Qemu) Execve(args types.ExecArgs, ukernel types.Unikernel) error {
 		cmdString += " -initrd " + extraMonArgs.ExtraInitrd
 	}
 	cmdString += extraMonArgs.OtherArgs
+
+	if args.VAccelType == "vsock" {
+		cmdString += " -device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=" + fmt.Sprintf("%d", args.VSockDevID)
+	}
+
 	exArgs := strings.Split(cmdString, " ")
 	exArgs = append(exArgs, "-append", args.Command)
 	vmmLog.WithField("qemu command", exArgs).Debug("Ready to execve qemu")

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -91,6 +91,9 @@ type ExecArgs struct {
 	VCPUs         uint     // The number of vCPUs to allocate
 	UnikernelPath string   // The path of the unikernel inside rootfs
 	InitrdPath    string   // The path to the initrd of the unikernel
+	VAccelType    string   // Specifies the vAccel acceleration type(e.g. vsock). When empty, vAccel is disabled
+	VSockDevPath  string   // The host directory where the fc unix socket is created
+	VSockDevID    int      // The guest-cid
 	Net           NetDevParams
 	Sharedfs      SharedfsParams
 }

--- a/pkg/unikontainers/vaccel.go
+++ b/pkg/unikontainers/vaccel.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikontainers
+
+import (
+	"fmt"
+	"regexp"
+
+	"golang.org/x/sys/unix"
+)
+
+// idToGuestCID generates a deterministic guest CID (Context Identifier)
+// for vsock communication based on a container or VM ID.
+func idToGuestCID(id string) int {
+	sum := 0
+	for _, c := range id {
+		sum += int(c)
+	}
+	const minVal = 3
+	const maxVal = 99
+	const valRange = maxVal - minVal + 1
+	val := (sum % valRange) + minVal
+
+	return val
+}
+
+// isValidVSockAddress validates a vsock address string and ensures
+// it matches the expected format for the selected hypervisor.
+// For firecracker, it also replaces the RPC address with the
+// corresponding vsock address, and returns the directory path of the
+// unix socket, which must later be bind-mounted into the guest rootfs.
+func isValidVSockAddress(rpcAddress *string, hypervisor string) (bool, string, error) {
+	var regex *regexp.Regexp
+
+	switch hypervisor {
+	case "qemu":
+		regex = regexp.MustCompile(`^vsock://2:\d+$`)
+	case "firecracker":
+		regex = regexp.MustCompile(`^unix://(.*)/vaccel\.sock_(\d+)$`)
+	default:
+		return false, "", fmt.Errorf("unsupported hypervisor: %q", hypervisor)
+	}
+
+	if regex.MatchString(*rpcAddress) {
+		if hypervisor == "firecracker" {
+			matches := regex.FindStringSubmatch(*rpcAddress)
+			if matches == nil {
+				return false, "", fmt.Errorf("failed to parse rpc address %q for %s", *rpcAddress, hypervisor)
+			}
+
+			*rpcAddress = "vsock://2:" + matches[2]
+			return true, matches[1], nil
+		}
+		return true, "", nil
+	}
+	return false, "", fmt.Errorf("rpc address %q does not match the expected format for %s", *rpcAddress, hypervisor)
+}
+
+// resolveVAccelConfig parses and validates vAccel-related annotations,
+// resolves the RPC address based on the selected hypervisor,
+// and returns the vAccel type (e.g., "vsock"), the unix socket path to be
+// bind-mounted (Firecracker only) and the normalized RPC address to be
+// exported to the guest.
+func resolveVAccelConfig(hypervisor string, annotations map[string]string) (string, string, string, error) {
+	var err error
+	var success bool
+	var vsockSocketPath string
+
+	address := annotations["com.urunc.unikernel.RPCAddress"]
+
+	vAccelType, exists := annotations["com.urunc.unikernel.vAccel"]
+	if exists {
+		if address == "" {
+			err = fmt.Errorf("vaccel is enabled, but rpc address is not set")
+			return vAccelType, "", "", err
+		}
+	} else {
+		err = fmt.Errorf("vaccel is disabled")
+		return vAccelType, "", "", err
+	}
+
+	if vAccelType == "vsock" {
+		// validate address
+		success, vsockSocketPath, err = isValidVSockAddress(&address, hypervisor)
+		if !success {
+			return vAccelType, "", "", err
+		}
+	}
+
+	return vAccelType, vsockSocketPath, address, err
+}
+
+// prepareVSockEnvironment prepares all required vsock devices and mounts
+// for vAccel execution inside the guest. This includes /dev/vsock,
+// /dev/vhost-vsock, and (for Firecracker) binding the host unix socket.
+func prepareVSockEnvironment(monRootfs string, hypervisor string, vsockSocketPath string) error {
+	err := setupDev(monRootfs, "/dev/vsock")
+	if err != nil {
+		return err
+	}
+
+	err = setupDev(monRootfs, "/dev/vhost-vsock")
+	if err != nil {
+		return err
+	}
+
+	// bind mount the unix socket directory
+	if hypervisor == "firecracker" {
+		err = fileFromHost(monRootfs, vsockSocketPath, "", unix.MS_BIND|unix.MS_PRIVATE, false)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
The implementation configures vAccel during container startup, validates the RPC address according to the selected hypervisor (QEMU or Firecracker) and sets the required environment variables.

This feature has been tested on: linux + {qemu, firecracker} using vsock.

vAccel behavior is controlled through two runtime annotations:
* `vAccel` selects how the guest will contact the host agent (e.g. vsock).
* `RPCAddress` specifies the address used by the vAccel agent on the
  host.

## How to Test / Run
### **QEMU**

#### Host side
Spawn the agent:
```bash
export VACCEL_PLUGINS=libvaccel-noop.so
export VACCEL_LOG_LEVEL=4
vaccel-rpc-agent -a vsock://2:2049
```

#### Guest side
Run the container image:
```bash 
sudo docker run --runtime io.containerd.urunc.v2 --rm -it --annotation vAccel="vsock" --annotation RPCAddress="vsock://2:2049" --pull always harbor.nbfc.io/nubificus/ubuntu-vaccel-urunc-qemu:x86_64
# run an example
classify /usr/share/vaccel/images/example.jpg 1
```

Expected output:
```bash
2025.12.11-15:02:16.45 - <info> vAccel 0.7.1-51-499fc2f7
2025.12.11-15:02:16.50 - <info> Registered plugin rpc 0.2.1-10-3d4d748c
Initialized session with id: 1
classification tags: This is a dummy classification tag!
classification imagename: This is a dummy imgname!
```
When rerun with log level set to 4:
```bash
export VACCEL_LOG_LEVEL=4
classify /usr/share/vaccel/images/example.jpg 1
```
The expected output is:
```bash
2025.12.11-15:03:04.72 - <debug> Initializing vAccel
2025.12.11-15:03:04.72 - <info> vAccel 0.7.1-51-499fc2f7
2025.12.11-15:03:04.72 - <debug> Config:
2025.12.11-15:03:04.72 - <debug>   plugins = libvaccel-rpc.so
2025.12.11-15:03:04.72 - <debug>   log_level = debug
2025.12.11-15:03:04.72 - <debug>   log_file = (null)
2025.12.11-15:03:04.72 - <debug>   profiling_enabled = false
2025.12.11-15:03:04.72 - <debug>   version_ignore = false
2025.12.11-15:03:04.74 - <debug> Created top-level rundir: /run/user/0/vaccel/oMcLeO
2025.12.11-15:03:04.75 - <info> Registered plugin rpc 0.2.1-10-3d4d748c
2025.12.11-15:03:04.76 - <debug> rpc is a VirtIO module
2025.12.11-15:03:04.76 - <debug> Registered op exec from plugin rpc
2025.12.11-15:03:04.77 - <debug> Registered op exec_with_resource from plugin rpc
2025.12.11-15:03:04.77 - <debug> Registered op image_classify from plugin rpc
2025.12.11-15:03:04.77 - <debug> Registered op image_detect from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op image_segment from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op image_depth from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op image_pose from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op tflite_model_load from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op tflite_model_unload from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op tflite_model_run from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op torch_model_load from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op torch_model_run from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op blas_sgemm from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op fpga_arraycopy from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op fpga_mmult from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op fpga_parallel from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op fpga_vectoradd from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op minmax from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op opencv from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op tf_model_load from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op tf_model_unload from plugin rpc
2025.12.11-15:03:04.78 - <debug> Registered op tf_model_run from plugin rpc
2025.12.11-15:03:04.78 - <debug> Loaded plugin rpc from libvaccel-rpc.so
2025.12.11-15:03:04.79 - <debug> [rpc] Initializing new remote session
2025.12.11-15:03:04.86 - <debug> [rpc] Initialized remote session 2
2025.12.11-15:03:04.86 - <debug> New rundir for session 1: /run/user/0/vaccel/oMcLe1
2025.12.11-15:03:04.87 - <debug> Initialized session 1 with plugin rpc (remote id: )
Initialized session with id: 1
2025.12.11-15:03:04.88 - <debug> session:1 Looking for func implementing op image_cy
2025.12.11-15:03:04.88 - <debug> Returning func for op image_classify from plugin rc
2025.12.11-15:03:04.89 - <debug> [rpc] session:2 Executing op image_classify
classification tags: This is a dummy classification tag!
classification imagename: This is a dummy imgname!
2025.12.11-15:03:04.90 - <debug> [rpc] Releasing remote session 2
2025.12.11-15:03:04.91 - <debug> Released session 1
2025.12.11-15:03:04.91 - <debug> Cleaning up vAccel
2025.12.11-15:03:04.91 - <debug> Cleaning up sessions
2025.12.11-15:03:04.92 - <debug> Cleaning up resources
2025.12.11-15:03:04.92 - <debug> Cleaning up plugins
2025.12.11-15:03:04.93 - <debug> Unregistered plugin rpc
```
### **Firecracker**

#### Host side
Spawn the agent:
```bash
export VACCEL_PLUGINS=libvaccel-noop.so
export VACCEL_LOG_LEVEL=4
sudo mkdir /vaccel  # if does not exist
sudo chown <user> /vaccel
vaccel-rpc-agent -a unix:///vaccel/vaccel.sock_2049
```

#### Guest side
Run the container image:
```bash 
sudo nerdctl run --runtime io.containerd.urunc.v2 --rm -it --snapshotter devmapper --annotation vAccel="vsock" --annotation RPCAddress="unix:///vaccel/vaccel.sock_2049" --pull always harbor.nbfc.io/nubificus/ubuntu-vaccel-urunc-fc:x86_64

# run an example
classify /usr/share/vaccel/images/example.jpg 1
```
Expected output matches that of QEMU execution.