### PR TITLE
Fix: Auto-detect unprivileged user and use XDG_RUNTIME_DIR for default root

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -329,6 +329,7 @@ unikontainer
 unikontainers
 unikraft
 urandom
+userns
 urfave
 urunc
 urunc's

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -118,6 +118,18 @@ func main() {
 			// stateCommand,
 		},
 		Before: func(_ context.Context, cmd *cli.Command) (context.Context, error) {
+			if !cmd.IsSet("root") {
+				xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR")
+				if xdgRuntimeDir != "" && ShouldHonorXDGRuntimeDir() {
+					root := xdgRuntimeDir + "/urunc"
+					if err := prepareXDGRuntimeDir(root); err != nil {
+						return nil, err
+					}
+					if err := cmd.Set("root", root); err != nil {
+						return nil, err
+					}
+				}
+			}
 			if err := reviseRootDir(cmd); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description
This change mirrors runc’s behavior when running as a non-root user (or as root inside a user namespace). In these cases, the runtime now automatically falls back to using $XDG_RUNTIME_DIR as the default runtime root, instead of requiring callers to explicitly pass --root.

By honoring $XDG_RUNTIME_DIR by default in these environments, urunc now aligns with runc’s behavior and integrates more smoothly with Podman.

### Related issues



- Fixes #114

### How was this tested?

### LLM usage

N/A

### Checklist

- [ ] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
