### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -53,3 +53,6 @@ users:
   ishaanxgupta:
     name: Ishaan Gupta
     email: ishaankone@gmail.com
+  ilp-sys:
+    name: Jiwoo Ahn
+    email: ikwydls1314@gmail.com

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and containerized environments, enabling seamless integration with cloud-native
 architectures. Designed to fully leverage the container semantics and benefits
 from the OCI tools and methodology, `urunc` aims to become “runc for
 unikernels”, while offering compatibility with the Container Runtime Interface
-(CRI). Unikernels are packaged inside OCI-compatible images and `urunc` launces
+(CRI). Unikernels are packaged inside OCI-compatible images and `urunc` launches
 the unikernel on top of the underlying Virtual Machine or seccomp monitors.
 Thus, developers and administrators can package, deliver, deploy and manage
 unikernels using familiar cloud-native practices.


### PR DESCRIPTION
Description
--- 
Found typo in README.md 
Modified "`urunc` launces" into "`urunc` launches"

Related issues
--- 
Documentation-only change


How was this tested?
--- 
Documentation-only change


LLM usage
--- 
None

Checklist
---
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (make lint).
- [x] The e2e tests of at least one tool pass locally (make test_ctr, make test_nerdctl, make test_docker, make test_crictl).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).