### PR TITLE
docs: Add LLM policy, PR template and update contribution guide

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -391,3 +391,4 @@ Liaskovitis
 Mallikopoulou
 Medfouni
 Khitem
+unreviewed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- Describe the changes and why they are needed. -->
+
+### Related issues
+
+<!-- Include links to relevant issues or other pages. -->
+
+- Fixes #
+
+### How was this tested?
+
+<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->
+
+### LLM usage
+
+<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->
+
+### Checklist
+
+- [ ] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
+- [ ] The linter passes locally (`make lint`).
+- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
+- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).

--- a/docs/developer-guide/contribute.md
+++ b/docs/developer-guide/contribute.md
@@ -4,10 +4,11 @@ title: "Contributing"
 description: "Contributing guidelines"
 ---
 
-Urunc is an open-source project licenced under the [Apache License 2.0](https://github.com/urunc-dev/urunc/blob/main/LICENSE).
-We welcome anyone who would be interested in contributing to `urunc`.
-As a first step, please take a look at the following document.
-The current document provides a high level overview of `urunc`'s code structure, along with a few guidelines regarding contributions to the project.
+Urunc is an open-source project licenced under the [Apache License
+2.0](https://github.com/urunc-dev/urunc/blob/main/LICENSE). We welcome anyone
+who would be interested in contributing to `urunc`. As a first step, please
+take a look at the following document and the [LLM
+policy](../developer-guide/llm-policy.md)).
 
 ## Table of contents:
 
@@ -33,19 +34,30 @@ Therefore, we expect any new documentation related files to be placed under `/do
 
 ## How to contribute
 
-There are plenty of ways to contribute to an open source project, even without changing or touching the code.
-Therefore, anyone who is interested in this project is very welcome to contribute in one of the following ways:
+There are plenty of ways to contribute to an open source project, even without
+changing or touching the code. Therefore, anyone who is interested in this
+project is very welcome to contribute in one of the following ways:
 
-1.  Using `urunc`. Try it out yourself and let us know your experience. Did everything work well? Were the instructions clear?
-2.  Improve or suggest changes to the documentation of the project. Documentation is very important for every project, hence any ideas on how to improve the documentation to make it more clear are more than welcome.
-3.  Request new features. Any proposals for improving or adding new features are very welcome.
-4.  Find a bug and report it. Bugs are everywhere and some are hidden very well. As a result, we would really appreciate it if someone found a bug and reported it to the maintainers.
-5.  Make changes to the code. Improve the code, add new functionalities and make `urunc` even more useful.
+- Using `urunc`. Try it out yourself and let us know your experience. Did
+  everything work well? Were the instructions clear?
+- Improve or suggest changes to the documentation of the project.
+  Documentation is very important for every project, hence any ideas on how to
+  improve the documentation to make it more clear are more than welcome.
+- Request new features. Any proposals for improving or adding new features are
+  very welcome.
+- Find a bug and report it. Bugs are everywhere and some are hidden very well.
+  As a result, we would really appreciate it if someone found a bug and
+  reported it to the maintainers.
+- Find an existing issue that interests you and try to resolve it. To get
+  started, simply express your interest in a comment, and the maintainers will
+  either assign the issue to you or ask for a proposal.
 
 ## Opening an issue
 
-We use Github issues to track bugs and requests for new features.
-Anyone is welcome to open a new issue, which is either related to a bug or a request for a new feature.
+We use Github issues to track bugs and requests for new features. Anyone is
+welcome to open a new issue, which is either related to a bug or a request for
+a new feature. Please make sure to read the [LLM
+policy](../developer-guide/llm-policy.md) in cases where an LLM has been used.
 
 ### Reporting bugs
 
@@ -91,14 +103,26 @@ However, we kindly ask you to mark the issue with the enhancement label and prov
 
 Anyone should feel free to submit a change or an addition to the codebase of `urunc`.
 Currently, we use Github's Pull Requests (PRs) to submit changes to `urunc`'s codebase.
-Before creating a new PR, please follow the guidelines below:
+Before creating a new PR, please follow the rules below:
 
+- Avoid opening PRs for non-existent issues. Please create an issue first.
+- Complete the PR template.
+- In case LLMs have been used, please read the [LLM
+  policy](../developer-guide/llm-policy.md).
+- Avoid changes unrelated to the PR/issue.
+- Test the changes locally.
 - Make sure that the changes do not break the building process of `urunc`.
 - Make sure that all the tests run successfully.
-- Make sure that no commit in a PR breaks the building process of `urunc`
+- Make sure that no commit in a PR breaks the building process of `urunc`.
 - Make sure to sign-off your commits.
+- Organize changes into logical commits. Each commit should represent a single,
+  specific change, avoiding both overly large and overly small commits.
 - Provide meaningful commit messages, describing shortly the changes.
-- Provide a meaningful PR message
+- Provide a meaningful PR message.
+
+The maintainers and andmins of the `urunc` project reserve the right to close
+PRs that do not comply with the above rules,with reference to this contribution
+guide.
 
 A new (draft) PR triggers the following process:
 

--- a/docs/developer-guide/llm-policy.md
+++ b/docs/developer-guide/llm-policy.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: "LLM policy"
+description: "LLM usage policy in urunc"
+---
+
+As a CNCF Sandbox project, `urunc` adheres to the [Linux Foundation Generative
+AI Policy](https://www.linuxfoundation.org/legal/generative-ai). All members of
+the `urunc` community are therefore expected to read and comply with the above
+policy. This document enhances the Linux Foundation policy specifically
+for the `urunc` project.
+
+Large Language Models (LLMs) are capable of analyzing and generating massive
+amounts of code in a very short period of time. While this can be beneficial,
+like many open source projects, `urunc` has experienced an increase in
+contributions that exhibit low quality and clear signs of unreviewed LLM usage.
+For that reason, the `urunc` project has decided to enforce some rules
+regarding the use of LLM in its development process:
+
+- LLM generated code must be treated in the same way as any other code.
+- The use of LLMs for any contributions must be disclosed, including the exact
+  model that was used.
+- The user of LLM takes full responsibility of the generated output.
+- All LLM-generated content must be reviewed by the contributor before opening
+  issues or PRs, ensuring correctness, quality, and relevance.
+- The use of LLMs to respond to comments in issues or PRs is not permitted.
+  Contributors are expected to express their own thoughts and ideas.  Acting as
+  a mediator between another user and an LLM is not helpful..
+- LLMs may assist in code review but can not replace human reviews. Human
+  reviewer guidance takes precedence over any LLM comments.
+
+The maintainers and admins of the `urunc` project reserve the right to
+close issues or PRs that do not comply with the above rules,
+with reference to this policy.
+
+## The rationale of the above rules
+
+The `urunc` project can significantly benefit from the responsible use of LLMs
+and this policy is not intended to prohibit their use. Instead, it aims to
+protect the project from the misuse of such tools. LLM outputs are
+probabilistic in nature and may introduce subtle bugs, outdated practices,
+security risks, or incorrect assumptions. As such, any code or technical
+contribution produced with the assistance of an LLMs must be carefully reviewed
+and tested. Responsibility for the correctness and quality of LLM-generated
+output lies solely with the contributor who uses the tool.
+
+Do not forget that behind the `urunc` project there are humans who aim to
+provide meaningful feedback and genuine assistance to the community.  However,
+an influx of low-quality contributions and bug reports significantly reduces
+their time and energy to properly review and assist other meaningful
+contributions.  Nevertheless, `urunc` is a unique and novel project with
+specific design choices and constraints that often require deeper explanation
+and discussion. As a result, LLMs may not produce helpful or accurate
+output for many `urunc`-specific use cases.
+
+With this in mind, it would be way more beneficial to engage in discussions
+with other people sharing genuine ideas, thoughts and concerns over an issue, PR
+or in the Slack channel. There is no need to consult LLMs for every
+interaction, on the contrary do not hesitate to ask other members. Let's help
+each other learn and share ideas to improve the project.


### PR DESCRIPTION
Lately, we encounter many contributions which are LLM-geenrated or assisted. Therefore, this commit aims to provide a policy regarding the use of LLMs in `urunc`. Overall, the use of LLMs is allowed. However, we want to make sure that the LLM users properly review and verify the generated output.

Due to this change, we also need to update the contribution guide.

Furthermore, we have created a PR template with a few questions that verify the contributors have read and followed the contribution guide.