### PR TITLE
fix(firecracker): do not add network config if no net device exists

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -72,7 +72,7 @@ type FirecrackerConfig struct {
 	Source  FirecrackerBootSource `json:"boot-source"`
 	Machine FirecrackerMachine    `json:"machine-config"`
 	Drives  []FirecrackerDrive    `json:"drives"`
-	NetIfs  []FirecrackerNet      `json:"network-interfaces"`
+	NetIfs  []FirecrackerNet      `json:"network-interfaces,omitempty"`
 	VSock   FirecrackerVSockDev   `json:"vsock,omitempty"`
 }
 
@@ -139,12 +139,14 @@ func (fc *Firecracker) Execve(args types.ExecArgs, ukernel types.Unikernel) erro
 
 	// Net config for Firecracker
 	FCNet := make([]FirecrackerNet, 0)
-	AnIF := FirecrackerNet{
-		IfaceID:  "net1",
-		GuestMAC: args.Net.MAC,
-		HostIF:   args.Net.TapDev,
+	if args.Net.TapDev != "" {
+		AnIF := FirecrackerNet{
+			IfaceID:  "net1",
+			GuestMAC: args.Net.MAC,
+			HostIF:   args.Net.TapDev,
+		}
+		FCNet = append(FCNet, AnIF)
 	}
-	FCNet = append(FCNet, AnIF)
 
 	// Block config for Firecracker
 	// TODO: Add support for block devices in FIrecracker

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -406,7 +406,7 @@ func prepareMonRootfs(monRootfs string, monitorPath string, monitorDataPath stri
 		return err
 	}
 
-	if needsTAP || monitorName == "firecracker" {
+	if needsTAP {
 		err = setupDev(monRootfs, "/dev/net/tun")
 		if err != nil {
 			return err


### PR DESCRIPTION
fix(firecracker): do not add network config if no net device exists

Previously, the Firecracker configuration always included a network
interface entry, regardless of whether a network device was actually
assigned to the container. This caused Firecracker to attempt to open
a TUN/TAP device.

When running urunc with a non-root user (e.g., via `ctr run --user`),
this operation failed with "Operation not permitted," preventing the
VM from booting even for containers that did not require networking.

This patch modifies the configuration generation to only append the
network interface section if a valid TAP device is present in the
execution arguments.

Fixes: #310 