### PR TITLE
docs: remove shell prefixes on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,26 +56,26 @@ following dependencies:
 Install Docker:
 
 ```bash
-$ curl -fsSL https://get.docker.com -o get-docker.sh
-$ sudo sh get-docker.sh
-$ rm get-docker.sh
-$ sudo groupadd docker
-$ sudo usermod -aG docker $USER
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+rm get-docker.sh
+sudo groupadd docker
+sudo usermod -aG docker $USER
 ```
 
 Install `urunc`:
 
 ```bash
-$ sudo apt-get install -y git
-$ git clone https://github.com/urunc-dev/urunc.git
-$ docker run --rm -ti -v $PWD/urunc:/urunc -w /urunc golang:latest bash -c "git config --global --add safe.directory /urunc && make"
-$ sudo make -C urunc install
+sudo apt-get install -y git
+git clone https://github.com/urunc-dev/urunc.git
+docker run --rm -ti -v $PWD/urunc:/urunc -w /urunc golang:latest bash -c "git config --global --add safe.directory /urunc && make"
+sudo make -C urunc install
 ```
 
 Install QEMU:
 
 ```bash
-$ sudo apt install -y qemu-kvm
+sudo apt install -y qemu-kvm
 ```
 
 Now we are ready to run nginx as a Unikraft unikernel using Docker and `urunc`:


### PR DESCRIPTION
## Description

Removed shell prefixes (`$`) remaining in README.md to improve the copy-paste experience.
Note: Code blocks with output left unchanged as discussed in #431.

### Related issues

- Discussed in #431 

### How was this tested?

Documentation-only changes

### LLM usage

None

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
