### PR TITLE
fix(urunc-deploy): Bring back the urunc-builder step name

### DIFF
--- a/deployment/urunc-deploy/Dockerfile
+++ b/deployment/urunc-deploy/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /artifacts
 RUN cp /app/tenders/hvt/solo5-hvt /artifacts/ && \
     cp /app/tenders/spt/solo5-spt /artifacts/
 
-FROM golang:1.25.4-alpine3.21@sha256:3289aac2aac769e031d644313d094dbda745f28af81cd7a94137e73eefd58b33
+FROM golang:1.25.4-alpine3.21@sha256:3289aac2aac769e031d644313d094dbda745f28af81cd7a94137e73eefd58b33 AS urunc-builder
 RUN apk update && \
     apk add --no-cache git make build-base linux-headers
 WORKDIR /app


### PR DESCRIPTION
## Description

Bring back the name of the step which builds urunc in the urunc-deploy Dockerfile. This name was incorrectly removed during the past Go update.

### Related issues

None open, but latest builds of the container for urunc-deploy fail.

### How was this tested?

Built urunc_deploy and used to install urunc in a k3s single node cluster

### LLM usage

No

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
