### PR TITLE
docs: fix typos across documentation files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ values.
 #### Supported monitors and their respective subsection names
 
 - [QEMU/KVM](./hypervisor-support#qemu) - `qemu`
-- [Firecrakcer](./hypervisor-support#firecracker) - `firecracker`
+- [Firecracker](./hypervisor-support#firecracker) - `firecracker`
 - [Solo5-hvt](./hypervisor-support#solo5-hvt) - `hvt` - Solo5 hvt (KVM-based tender)
 - [Solo5-spt](./hypervisor-support#solo5-spt) - `spt` - Solo5 spt (Seccomp-based tender)
 
@@ -114,7 +114,7 @@ Each monitor subsection supports the following options:
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 
 Since Qemu is the only currently supported monitor which requires extra data to
-boot a VM, `urunc` wll first check `/usr/local/share` and then `/usr/share` for
+boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for
 Qemu's data files.
 
 **Example:**

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -42,7 +42,7 @@ higher-level runtime (`containerd`) level:
   `createContainer` hooks.
 - When `Containerd` starts the container `urunc` configures any required
   resources such as block devices or  network interfaces and runs the
-  `statContainer` hooks.
+  `startContainer` hooks.
 - Depending on the specified unikernel type and annotations, `urunc` selects the
   appropriate VMM or sandbox monitor (e.g.  Qemu, Solo5-spt) and boots the
   unikernel. The unikernel runs inside its own isolated environment, interacting

--- a/docs/developer-guide/llm-policy.md
+++ b/docs/developer-guide/llm-policy.md
@@ -25,7 +25,7 @@ regarding the use of LLM in its development process:
   issues or PRs, ensuring correctness, quality, and relevance.
 - The use of LLMs to respond to comments in issues or PRs is not permitted.
   Contributors are expected to express their own thoughts and ideas.  Acting as
-  a mediator between another user and an LLM is not helpful..
+  a mediator between another user and an LLM is not helpful.
 - LLMs may assist in code review but can not replace human reviews. Human
   reviewer guidance takes precedence over any LLM comments.
 

--- a/docs/hypervisor-support.md
+++ b/docs/hypervisor-support.md
@@ -87,7 +87,7 @@ VM instantiation and guest OS boot.
 #### Installing Firecracker
 
 [Firecracker](https://firecracker-microvm.github.io/) is not available through
-a package manger, but it can easily be installed. The [Getting
+a package manager, but it can easily be installed. The [Getting
 Started](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md) guide
 of [Firecracker](https://firecracker-microvm.github.io/) describes how users
 can set up [Firecracker](https://firecracker-microvm.github.io/). Long story short,
@@ -146,7 +146,7 @@ VMM designed to run unikernels in a virtualized environment. As a part of the
 broader Solo5 project, [Solo5-hvt](https://github.com/Solo5/solo5) provides a
 minimal, efficient abstraction layer for running unikernels on modern hardware,
 leveraging hardware virtualization technologies Some of the key benefits of
-[Solo5-hvt](https://github.com/Solo5/solo5) is its simplicity and and extremely
+[Solo5-hvt](https://github.com/Solo5/solo5) is its simplicity and extremely
 fast boot times of unikernels. In contrast to the other VMMs,
 [Solo5-hvt](https://github.com/Solo5/solo5) does not provide support for virtIO
 devices. Instead, it defines its own interface, which can be used for network
@@ -199,7 +199,7 @@ Supported unikernel frameworks with `urunc`:
 - [Rumprun](../unikernel-support#rumprun)
 - [MirageOS](../unikernel-support#mirage)
 
-An example unikernel with a block image inside the conntainer's rootfs:
+An example unikernel with a block image inside the container's rootfs:
 
 ```bash
 sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun-block:latest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -140,7 +140,7 @@ directory](https://github.com/urunc-dev/urunc/tree/main/script/dm_create.sh).
 The first
 [dm\_create.sh](https://github.com/urunc-dev/urunc/tree/main/script/dm_create.sh)
 creates a thinpool, while the second
-[dm\_relosd.sh](https://github.com/urunc-dev/urunc/tree/main/script/dm_relosd.sh)
+[dm\_reload.sh](https://github.com/urunc-dev/urunc/tree/main/script/dm_reload.sh)
 reloads the same thinpool that has been created from
 [dm\_create.sh](https://github.com/urunc-dev/urunc/tree/main/script/dm_create.sh).
 
@@ -222,7 +222,7 @@ io.containerd.snapshotter.v1              devmapper                linux/amd64  
 
 #### Setting and configuring blockfile
 
-THe first stpe of setting up `blockfile` is the creation of the
+The first step of setting up `blockfile` is the creation of the
 scratch file, which will be used from the snapshotter:
 
 ```bash
@@ -282,8 +282,8 @@ $ sudo ctr plugin ls | grep blockfile
 ### Install nerdctl
 
 To easily interact with containerd,
-[nerdctl](https://github.com/containerd/nerdctl) offers a Dockerompatible CLI
-exprerience. The following commands download and install the latest release.
+[nerdctl](https://github.com/containerd/nerdctl) offers a Docker-compatible CLI
+experience. The following commands download and install the latest release.
 
 ```bash
 NERDCTL_VERSION=$(curl -L -s -o /dev/null -w '%{url_effective}' "https://github.com/containerd/nerdctl/releases/latest" | grep -oP "v\d+\.\d+\.\d+" | sed 's/v//')
@@ -299,7 +299,7 @@ This section includes the installation of all supported monitors and
 [monitors-build repository](https://github.com/urunc-dev/monitors-build)
 contains releases with various versions of these monitors and tools.
 Alternatively, each monitor can be downloaded and installed following the
-respective installtion guide.
+respective installation guide.
 
 ### Option 1: Using the monitors-build repository
 
@@ -380,7 +380,7 @@ sudo cp tenders/spt/solo5-spt /usr/local/bin
 ### Qemu
 
 [Qemu](https://www.qemu.org/) is a popular VMM and emulator which is available
-as apcakge from the vast majority of Linux distributions. In apt-based
+as a package from the vast majority of Linux distributions. In apt-based
 distributions:
 
 ```bash
@@ -417,7 +417,7 @@ virtiofsd](https://gitlab.com/virtio-fs/virtiofsd):
 
 ```
 wget https://gitlab.com/-/project/21523468/uploads/0298165d4cd2c73ca444a8c0f6a9ecc7/virtiofsd-v1.13.2.zip
-unzip virtiofsd-v1.13.2.zi
+unzip virtiofsd-v1.13.2.zip
 sudo mv target/x86_64-unknown-linux-musl/release/virtiofsd /usr/libexec/
 rm -rf target virtiofsd-v1.13.2.zip
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,7 +3,7 @@ refer to the [installation guide](../installation) for more detailed installatio
 instructions, or the [design](../design#architecture) document for more
 details regarding `urunc`'s architecture.
 
-We can quickly set `urunc` either with [docker](https://docs.docker.com/engine/install/ubuntu/) or [containerd](https://github.com/containerd/containerd) and [nerdctl](https://github.com/containerd/nerdctl/).
+We can quickly set up `urunc` either with [docker](https://docs.docker.com/engine/install/ubuntu/) or [containerd](https://github.com/containerd/containerd) and [nerdctl](https://github.com/containerd/nerdctl/).
 We assume a vanilla ubuntu 22.04 environment, although `urunc` is able to run
 on a number of GNU/Linux distributions.
 
@@ -49,8 +49,8 @@ We will try out a Unikraft unikernel over [Qemu](https://www.qemu.org/).
 
 #### Install Qemu
 
-Let's make sure that [Qemu](https://www.qemu.org/download/) is installed
-:
+Let's make sure that [Qemu](https://www.qemu.org/download/) is installed:
+
 ```bash
 sudo apt install -y qemu-system
 ```
@@ -154,7 +154,7 @@ sudo /usr/local/bin/scripts/dm_create.sh
 
 At last, we need to modify
 [containerd](https://github.com/containerd/containerd/tree/main) configuration
-for the new demapper snapshotter:
+for the new devmapper snapshotter:
 
 - In containerd v2.x:
 
@@ -222,7 +222,7 @@ chmod +x urunc_$(dpkg --print-architecture)
 sudo mv urunc_$(dpkg --print-architecture) /usr/local/bin/urunc
 ```
 
-Secondly, we will install the `containerd-shim-urunc-v2` binary:.
+Secondly, we will install the `containerd-shim-urunc-v2` binary:
 
 ```bash
 wget -q https://github.com/urunc-dev/urunc/releases/download/v$URUNC_VERSION/containerd-shim-urunc-v2_$(dpkg --print-architecture)

--- a/docs/tutorials/existing-container-linux.md
+++ b/docs/tutorials/existing-container-linux.md
@@ -11,7 +11,7 @@ With this goal in mind, this guide walks through the steps required to take an
 existing container image and execute it on top of `urunc` as a Linux virtual
 machine (VM).
 
-Overall, we need to do the followings:
+Overall, we need to do the following:
 
 1. Build or reuse a Linux kernel.
 2. (Optional but recommended) Build or fetch an init process.
@@ -141,7 +141,7 @@ The simplest way to boot an existing container with a Linux kernel on `urunc`
 is to reuse the container’s rootfs. This is possible either through shared-fs
 between the host and the Linux VM or by using devmapper as the snapshotter. In
 the latter case containerd's devmapper snapshotter will create a snapshot of
-the container;s image in the form of a block image and `urunc` can then
+the container's image in the form of a block image and `urunc` can then
 directly attach this block image to the VM.
 
 To set up devmapper as a snapshotter please refer to the [installation
@@ -250,7 +250,7 @@ and we should be able to ping it:
 ping -c 3 172.17.0.2
 ```
 
-ALternatively, if we want to use devmapper as the snapshotter, we can use
+Alternatively, if we want to use devmapper as the snapshotter, we can use
 [nerdctl](https://github.com/containerd/nerdctl), which integrates seamlessly
 with containerd and supports devmapper out of the box.
 

--- a/docs/tutorials/knative.md
+++ b/docs/tutorials/knative.md
@@ -126,7 +126,7 @@ kubectl get ksvc -A -o wide
 curl -v -H "Host: hellocontainerc.default.127.0.0.1.nip.io" http://<INGRESS_IP>
 ```
 
-Now, let's create a `urunc`-compatible function. Create a [service](https://github.com/nubificus/app-httpreply/blob/fb0ec5c7f5e6b1fedbc589cdc96477c472fef2ca/service.yaml), based on Unikraft's [httreply example](https://github.com/nubificus/app-httpreply/tree/feat_generic): 
+Now, let's create a `urunc`-compatible function. Create a [service](https://github.com/nubificus/app-httpreply/blob/fb0ec5c7f5e6b1fedbc589cdc96477c472fef2ca/service.yaml), based on Unikraft's [httpreply example](https://github.com/nubificus/app-httpreply/tree/feat_generic): 
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/nubificus/app-httpreply/refs/heads/feat_generic/service.yaml

--- a/docs/unikernel-support.md
+++ b/docs/unikernel-support.md
@@ -77,7 +77,7 @@ libraries that provide networking, storage and concurrency support that work
 under Unix during development, but become operating system drivers when being
 compiled for production deployment. We can easily set up and build
 [MirageOS](https://github.com/mirage/mirage) unikernels with `mirage`, which can
-be installed throgu the [Opam](https://opam.ocaml.org/) source package manager.
+be installed through the [Opam](https://opam.ocaml.org/) source package manager.
 The framework is fully event-driven, with no support for preemptive threading.
 
 [MirageOS](https://github.com/mirage/mirage) is characterized from the extremely
@@ -314,7 +314,7 @@ Focusing on the single-application notion of using the
 both [Qemu](https://qemu.org) and
 [Firecracker](https://github.com/firecracker-microvm/firecracker). For network,
 `urunc` will make use of virtio-net either through PCI or MMIO, depending on
-the monitor. In the case of storage, `urunc` can use initrd, virtio-block ,9pfs
+the monitor. In the case of storage, `urunc` can use initrd, virtio-block, 9pfs
 or Virtiofs. In particular, `urunc` takes advantage of the extensive filesystem
 support of [Linux](https://github.com/torvalds/linux) and can directly mount
 containerd's snapshot directly to a [Linux](https://github.com/torvalds/linux)
@@ -324,7 +324,7 @@ more information on setting up devmapper, please take a look on our
 
 For more information on packaging applications and executing them on top of
 [Linux](https://github.com/torvalds/linux) with `urunc` take a look at our
-[running existing containers tutorial.](../tutorials/exisitng-containers-linux)
+[running existing containers tutorial.](../tutorials/existing-container-linux)
 
 An example of a Nginx alpine image on top of [Qemu](https://qemu.org) and
 [Linux](https://github.com/torvalds/linux) with 'urunc' and devmapper as a


### PR DESCRIPTION
## Summary
Fixed typos and grammatical errors across 9 documentation files.

## Related Issues
- Documentation-only change

## How Was This Tested?
- Documentation-only change

## LLM Usage
- None

## Checklist
- [x] I have read the contribution guide
- [x] The linter passes locally (`make lint`)
- [x] The e2e tests of at least one tool pass locally
- [x] If LLMs were used: I have read the LLM policy
