### PR TITLE
fix: write runtime pidfile when provided

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -252,9 +252,10 @@ func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (
 
 	// Retrieve reexec cmd's pid and write to file and state
 	containerPid := reexecPid
+	pidFilePath := cmd.String("pid-file")
 	metrics.Capture(m.TS06)
 
-	err = unikontainer.Create(containerPid)
+	err = unikontainer.Create(containerPid, pidFilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -147,9 +147,14 @@ func (u *Unikontainer) InitialSetup() error {
 }
 
 // Create sets the Unikernel status as created,
-// and saves the given PID in init.pid
-func (u *Unikontainer) Create(pid int) error {
-	err := writePidFile(filepath.Join(u.State.Bundle, initPidFilename), pid)
+// and saves the given PID in the provided pid file path.
+// If pidFilePath is empty, it falls back to the default init.pid path.
+func (u *Unikontainer) Create(pid int, pidFilePath string) error {
+	path := filepath.Join(u.State.Bundle, initPidFilename)
+	if pidFilePath != "" {
+		path = pidFilePath
+	}
+	err := writePidFile(path, pid)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ensure the PID is written to the runtime-provided --pid-file after container creation. This allows supervisors like conmon to track and reap the container process correctly, preventing early cleanup or EOF failures. This change also ensures that Podman can reliably start urunc containers.


## Description

In the current code, there is a --pid-file flag, but in reality, we are not actually writing to the specified pid-file. This causes issues when starting urunc with Podman, preventing it from starting properly.

### Related issues

#114 

- Fixes #114

### How was this tested?


- Configure Podman to Use urunc
I tested using the method described in #114 and configured Podman to use urunc as the runtime. I executed the following command to modify the Podman container configuration:
```
sudo tee /etc/containers/containers.conf >/dev/null <<EOT
[engine]
runtime = "/usr/local/bin/urunc"
EOT
```

- Configure the QEMU Path for urunc
To ensure urunc can locate the QEMU binary, the QEMU path needs to be set in the config.toml file for urunc. The configuration should look like this:
```
[monitors.qemu]
path = "/usr/bin/qemu-system-x86_64"
```
Run urunc with Podman
After configuring the runtime and QEMU path, I attempted to run the urunc container using Podman:
```
podman run --rm -d harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest
```
result:
<img width="1516" height="292" alt="image" src="https://github.com/user-attachments/assets/75988751-5e39-466d-9498-290677ee8fee" />

### LLM usage

Using Codex to debug the cause of the issue#114

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
