### PR TITLE
Enable urunc debug logging in CI 

### DIFF
--- a/.github/workflows/kind_test.yml
+++ b/.github/workflows/kind_test.yml
@@ -160,6 +160,17 @@ jobs:
           /usr/local/bin/urunc --version
         '
 
+    - name: Configure urunc with debug logging
+      run: |
+        docker exec urunc-test-control-plane bash -c '
+          mkdir -p /etc/urunc
+          cat > /etc/urunc/config.toml <<EOF
+        [log]
+        level = "debug"
+        syslog = true
+        EOF
+        '
+
     - name: Install QEMU inside kind node (amd64 only)
       if: matrix.arch == 'amd64'
       run: |
@@ -340,4 +351,6 @@ jobs:
           echo "=== Logs ==="
           kubectl logs hello-spt-rumprun-block || true
         fi
-        
+        echo "=== urunc debug logs ==="
+        docker exec urunc-test-control-plane journalctl --identifier=urunc --no-pager || true
+

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -253,7 +253,16 @@ jobs:
         sudo mv urunc_static_${{ matrix.arch }} /usr/local/bin/urunc
         sudo mv containerd-shim-urunc-v2_static_${{ matrix.arch }} /usr/local/bin/containerd-shim-urunc-v2
         urunc --version
-  
+
+    - name: Configure urunc with debug logging
+      run: |
+        sudo mkdir -p /etc/urunc
+        sudo tee /etc/urunc/config.toml > /dev/null <<'EOF'
+        [log]
+        level = "debug"
+        syslog = true
+        EOF
+
     - name: Add runner user to KVM group
       if: ${{ matrix.arch == 'amd64' }}
       id: kvm-setup
@@ -287,3 +296,9 @@ jobs:
         else
           sudo -E env "PATH=$PATH" "GOROOT=$GOROOT" make ${{ matrix.test }}
         fi
+
+    - name: Dump urunc logs on failure
+      if: failure()
+      run: |
+        echo "=== urunc debug logs ==="
+        sudo journalctl --identifier=urunc --no-pager


### PR DESCRIPTION
Enable urunc debug logging in CI and dump logs on test failure for easier debugging.

Fixes #206