### PR TITLE
Fix: QEMU terminal corruption

### DIFF
--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -61,7 +61,7 @@ func (q *Qemu) Execve(args types.ExecArgs, ukernel types.Unikernel) error {
 	cmdString += " -L /usr/share/qemu"   // Set the path for qemu bios/data
 	cmdString += " -cpu host"            // Choose CPU
 	cmdString += " -enable-kvm"          // Enable KVM to use CPU virt extensions
-	cmdString += " -nographic -vga none" // Disable graphic output
+	cmdString += " -nographic -vga none -nodefaults -serial stdio" // Disable graphic output and suppress BIOS control characters
 
 	if args.VCPUs > 0 {
 		cmdString += fmt.Sprintf(" -smp %d", args.VCPUs)

--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -190,7 +190,7 @@ func (l *Linux) MonitorCli() types.MonitorCliArgs {
 	switch l.Monitor {
 	case "qemu":
 		extraCliArgs := types.MonitorCliArgs{
-			OtherArgs: " -no-reboot -serial stdio -nodefaults",
+			OtherArgs: " -no-reboot",
 		}
 		if l.InitrdConf && l.RootFsType != "initrd" {
 			extraCliArgs.ExtraInitrd = urunitConfPath


### PR DESCRIPTION

## Description
This PR resolves the issue where the terminal display would become unusable when running QEMU-based containers. It updates the global QEMU configuration to properly handle console output, ensuring that startup signals no longer distort the terminal screen for any deployment type.

<!-- Describe the changes and why they are needed. -->

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #440 

### LLM usage
Used ChatGPT to find out how to suppress BIOS control characters
<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
