### PR TITLE
fix: verify VMM startup before reporting container as running

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -56,3 +56,6 @@ users:
   ilp-sys:
     name: Jiwoo Ahn
     email: ikwydls1314@gmail.com
+  goyalpalak18:
+    name: Palak Goyal
+    email: goyalpalak1806@gmail.com

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -13,6 +13,7 @@ Debugf
 Devmapper
 Dockerfiles
 EUID
+Exec
 Execve
 GOARCH
 GOFLAGS
@@ -97,6 +98,7 @@ Unikraft
 Unikraft's
 Urunc
 Urunc's
+VMM
 VNET
 Vcpu
 Virt
@@ -256,6 +258,7 @@ pluginid
 posixacl
 practises
 prctl
+prebuild
 privs
 prlimit
 pwait
@@ -303,6 +306,7 @@ subtest
 superfences
 sworker
 symfollow
+syscall
 syscalls
 systemcalls
 tgkill

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -50,7 +50,12 @@ func (h *Hedge) Path() string {
 	return ""
 }
 
-func (h *Hedge) Execve(_ types.ExecArgs, _ types.Unikernel) error {
+func (h *Hedge) BuildExecCmd(_ types.ExecArgs, _ types.Unikernel) ([]string, error) {
+	return nil, fmt.Errorf("hedge not implemented yet")
+}
+
+// PreExec performs pre-execution setup. Hedge is not fully implemented.
+func (h *Hedge) PreExec(_ types.ExecArgs) error {
 	return fmt.Errorf("hedge not implemented yet")
 }
 

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
@@ -55,7 +54,7 @@ func (q *Qemu) Path() string {
 	return q.binaryPath
 }
 
-func (q *Qemu) Execve(args types.ExecArgs, ukernel types.Unikernel) error {
+func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
 	qemuMem := BytesToStringMB(args.MemSizeB)
 	cmdString := q.binaryPath + " -m " + qemuMem + "M"
 	cmdString += " -L /usr/share/qemu"   // Set the path for qemu bios/data
@@ -137,6 +136,10 @@ func (q *Qemu) Execve(args types.ExecArgs, ukernel types.Unikernel) error {
 
 	exArgs := strings.Split(cmdString, " ")
 	exArgs = append(exArgs, "-append", args.Command)
-	vmmLog.WithField("qemu command", exArgs).Debug("Ready to execve qemu")
-	return syscall.Exec(q.Path(), exArgs, args.Environment) //nolint: gosec
+	return exArgs, nil
+}
+
+// PreExec performs pre-execution setup. QEMU has no special pre-exec requirements.
+func (q *Qemu) PreExec(_ types.ExecArgs) error {
+	return nil
 }

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -17,7 +17,6 @@ package hypervisors
 import (
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
@@ -60,7 +59,7 @@ func (s *SPT) Ok() error {
 	return nil
 }
 
-func (s *SPT) Execve(args types.ExecArgs, ukernel types.Unikernel) error {
+func (s *SPT) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
 	sptMem := BytesToStringMB(args.MemSizeB)
 	cmdString := s.binaryPath + " --mem=" + sptMem
 	if args.Net.TapDev != "" {
@@ -76,6 +75,10 @@ func (s *SPT) Execve(args types.ExecArgs, ukernel types.Unikernel) error {
 	cmdString = appendNonEmpty(cmdString, " ", extraMonArgs.OtherArgs)
 	cmdString += " " + args.UnikernelPath + " " + args.Command
 	cmdArgs := strings.Split(cmdString, " ")
-	vmmLog.WithField("spt command", cmdString).Debug("Ready to execve spt")
-	return syscall.Exec(s.binaryPath, cmdArgs, args.Environment) //nolint: gosec
+	return cmdArgs, nil
+}
+
+// PreExec performs pre-execution setup. SPT has no special pre-exec requirements.
+func (s *SPT) PreExec(_ types.ExecArgs) error {
+	return nil
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -25,7 +25,14 @@ type Unikernel interface {
 }
 
 type VMM interface {
-	Execve(args ExecArgs, ukernel Unikernel) error
+	// BuildExecCmd builds and validates the VMM command arguments without executing.
+	// This is used to verify the command can be built before reporting container as started.
+	// The returned slice contains the command path as the first element followed by arguments.
+	BuildExecCmd(args ExecArgs, ukernel Unikernel) ([]string, error)
+	// PreExec performs any monitor-specific setup that must happen after BuildExecCmd
+	// succeeds but before syscall.Exec is called. For example, HVT applies seccomp
+	// filters here. Most monitors can return nil (no-op).
+	PreExec(args ExecArgs) error
 	Stop(int) error
 	Path() string
 	UsesKVM() bool


### PR DESCRIPTION
### Description

I’ve fixed a critical race condition in our container lifecycle where we were telling the runtime (CRI) that the container had started successfully *before* we actually knew if the VMM was running.

Previously, we were using `syscall.Exec()` to replace the `urunc` process with the VMM. The problem with `exec` is that it doesn't return on success, so we were forced to send the **StartSuccess** signal optimistically before making the call. This meant that if the VMM failed to launch (missing binary, bad config, etc.), we ended up with a "zombie" state: Kubernetes thought the container was `Running`, but the process was actually dead.

To fix this, I refactored the startup logic to use a `fork+exec` pattern. My new flow looks like this:

1.  **Spawn**: I start the VMM as a child process using `exec.Command().Start()`.
2.  **Verify**: I wait a brief window (100ms) and then check if the process is still alive using `kill -0`.
3.  **Record**: I capture the *actual* child PID and save it to `state.json`.
4.  **Signal**: I only send `StartSuccess` once I've confirmed the VMM is up and running.
5.  **Detach**: Finally, I exit the reexec process, leaving the VMM correctly orphaned to the shim.
---
### Changes

- **`pkg/unikontainers/unikontainers.go`**:
    - Switched from `syscall.Exec` to `exec.Command().Start()`.
    - Added the liveness check (wait 100ms + `kill -0`) to catch immediate crashes.
    - Updated the logic to ensure we write the correct child PID to `state.json` before exiting.
- **`pkg/unikontainers/types/types.go`**:
    - I updated the `VMM` interface with a `BuildExecCmd` method. This lets us build the command arguments separately from executing them.
- **Hypervisor Implementations** (`qemu.go`, `firecracker.go`, `hvt.go`, `spt.go`):
    - I implemented `BuildExecCmd` for all our supported hypervisors.
    - *Side fix:* While I was in `firecracker.go`, I also fixed a swallowed `json.Marshal` error I noticed.
- **`pkg/unikontainers/hypervisors/hedge.go`**:
    - Added a stub for `BuildExecCmd` to keep the interface satisfied.
---
### Testing

I ran a few scenarios to confirm this behaves as expected:

- **Reproduction (The "Before" State)**: I intentionally configured `urunc` with a bad path to the QEMU binary. Before this fix, the pod would falsely report as `Running` with no logs and a bogus PID.
- **Verification (The Fix)**: using that same bad configuration, the pod now correctly fails to start. Kubernetes catches the error immediately (`CreateContainerError` / `CrashLoopBackOff`), which is exactly what we want.
- **Success Path**: I also verified that valid unikernels still boot up fine, network comes up, and the process handoff works correctly.
---
### Impact

- **No More Silent Failures**: If the VMM breaks, the user will actually see it fail now.
- **Better Observability**: Kubernetes will receive proper exit codes and error messages.
- **Accurate State**: The PID inside `state.json` is finally trustworthy.

---