### PR TITLE
feat(config): pass rlimits to urunit via UCS

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -375,6 +375,7 @@ derr
 ldconfig
 vfsd
 crun
+Rlimits
 vaccel
 VACCEL
 vsock

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -60,11 +60,18 @@ type RootfsParams struct {
 	MonRootfs   string // The rootfs for the monitor process
 }
 
+type Rlimit struct {
+	Type string
+	Hard uint64
+	Soft uint64
+}
+
 // Specific to Linux
 type ProcessConfig struct {
 	UID     uint32 // The uid of the process inside the guest
 	GID     uint32 // The gid of the process inside the guest
 	WorkDir string // The workdir of the process inside the guest
+	Rlimits []Rlimit
 }
 
 // UnikernelParams holds the data required to build the unikernels commandline

--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -314,6 +314,15 @@ func (l *Linux) buildUrunitConfig() string {
 	sb.WriteString("WD:")
 	sb.WriteString(l.ProcConfig.WorkDir)
 	sb.WriteString("\n")
+	for _, limit := range l.ProcConfig.Rlimits {
+		sb.WriteString("RLIMIT:")
+		sb.WriteString(limit.Type)
+		sb.WriteString(":")
+		sb.WriteString(strconv.FormatUint(limit.Hard, 10))
+		sb.WriteString(":")
+		sb.WriteString(strconv.FormatUint(limit.Soft, 10))
+		sb.WriteString("\n")
+	}
 	sb.WriteString(lpcEndMarker)
 	sb.WriteString("\n")
 	sb.WriteString(blkStartMarker)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -280,6 +280,16 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		GID:     u.Spec.Process.User.GID,
 		WorkDir: u.Spec.Process.Cwd,
 	}
+
+	if u.Spec.Process.Rlimits != nil {
+		for _, rl := range u.Spec.Process.Rlimits {
+			procAttrs.Rlimits = append(procAttrs.Rlimits, types.Rlimit{
+				Type: rl.Type,
+				Hard: rl.Hard,
+				Soft: rl.Soft,
+			})
+		}
+	}
 	// UnikernelParams
 	// populate unikernel params
 	unikernelParams := types.UnikernelParams{


### PR DESCRIPTION
feat(unikernels): pass rlimits to urunit via UCS

This adds support for passing rlimits from the OCI spec to the 
guest VM by appending them to the UCS configuration block.

Fixes #312 