### PR TITLE
feat: add configurable vhost option for monitors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ test: unittest e2etest
 
 ## unittest Run all unit tests
 .PHONY: unittest
-unittest: test_unikontainers test_metrics test_network
+unittest: test_unikontainers test_metrics test_network test_hypervisors
 
 ## e2etest Run all end-to-end tests
 .PHONY: e2etest
@@ -253,6 +253,12 @@ test_metrics:
 test_network:
 	@echo "Unit testing in pkg/network"
 	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/network -v
+	@echo " "
+
+## test_hypervisors Run unit tests for hypervisors package
+test_hypervisors:
+	@echo "Unit testing in hypervisors"
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/unikontainers/hypervisors -v
 	@echo " "
 
 ## test_nerdctl Run all end-to-end tests with nerdctl

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -30,6 +30,7 @@ const (
 type Qemu struct {
 	binaryPath string
 	binary     string
+	vhost      bool
 }
 
 func (q *Qemu) Stop(pid int) error {
@@ -94,6 +95,9 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 			netcli += args.Net.MAC
 			netcli += " -net tap,script=no,downscript=no,ifname="
 			netcli += args.Net.TapDev
+			if q.vhost {
+				netcli += ",vhost=on"
+			}
 		}
 		cmdString += netcli
 	} else {

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -32,25 +32,33 @@ var vmmLog = logrus.WithField("subsystem", "monitors")
 
 type VMMFactory struct {
 	binary     string
-	createFunc func(binary, binaryPath string) types.VMM
+	createFunc func(binary, binaryPath string, vhost bool) types.VMM
 }
 
 var vmmFactories = map[VmmType]VMMFactory{
 	SptVmm: {
-		binary:     SptBinary,
-		createFunc: func(binary, binaryPath string) types.VMM { return &SPT{binary: binary, binaryPath: binaryPath} },
+		binary: SptBinary,
+		createFunc: func(binary, binaryPath string, _ bool) types.VMM {
+			return &SPT{binary: binary, binaryPath: binaryPath}
+		},
 	},
 	HvtVmm: {
-		binary:     HvtBinary,
-		createFunc: func(binary, binaryPath string) types.VMM { return &HVT{binary: binary, binaryPath: binaryPath} },
+		binary: HvtBinary,
+		createFunc: func(binary, binaryPath string, _ bool) types.VMM {
+			return &HVT{binary: binary, binaryPath: binaryPath}
+		},
 	},
 	QemuVmm: {
-		binary:     QemuBinary,
-		createFunc: func(binary, binaryPath string) types.VMM { return &Qemu{binary: binary, binaryPath: binaryPath} },
+		binary: QemuBinary,
+		createFunc: func(binary, binaryPath string, vhost bool) types.VMM {
+			return &Qemu{binary: binary, binaryPath: binaryPath, vhost: vhost}
+		},
 	},
 	FirecrackerVmm: {
-		binary:     FirecrackerBinary,
-		createFunc: func(binary, binaryPath string) types.VMM { return &Firecracker{binary: binary, binaryPath: binaryPath} },
+		binary: FirecrackerBinary,
+		createFunc: func(binary, binaryPath string, _ bool) types.VMM {
+			return &Firecracker{binary: binary, binaryPath: binaryPath}
+		},
 	},
 }
 
@@ -80,7 +88,7 @@ func NewVMM(vmmType VmmType, monitors map[string]types.MonitorConfig) (vmm types
 		return nil, err
 	}
 
-	return factory.createFunc(factory.binary, vmmPath), nil
+	return factory.createFunc(factory.binary, vmmPath, monitors[string(vmmType)].Vhost), nil
 }
 
 func getVMMPath(vmmType VmmType, binary string, monitors map[string]types.MonitorConfig) (string, error) {

--- a/pkg/unikontainers/hypervisors/vmm_test.go
+++ b/pkg/unikontainers/hypervisors/vmm_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVMMFactoryQemuVhostFalse(t *testing.T) {
+	t.Parallel()
+	factory, exists := vmmFactories[QemuVmm]
+	assert.True(t, exists, "qemu factory should exist")
+
+	vmm := factory.createFunc(QemuBinary, "/usr/bin/qemu-system-x86_64", false)
+	qemu, ok := vmm.(*Qemu)
+	assert.True(t, ok, "factory should return *Qemu")
+	assert.False(t, qemu.vhost, "vhost should be false when passed as false")
+}
+
+func TestVMMFactoryQemuVhostTrue(t *testing.T) {
+	t.Parallel()
+	factory, exists := vmmFactories[QemuVmm]
+	assert.True(t, exists, "qemu factory should exist")
+
+	vmm := factory.createFunc(QemuBinary, "/usr/bin/qemu-system-x86_64", true)
+	qemu, ok := vmm.(*Qemu)
+	assert.True(t, ok, "factory should return *Qemu")
+	assert.True(t, qemu.vhost, "vhost should be true when passed as true")
+}
+
+func TestVMMFactoryNonQemuIgnoresVhost(t *testing.T) {
+	t.Parallel()
+
+	// SPT factory should ignore vhost parameter
+	factory, exists := vmmFactories[SptVmm]
+	assert.True(t, exists, "spt factory should exist")
+
+	vmm := factory.createFunc(SptBinary, "/usr/bin/solo5-spt", true)
+	_, ok := vmm.(*SPT)
+	assert.True(t, ok, "factory should return *SPT")
+
+	// HVT factory should ignore vhost parameter
+	factory, exists = vmmFactories[HvtVmm]
+	assert.True(t, exists, "hvt factory should exist")
+
+	vmm = factory.createFunc(HvtBinary, "/usr/bin/solo5-hvt", true)
+	_, ok = vmm.(*HVT)
+	assert.True(t, ok, "factory should return *HVT")
+
+	// Firecracker factory should ignore vhost parameter
+	factory, exists = vmmFactories[FirecrackerVmm]
+	assert.True(t, exists, "firecracker factory should exist")
+
+	vmm = factory.createFunc(FirecrackerBinary, "/usr/bin/firecracker", true)
+	_, ok = vmm.(*Firecracker)
+	assert.True(t, ok, "factory should return *Firecracker")
+}

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -131,4 +131,5 @@ type MonitorConfig struct {
 	DefaultVCPUs    uint   `toml:"default_vcpus"`
 	BinaryPath      string `toml:"path,omitempty"`      // Optional path to the hypervisor binary
 	DataPath        string `toml:"data_path,omitempty"` // Optional path to the hypervisor data files (e.g. qemu bios stuff)
+	Vhost           bool   `toml:"vhost,omitempty"`     // Optional: enable vhost for network performance optimization
 }

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -125,6 +125,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"default_vcpus"] = strconv.FormatUint(uint64(hvCfg.DefaultVCPUs), 10)
 		cfgMap[prefix+"binary_path"] = hvCfg.BinaryPath
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
+		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
 	}
 	for eb, ebCfg := range p.ExtraBins {
 		prefix := "urunc_config.extra_binaries." + eb + "."
@@ -171,6 +172,13 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 			hvCfg.BinaryPath = val
 		case "data_path":
 			hvCfg.DataPath = val
+		case "vhost":
+			boolVal, err := strconv.ParseBool(val)
+			if err != nil {
+				uniklog.Warnf("Invalid vhost value '%s' for monitor '%s': %v. Using default (false).", val, hv, err)
+			} else {
+				hvCfg.Vhost = boolVal
+			}
 		}
 		cfg.Monitors[hv] = hvCfg
 	}


### PR DESCRIPTION
## Description

This change adds a configurable `vhost` option to monitors.  
When enabled for QEMU, it allows the use of `vhost-net` to improve network performance.

## Related issues
- #410

## Fixes
- Fixes #410

## How was this tested?
- `make lint`
- `make test_ctr`

## LLM usage
Yes – LLMs were used for drafting code and clarifying implementation details.  
All changes were reviewed and verified manually.

## Checklist
- [x] I have read the contribution guide.
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`).
- [x] If LLMs were used: I have read the LLM policy.
