### PR TITLE
fix: ensure network cleanup runs when VMM is already dead

### DIFF
--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -71,6 +71,10 @@ func killProcess(pid int) error {
 	const timeout = 2 * time.Second
 	err := syscall.Kill(pid, unix.SIGKILL)
 	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			// Process already dead, nothing to do
+			return nil
+		}
 		return err
 	}
 	deadline := time.Now().Add(timeout)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -555,18 +555,23 @@ func (u *Unikontainer) Kill() error {
 	if err != nil {
 		return err
 	}
-	err = vmm.Stop(u.State.Pid)
-	if err != nil {
-		return err
+	// Attempt to stop VMM process. If it's already dead, vmm.Stop() returns nil.
+	// We save any error but continue with network cleanup regardless.
+	stopErr := vmm.Stop(u.State.Pid)
+	if stopErr != nil {
+		uniklog.Warnf("vmm.Stop returned error (will continue with cleanup): %v", stopErr)
 	}
 
+	// Always clean up network resources, regardless of VMM state.
+	// The TAP device and TC rules exist independently of the VMM process.
 	// TODO: tap0_urunc should not be hardcoded
-	err = network.Cleanup("tap0_urunc")
-	if err != nil {
-		uniklog.Errorf("failed to delete tap0_urunc: %v", err)
+	cleanupErr := network.Cleanup("tap0_urunc")
+	if cleanupErr != nil {
+		uniklog.Errorf("failed to delete tap0_urunc: %v", cleanupErr)
 	}
 
-	return nil
+	// Return vmm.Stop error if any (network cleanup errors are logged but not fatal)
+	return stopErr
 }
 
 // Delete removes the containers base directory and its contents


### PR DESCRIPTION
### Description

I fixed a resource leak where network interfaces (TAP devices) and Traffic Control (TC) rules were being left behind if a VMM crashed or was killed externally.

The issue was a logic flaw in how we handled the `Kill()` command. Previously, the code tried to stop the VMM process first. If that failed—for example, if the process was already dead (returning `ESRCH`)—the function would return an error immediately and skip the `network.Cleanup()` step entirely.

This was causing serious issues in crash-loop scenarios (like an OOMing unikernel). Since the cleanup never ran, `tap0_urunc` devices and TC redirect filters kept piling up in the network namespace, eventually causing network blackholes and exhausting node resources.

### Changes

- **pkg/unikontainers/unikontainers.go**:
    - I decoupled the VMM stop operation from the network cleanup.
    - The code now guarantees that `network.Cleanup("tap0_urunc")` runs, even if `vmm.Stop()` returns an error. If the stop fails, I log a warning but still proceed to clean up the network resources before returning.

- **pkg/unikontainers/hypervisors/utils.go**:
    - I updated the `killProcess` function to handle `syscall.ESRCH` gracefully.
    - If we try to kill a process that is already dead, I now treat that as a success (returning `nil`) instead of an error. This makes the stop operation idempotent—if it's dead, my job is done.

### Testing

I verified this using a "zombie VMM" reproduction scenario:

1.  **Reproduction**:
    - I started a container, then manually killed the VMM process using `kill -9`.
    - I ran `urunc kill <container_id>`.
    - **Before**: The command failed with "no such process," and `ip link show` proved the TAP device was still there.
    - **After**: The command succeeded (silently handling the dead process), and I confirmed the TAP device was correctly removed.

2.  **Crash Loop**:
    - I simulated a Kubernetes crash loop and verified that after 10+ restarts, `tc filter show` showed zero orphaned rules.

### Impact

- **Stability**: This prevents network degradation in long-running clusters where pods might crash and restart frequently.
- **Resource Management**: We now ensure strict cleanup of kernel network objects regardless of whether the application crashed or stopped gracefully.
- **Correctness**: The kill command now accurately reflects that the resources are gone, rather than erroring out just because the process was already missing.

---