### PR TITLE
fix(hooks): prevent panic from loop variable capture in concurrent execution

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -53,6 +53,9 @@ users:
   ishaanxgupta:
     name: Ishaan Gupta
     email: ishaankone@gmail.com
+  hemang1404:
+    name: Hemang Sharrma
+    email: hemangsharrma@gmail.com
   ilp-sys:
     name: Jiwoo Ahn
     email: ikwydls1314@gmail.com

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -777,8 +777,8 @@ func (u *Unikontainer) executeHooksConcurrently(name string, hooks []specs.Hook,
 				uniklog.WithFields(logrus.Fields{
 					"id":    u.State.ID,
 					"name":  name,
-					"path":  hooks[i].Path,
-					"args":  hooks[i].Args,
+					"path":  h.Path,
+					"args":  h.Args,
 					"error": err,
 				}).Error("Executing hook failed")
 				errChan <- err


### PR DESCRIPTION
## Description
This PR fixes a loop variable capture bug in executeHooksConcurrently() that could cause panics and incorrect logging when hooks are executed concurrently.
Panic Prevention: Eliminates panic when i == len(hooks) after loop completes

### Related issues
- Fixes #418

### How was this tested?
Confirmed the captured parameter h is used consistently in the goroutine
Checked that no other instances of this pattern exist in the function

### LLM usage
N/A

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).

collaborated with @hemang1404