### PR TITLE
fix(qemu): fix terminal mess up in qemu based deployment

### DIFF
--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -61,7 +61,7 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 	cmdString += " -L /usr/share/qemu"   // Set the path for qemu bios/data
 	cmdString += " -cpu host"            // Choose CPU
 	cmdString += " -enable-kvm"          // Enable KVM to use CPU virt extensions
-	cmdString += " -nographic -vga none" // Disable graphic output
+	cmdString += " -display none -vga none -serial stdio -monitor null" // Disable graphic output
 
 	if args.VCPUs > 0 {
 		cmdString += fmt.Sprintf(" -smp %d", args.VCPUs)

--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -190,7 +190,7 @@ func (l *Linux) MonitorCli() types.MonitorCliArgs {
 	switch l.Monitor {
 	case "qemu":
 		extraCliArgs := types.MonitorCliArgs{
-			OtherArgs: " -no-reboot -serial stdio -nodefaults",
+			OtherArgs: " -no-reboot -nodefaults",
 		}
 		if l.InitrdConf && l.RootFsType != "initrd" {
 			extraCliArgs.ExtraInitrd = urunitConfPath


### PR DESCRIPTION
## Description
With QEMU, -nographic doesn’t just “disable graphics”; it also redirects the emulated VGA/serial output to the controlling terminal (stdio) and can multiplex the QEMU monitor/serial on the same stream. That output often contains control characters / escape sequences and QEMU can leave your terminal in a weird state when it exits (so you need reset / stty sane).

Replaced -nographic with:
- display none (or -vga none -display none)
- serial stdio
- monitor none

### Related issues
- Fixes #440

### LLM usage
N/A

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).


