### PR TITLE
fix(ci): update golangci-lint-action to v6.3.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
           go-version: ${{ inputs.go_version }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@9710a1764f12a3f4a0f19124d8934b67b1f30f90 # v6.3.2
         with:
           version: v1.64
 


### PR DESCRIPTION
## Summary
This PR updates the golangci-lint-action from v3.7.0 to v6.3.2 to fix deprecation warnings and use the latest stable version.

## Changes
- Updated golangci/golangci-lint-action from v3.7.0 to v6.3.2 (latest stable)

## Related Issue
Fixes urunc-dev/urunc#219

## Testing
- [x] Verified action version is latest stable (v6.3.2)
- [x] Confirmed the action works with current golangci-lint version v1.64

## Checklist
- [x] Commit message follows conventional commits format
- [x] Signed-off-by included
- [x] Issue referenced in commit and PR description
- [x] Branch is up-to-date with main