### PR TITLE
chore(ci): Revert artifact name to static

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,11 +91,11 @@ jobs:
     - name: Upload urunc_${{ matrix.arch }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: urunc_${{ matrix.arch }}-${{ github.run_id }}
+        name: urunc_static_${{ matrix.arch }}-${{ github.run_id }}
         path: dist/urunc_static_${{ matrix.arch }}
     
     - name: Upload containerd-shim-urunc-v2 artifact
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: containerd-shim-urunc-v2_${{ matrix.arch }}-${{ github.run_id }}
+        name: containerd-shim-urunc-v2_static_${{ matrix.arch }}-${{ github.run_id }}
         path: dist/containerd-shim-urunc-v2_static_${{ matrix.arch }}

--- a/.github/workflows/kind_test.yml
+++ b/.github/workflows/kind_test.yml
@@ -127,13 +127,13 @@ jobs:
     - name: Download urunc artifact
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
-        name: urunc_${{ matrix.arch }}-${{ github.run_id }}
+        name: urunc_static_${{ matrix.arch }}-${{ github.run_id }}
         path: ./artifacts
 
     - name: Download containerd-shim artifact
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
-        name: containerd-shim-urunc-v2_${{ matrix.arch }}-${{ github.run_id }}
+        name: containerd-shim-urunc-v2_static_${{ matrix.arch }}-${{ github.run_id }}
         path: ./artifacts    
     
     - name: List artifacts dir

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -75,13 +75,13 @@ jobs:
     - name: Download urunc artifact
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
-        name: urunc_${{ matrix.arch }}-${{ github.run_id }}
+        name: urunc_static_${{ matrix.arch }}-${{ github.run_id }}
         path: ./
 
     - name: Download containerd-shim-urunc-v2 artifact
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
-        name: containerd-shim-urunc-v2_${{ matrix.arch }}-${{ github.run_id }}
+        name: containerd-shim-urunc-v2_static_${{ matrix.arch }}-${{ github.run_id }}
         path: ./
 
     - name: Upload urunc to S3

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -236,13 +236,13 @@ jobs:
     - name: Download urunc artifact
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
-        name: urunc_${{ matrix.arch }}-${{ github.run_id }}
+        name: urunc_static_${{ matrix.arch }}-${{ github.run_id }}
         path: ./
 
     - name: Download containerd-shim-urunc-v2 artifact
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
-        name: containerd-shim-urunc-v2_${{ matrix.arch }}-${{ github.run_id }}
+        name: containerd-shim-urunc-v2_static_${{ matrix.arch }}-${{ github.run_id }}
         path: ./
 
     - name: Install urunc


### PR DESCRIPTION
To facilitate the release we revert the artifact name to include `static`.