### PR TITLE
fix:add container veth discovery to replace hardcoded eth0

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -44,3 +44,6 @@ users:
   IrvingMg:
     name: Irving Mondragón
     email: mirvingr@gmail.com
+  sidneychang:
+    name: Xuedong Zhang
+    email: 2190206983@qq.com


### PR DESCRIPTION
- Add `discoverContainerIface` in `pkg/network/network.go` to discover the container-side veth endpoint by scanning links in the current netns.
- Replace places that relied on the hardcoded `DefaultInterface` with the discovered link.

This implements interface discovery instead of assuming `eth0`, improving compatibility across different runtimes/CNIs.

Fixes #14