### PR TITLE
feat(delete): add --dry-run flag and safety guardrails

### DIFF
--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -44,6 +44,11 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 			Aliases: []string{"f"},
 			Usage:   "Forcibly deletes the container if it is still running (uses SIGKILL)",
 		},
+		&cli.BoolFlag{
+			Name:    "dry-run",
+			Aliases: []string{"n"},
+			Usage:   "Print what would be deleted without actually deleting",
+		},
 	},
 	Action: func(_ context.Context, cmd *cli.Command) error {
 		runtime.GOMAXPROCS(1)
@@ -53,16 +58,35 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 			return err
 		}
 
+		containerID := cmd.Args().First()
+		if containerID == "" {
+			return ErrEmptyContainerID
+		}
+
+		// Validate containerID for safety
+		if err := validateContainerID(containerID); err != nil {
+			return err
+		}
+
+		dryRun := cmd.Bool("dry-run")
+
 		// get Unikontainer data from state.json
 		unikontainer, err := getUnikontainer(cmd)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				containerID := cmd.Args().First()
-				if containerID == "" {
-					return ErrEmptyContainerID
-				}
 				rootDir := cmd.String("root")
 				containerDir := filepath.Join(rootDir, containerID)
+
+				// Validate the path is safe
+				if err := validateDeletionPath(containerDir, rootDir); err != nil {
+					return err
+				}
+
+				if dryRun {
+					logrus.Infof("would remove: %s", containerDir)
+					return nil
+				}
+
 				e := os.RemoveAll(containerDir)
 				if e != nil {
 					logrus.Errorf("remove %s: %v", containerDir, e)
@@ -73,6 +97,11 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 			}
 			return err
 		}
+
+		if dryRun {
+			return unikontainer.DryRunDelete()
+		}
+
 		if cmd.Bool("force") {
 			err := unikontainer.Kill()
 			if err != nil {

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -129,4 +131,87 @@ func fatalWithCode(err error, ret int) {
 		fmt.Fprintln(os.Stderr, err)
 	}
 	os.Exit(ret)
+}
+
+// Critical system paths that should never be deleted
+var criticalPaths = []string{
+	"/",
+	"/bin",
+	"/boot",
+	"/dev",
+	"/etc",
+	"/home",
+	"/lib",
+	"/lib64",
+	"/opt",
+	"/proc",
+	"/root",
+	"/sbin",
+	"/sys",
+	"/usr",
+	"/var",
+}
+
+// validateContainerID checks if the container ID is safe and doesn't contain path traversal
+func validateContainerID(containerID string) error {
+	// Check for empty ID
+	if containerID == "" {
+		return ErrEmptyContainerID
+	}
+
+	// Check for path traversal patterns
+	if strings.Contains(containerID, "..") {
+		return fmt.Errorf("container ID contains path traversal sequence (..): %s", containerID)
+	}
+
+	// Check for absolute paths
+	if filepath.IsAbs(containerID) {
+		return fmt.Errorf("container ID must not be an absolute path: %s", containerID)
+	}
+
+	// Check for directory separators (should be a simple name)
+	if strings.ContainsAny(containerID, "/\\") {
+		return fmt.Errorf("container ID must not contain path separators: %s", containerID)
+	}
+
+	return nil
+}
+
+// validateDeletionPath ensures a path is safe to delete
+func validateDeletionPath(targetPath, rootDir string) error {
+	// Clean and make absolute
+	targetPath = filepath.Clean(targetPath)
+	rootDir = filepath.Clean(rootDir)
+
+	// Ensure both are absolute paths
+	if !filepath.IsAbs(targetPath) {
+		return fmt.Errorf("target path must be absolute: %s", targetPath)
+	}
+	if !filepath.IsAbs(rootDir) {
+		return fmt.Errorf("root directory must be absolute: %s", rootDir)
+	}
+
+	// Check if target is within rootDir
+	relPath, err := filepath.Rel(rootDir, targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to compute relative path: %w", err)
+	}
+
+	// If relative path starts with "..", it's outside rootDir
+	if strings.HasPrefix(relPath, "..") {
+		return fmt.Errorf("target path %s is outside root directory %s", targetPath, rootDir)
+	}
+
+	// Check against critical system paths
+	for _, criticalPath := range criticalPaths {
+		if targetPath == criticalPath {
+			return fmt.Errorf("refusing to delete critical system path: %s", targetPath)
+		}
+		// Also check if target path is a parent of critical path
+		if strings.HasPrefix(criticalPath, targetPath+string(filepath.Separator)) {
+			return fmt.Errorf("target path %s contains critical system path %s", targetPath, criticalPath)
+		}
+	}
+
+	return nil
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -593,6 +593,14 @@ func (u *Unikontainer) Delete() error {
 	}
 	monRootfs := filepath.Join(bundleDir, monitorRootfsDirName)
 
+	// Validate bundle and rootfs paths are safe
+	if err := validatePathSafety(bundleDir); err != nil {
+		return fmt.Errorf("unsafe bundle path: %w", err)
+	}
+	if err := validatePathSafety(rootfsDir); err != nil {
+		return fmt.Errorf("unsafe rootfs path: %w", err)
+	}
+
 	// TODO: We might not need to remove any of the directories and let
 	// the kernel cleanup the mounts and shim to remove directories.
 	// However, just to be on the safe side, we remove all the newly
@@ -629,7 +637,77 @@ func (u *Unikontainer) Delete() error {
 		return err
 	}
 
+	// Validate BaseDir before deleting
+	if err := validatePathSafety(u.BaseDir); err != nil {
+		return fmt.Errorf("unsafe BaseDir path: %w", err)
+	}
+
 	return os.RemoveAll(u.BaseDir)
+}
+
+// DryRunDelete prints what would be deleted without actually deleting
+func (u *Unikontainer) DryRunDelete() error {
+	var dirs []string
+	var prefPath string
+
+	if u.isRunning() {
+		return fmt.Errorf("cannot delete running container: %s", u.State.ID)
+	}
+
+	// get a monitor instance of the running monitor
+	vmmType := u.State.Annotations[annotHypervisor]
+	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
+	if err != nil {
+		return err
+	}
+
+	// Make sure paths are clean
+	bundleDir := filepath.Clean(u.State.Bundle)
+	rootfsDir := filepath.Clean(u.Spec.Root.Path)
+	if !filepath.IsAbs(rootfsDir) {
+		rootfsDir = filepath.Join(bundleDir, rootfsDir)
+	}
+	monRootfs := filepath.Join(bundleDir, monitorRootfsDirName)
+
+	// Validate paths
+	if err := validatePathSafety(bundleDir); err != nil {
+		return fmt.Errorf("unsafe bundle path: %w", err)
+	}
+	if err := validatePathSafety(rootfsDir); err != nil {
+		return fmt.Errorf("unsafe rootfs path: %w", err)
+	}
+
+	_, err = os.Stat(monRootfs)
+	if !os.IsNotExist(err) {
+		dirs = append(dirs, monitorRootfsDirName)
+		prefPath = bundleDir
+	} else {
+		dirs = []string{
+			"/lib",
+			"/lib64",
+			"/usr",
+			"/proc",
+			"/dev",
+			"/tmp",
+		}
+		dirs = append(dirs, vmm.Path())
+		prefPath = rootfsDir
+	}
+
+	// Print what would be deleted
+	uniklog.Infof("Dry-run mode: would delete the following paths:")
+	for _, d := range dirs {
+		path := filepath.Join(prefPath, d)
+		uniklog.Infof("  would remove: %s", path)
+	}
+
+	// Validate BaseDir
+	if err := validatePathSafety(u.BaseDir); err != nil {
+		return fmt.Errorf("unsafe BaseDir path: %w", err)
+	}
+
+	uniklog.Infof("  would remove: %s", u.BaseDir)
+	return nil
 }
 
 // joinSandboxNetns joins the network namespace of the sandbox

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -375,3 +375,53 @@ func executeHook(hook specs.Hook, state []byte) error {
 
 	return nil
 }
+
+// Critical system paths that should never be deleted
+var criticalSystemPaths = []string{
+	"/",
+	"/bin",
+	"/boot",
+	"/dev",
+	"/etc",
+	"/home",
+	"/lib",
+	"/lib64",
+	"/opt",
+	"/proc",
+	"/root",
+	"/sbin",
+	"/sys",
+	"/usr",
+	"/var",
+}
+
+// validatePathSafety ensures a path is safe to delete
+func validatePathSafety(targetPath string) error {
+	// Clean the path
+	targetPath = filepath.Clean(targetPath)
+
+	// Check if path is empty or just "."
+	if targetPath == "" || targetPath == "." {
+		return fmt.Errorf("target path is empty or current directory")
+	}
+
+	// If path is not absolute, it's relative which could be problematic
+	// but we'll allow it since it's relative to the process working directory
+	if !filepath.IsAbs(targetPath) {
+		return fmt.Errorf("target path must be absolute: %s", targetPath)
+	}
+
+	// Check against critical system paths
+	for _, criticalPath := range criticalSystemPaths {
+		if targetPath == criticalPath {
+			return fmt.Errorf("refusing to delete critical system path: %s", targetPath)
+		}
+	}
+
+	// Check if target contains any critical paths (e.g., if rootfsDir becomes /)
+	if strings.HasPrefix(targetPath, "//") || targetPath == "/" {
+		return fmt.Errorf("refusing to delete root filesystem")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
This PR adds security hardening to the urunc delete command to prevent accidental deletion of host system paths and provides a dry-run mode for safe preview of operations.
### 1. Dry-Run Functionality
- Added --dry-run (-n) flag to preview what would be deleted without actually deleting
- Implemented DryRunDelete() method that shows all paths that would be removed
- Useful for debugging and verifying delete operations

### 2. Path Traversal Protection
- validateContainerID(): Prevents path traversal attacks via containerID
  - Blocks .. sequences
  - Blocks absolute paths
  - Blocks path separators
- Example: urunc delete ../../etc is now rejected

### 3. Path Safety Validation
- validateDeletionPath(): Ensures target paths stay within expected boundaries
  - Validates paths are within rootDir
  - Uses filepath.Rel() to detect escapes
- validatePathSafety(): Additional safety layer in unikontainers package
  - Checks against critical system path denylist
  - Prevents deletion of /, /usr, /etc, /lib, etc.

### Related issues
Fixes #423

### How was this tested?
- [X] Code review for logic correctness
- [X] Verified no compilation errors
- [X] Validated against existing code patterns
- [X] Checked error handling paths
- [X] Ensured backward compatibility
- [X] Confirmed validation functions work correctly

### LLM usage
GitHub Copilot assisted with code implementation

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).


collaborated with @hemang1404