### PR TITLE
fix(utils): perform extra handling of QueueProxy container

### DIFF
--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -163,7 +163,10 @@ func handleQueueProxy(spec specs.Spec, configFile string) error {
 	}
 
 	redirectIPEnv := fmt.Sprintf("REDIRECT_IP=%s", constants.QueueProxyRedirectIP)
-	envs := []string{readinessProbeEnv, redirectIPEnv}
+	envs := []string{redirectIPEnv}
+	if readinessProbeEnv != "" {
+		envs = append(envs, readinessProbeEnv)
+	}
 	spec.Process.Env = append(spec.Process.Env, envs...)
 
 	// Get permissions of specification file


### PR DESCRIPTION
## Description
Add extra check in handleQueueProxy() so it only appends readinessProbeEnv when it’s non-empty.

### Related issues
Fixes #419

### LLM usage
N/A

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
