### PR TITLE
Fix: Add nil checks for Linux spec fields in Exec()

### DIFF
--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -260,7 +260,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// ExecArgs
 	// If memory limit is set in spec, use it instead of the config default value
-	if u.Spec.Linux.Resources.Memory != nil {
+	if u.Spec.Linux != nil && u.Spec.Linux.Resources != nil && u.Spec.Linux.Resources.Memory != nil {
 		if u.Spec.Linux.Resources.Memory.Limit != nil {
 			if *u.Spec.Linux.Resources.Memory.Limit > 0 {
 				vmmArgs.MemSizeB = uint64(*u.Spec.Linux.Resources.Memory.Limit) // nolint:gosec
@@ -270,7 +270,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// ExecArgs
 	// Check if container is set to unconfined -- disable seccomp
-	if u.Spec.Linux.Seccomp == nil {
+	if u.Spec.Linux == nil || u.Spec.Linux.Seccomp == nil {
 		uniklog.Warn("Seccomp is disabled")
 		vmmArgs.Seccomp = false
 	}


### PR DESCRIPTION
### Summary

This PR fixes a nil pointer dereference in Exec() that can occur when the OCI spec does not include
linux.resources, which is valid when containers are started without explicit resource limits.

The current implementation assumes that Spec.Linux and Spec.Linux.Resources are always present
when checking memory limits and seccomp configuration. When these fields are omitted from the OCI
spec, the runtime panics during container startup.

This change adds defensive checks to ensure optional OCI fields are handled safely while preserving
the existing behavior for memory and seccomp configuration.

---

### Root Cause

The OCI runtime specification defines both linux and linux.resources as optional fields.
Containerd and Kubernetes only populate linux.resources when resource limits are explicitly
configured.

However, Exec() accessed the following fields without verifying parent objects were non-nil:
	•	Spec.Linux.Resources.Memory
	•	Spec.Linux.Seccomp

When containers are started without memory limits, Spec.Linux or Spec.Linux.Resources may be nil,
causing a nil pointer dereference during execution.

---

### Steps to Reproduce
	1.	Configure urunc as a runtime handler in containerd or Kubernetes.
	2.	Start a container or pod without specifying memory limits:
	         • No resources.limits.memory in pod spec, or
	         • No --memory flag when using ctr run.
	3.	Containerd generates an OCI spec where linux.resources is omitted.
	4.	urunc enters Exec() and attempts to access Spec.Linux.Resources.Memory.
	5.	The runtime panics and the container fails to start.

---

### Fix Applied

Defensive nil checks were added before accessing optional OCI fields:
	•	Verify Spec.Linux is non-nil
	•	Verify Spec.Linux.Resources is non-nil before checking memory limits
	•	Handle the case where Spec.Linux is nil when evaluating seccomp configuration

Execution flow remains unchanged:
	•	Memory limits from the OCI spec are used when present
	•	Otherwise, default memory configuration from runtime config is applied

---

### Impact
	•	Prevents runtime panics during container startup
	•	Allows containers without explicit resource limits to run successfully
	•	Improves stability for common Kubernetes and containerd workloads
	•	No change to intended runtime behavior or configuration handling

---

### Testing
	•	Verified code paths for OCI specs with and without linux.resources
	•	Change is limited to defensive checks and does not modify execution logic
