### PR TITLE
tests: add Firecracker edge-case unit tests

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -104,6 +104,25 @@ func (fc *Firecracker) Execve(args types.ExecArgs, ukernel types.Unikernel) erro
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
+	FCConfigJSON, exArgs, JSONConfigFile, err := fc.buildConfigAndCmd(args, ukernel)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
+		return fmt.Errorf("failed to save Firecracker json config: %w", err)
+	}
+	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")
+
+	vmmLog.WithField("Firecracker command", exArgs).Debug("Ready to execve Firecracker")
+
+	return syscall.Exec(fc.Path(), exArgs, args.Environment) //nolint: gosec
+}
+
+// buildConfigAndCmd constructs the Firecracker JSON config and returns the
+// JSON bytes, the command argument slice and the path where the config
+// should be written. This is separated for easier unit testing.
+func (fc *Firecracker) buildConfigAndCmd(args types.ExecArgs, ukernel types.Unikernel) ([]byte, []string, string, error) {
 	cmdString := fc.Path() + " --no-api --config-file "
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	cmdString += JSONConfigFile
@@ -149,7 +168,7 @@ func (fc *Firecracker) Execve(args types.ExecArgs, ukernel types.Unikernel) erro
 	}
 
 	// Block config for Firecracker
-	// TODO: Add support for block devices in FIrecracker
+	// TODO: Add support for block devices in Firecracker
 	FCDrives := make([]FirecrackerDrive, 0)
 
 	bArgs := ukernel.MonitorBlockCli()
@@ -187,14 +206,11 @@ func (fc *Firecracker) Execve(args types.ExecArgs, ukernel types.Unikernel) erro
 		NetIfs:  FCNet,
 		VSock:   FCVSockDev,
 	}
-	FCConfigJSON, _ := json.Marshal(FCConfig)
-	if err := os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
-		return fmt.Errorf("failed to save Firecracker json config: %w", err)
+	FCConfigJSON, err := json.Marshal(FCConfig)
+	if err != nil {
+		return nil, nil, "", err
 	}
-	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")
 
 	exArgs := strings.Split(cmdString, " ")
-	vmmLog.WithField("Firecracker command", exArgs).Debug("Ready to execve Firecracker")
-
-	return syscall.Exec(fc.Path(), exArgs, args.Environment) //nolint: gosec
+	return FCConfigJSON, exArgs, JSONConfigFile, nil
 }

--- a/pkg/unikontainers/hypervisors/firecracker_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+    "encoding/json"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+type fakeUK struct {
+    extraInitrd string
+    blocks      []types.MonitorBlockArgs
+}
+
+func (f *fakeUK) Init(types.UnikernelParams) error { return nil }
+func (f *fakeUK) CommandString() (string, error) { return "", nil }
+func (f *fakeUK) SupportsBlock() bool { return false }
+func (f *fakeUK) SupportsFS(string) bool { return false }
+func (f *fakeUK) MonitorNetCli(string, string) string { return "" }
+func (f *fakeUK) MonitorBlockCli() []types.MonitorBlockArgs { return f.blocks }
+func (f *fakeUK) MonitorCli() types.MonitorCliArgs { return types.MonitorCliArgs{ExtraInitrd: f.extraInitrd} }
+func TestBuildConfig_InitrdAndDefaultMemory(t *testing.T) {
+    fc := &Firecracker{binaryPath: "/usr/bin/firecracker", binary: "firecracker"}
+
+    args := types.ExecArgs{
+        InitrdPath:    "",
+        UnikernelPath: "/vm/kernel",
+        Command:       "-n",
+        MemSizeB:      0,
+        VCPUs:         2,
+    }
+    uk := &fakeUK{extraInitrd: "/opt/initrd.img"}
+
+    jsonBytes, _, _, err := fc.buildConfigAndCmd(args, uk)
+    assert.NoError(t, err)
+
+    var cfg FirecrackerConfig
+    err = json.Unmarshal(jsonBytes, &cfg)
+    assert.NoError(t, err)
+
+    // when InitrdPath is empty, MonitorCli ExtraInitrd should be used
+    assert.Equal(t, "/opt/initrd.img", cfg.Source.InitrdPath)
+
+    // DefaultMemory should be used when MemSizeB is zero
+    assert.Equal(t, DefaultMemory, cfg.Machine.MemSizeMiB)
+}
+
+func TestBuildConfig_MemTooSmallDefaults(t *testing.T) {
+    fc := &Firecracker{binaryPath: "/usr/bin/firecracker", binary: "firecracker"}
+
+    args := types.ExecArgs{
+        MemSizeB:      512, // less than 1 MiB -> bytesToMiB == 0
+        UnikernelPath: "/vm/kernel",
+        Command:       "-n",
+        VCPUs:         1,
+    }
+    uk := &fakeUK{}
+
+    jsonBytes, _, _, err := fc.buildConfigAndCmd(args, uk)
+    assert.NoError(t, err)
+
+    var cfg FirecrackerConfig
+    err = json.Unmarshal(jsonBytes, &cfg)
+    assert.NoError(t, err)
+
+    assert.Equal(t, DefaultMemory, cfg.Machine.MemSizeMiB)
+}
+
+func TestBuildConfig_VSockAndNetwork(t *testing.T) {
+    fc := &Firecracker{binaryPath: "/usr/bin/firecracker", binary: "firecracker"}
+
+    args := types.ExecArgs{
+        VAccelType:    "vsock",
+        VSockDevPath:  "/var/run",
+        VSockDevID:    7,
+        UnikernelPath: "/vm/kernel",
+        Command:       "-n",
+        VCPUs:         1,
+        Net: types.NetDevParams{
+            TapDev: "tap0",
+            MAC:    "02:00:00:00:00:01",
+        },
+    }
+    uk := &fakeUK{}
+
+    jsonBytes, _, _, err := fc.buildConfigAndCmd(args, uk)
+    assert.NoError(t, err)
+
+    var cfg FirecrackerConfig
+    err = json.Unmarshal(jsonBytes, &cfg)
+    assert.NoError(t, err)
+
+    // vsock configured
+    assert.Equal(t, 7, cfg.VSock.GuestCID)
+    assert.Equal(t, "/var/run/vaccel.sock", cfg.VSock.UDSPath)
+    assert.Equal(t, "root", cfg.VSock.VSockID)
+
+    // net interface configured
+    if assert.Len(t, cfg.NetIfs, 1) {
+        assert.Equal(t, "tap0", cfg.NetIfs[0].HostIF)
+        assert.Equal(t, "02:00:00:00:00:01", cfg.NetIfs[0].GuestMAC)
+    }
+}


### PR DESCRIPTION
Adds unit tests for Firecracker config builder (initrd selection, memory defaulting, vsock and networking). Extracts a helper to build the JSON config so it can be unit-tested without execve side-effects.