### PR TITLE
fix(ipc): Handle unsuccessful setup for monitor environment

### DIFF
--- a/pkg/unikontainers/ipc_test.go
+++ b/pkg/unikontainers/ipc_test.go
@@ -141,11 +141,11 @@ func TestSendIPCMessageWithRetry(t *testing.T) {
 func TestCreateListener(t *testing.T) {
 	socketAddress := "/tmp/test_create_listener.sock"
 
-	listener, cleaner, err := CreateListener(socketAddress, true)
+	listener, err := createListener(socketAddress, true)
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
-	defer cleaner()
+	defer listener.Close()
 
 	assert.NotNil(t, listener, "Expected listener to be created")
 }
@@ -154,11 +154,11 @@ func TestAwaitMessage(t *testing.T) {
 	socketAddress := "/tmp/test_await_message.sock"
 	expectedMessage := ReexecStarted
 
-	listener, cleaner, err := CreateListener(socketAddress, true)
+	listener, err := createListener(socketAddress, true)
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
-	defer cleaner()
+	defer listener.Close()
 
 	go func() {
 		conn, err := net.Dial("unix", socketAddress)

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -172,7 +172,7 @@ func (rs *rootfsSelector) tryContainerRootfs() (types.RootfsParams, bool) {
 		return result, true
 	}
 
-	uniklog.Error("can not use the container rootfs as block, or through shared-fs")
+	uniklog.Error("can not use the container rootfs as the sandbox's guest rootfs through block or shared-fs")
 	return types.RootfsParams{}, false
 }
 
@@ -225,7 +225,7 @@ func chooseRootfs(bundle string, cntrRootfs string, annot map[string]string,
 	}
 
 	if selector.shouldMountContainerRootfs() {
-		return types.RootfsParams{}, fmt.Errorf("can not mount container's rootfs as block or through shared-fs to guest")
+		return types.RootfsParams{}, fmt.Errorf("can not use the container rootfs as the sandbox's guest rootfs through block or shared-fs")
 	}
 
 	uniklog.Info("no rootfs configured for guest")


### PR DESCRIPTION
In case there was an error during the monitor execution environment setup (e.g. vmm not found, rootfs issue) then the urunc start command was keep waiting for a message from reexec that everything was ok. This was leading to the urunc start process hanging there forever and of course the container was staying like that.

THis commit fixes this issue and moreover it slightly refactors the whole IPC between the urunc instances and reexec.