### PR TITLE
fix: handle dead VMM and scan all urunc TAP devices during cleanup

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -403,3 +403,4 @@ gocyclo
 gomega
 Logr
 onsi
+ESRCH

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 
 	"github.com/jackpal/gateway"
@@ -262,35 +263,53 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 	return newTapDevice, nil
 }
 
-func Cleanup(tapDevice string) error {
+func CleanupAllUruncTaps() error {
 	netlog.Debug("net cleanup called")
-	ifaces, err := net.Interfaces()
+
+	handle, err := netlink.NewHandle()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get netlink handle: %w", err)
 	}
-	for _, iface := range ifaces {
-		netlog.Debugf("Discovered device %s", iface.Name)
-	}
-	tapLink, err := netlink.LinkByName(tapDevice)
+	defer handle.Close()
+
+	links, err := handle.LinkList()
 	if err != nil {
-		netlog.Errorf("Failed to get link %s by name: %v", tapDevice, err)
-		return nil
+		return fmt.Errorf("failed to list links: %w", err)
 	}
-	err = deleteAllTCFilters(tapLink)
-	if err != nil {
-		netlog.Errorf("Failed to delete all TC filters: %v", err)
-		return err
+
+	var retErr error
+	tapRe := regexp.MustCompile(`^tap_\d+_urunc$`)
+	for _, link := range links {
+		attrs := link.Attrs()
+		if attrs == nil {
+			continue
+		}
+		name := attrs.Name
+		if !tapRe.MatchString(name) {
+			continue
+		}
+
+		netlog.Debugf("cleaning up tap device %s", name)
+		var devErr error
+		if err := deleteAllTCFilters(link); err != nil {
+			netlog.Errorf("failed to delete TC filters for %s: %v", name, err)
+			devErr = errors.Join(devErr, err)
+		}
+		if err := deleteAllQDiscs(link); err != nil {
+			netlog.Errorf("failed to delete qdiscs for %s: %v", name, err)
+			devErr = errors.Join(devErr, err)
+		}
+		if err := deleteTapDevice(link); err != nil {
+			netlog.Errorf("failed to delete tap %s: %v", name, err)
+			devErr = errors.Join(devErr, err)
+		}
+		if devErr == nil {
+			netlog.Debugf("deleted tap device %s", name)
+		}
+		retErr = errors.Join(retErr, devErr)
 	}
-	err = deleteAllQDiscs(tapLink)
-	if err != nil {
-		netlog.Errorf("Failed to delete all qdiscs: %v", err)
-		return err
-	}
-	err = deleteTapDevice(tapLink)
-	if err != nil {
-		netlog.Errorf("Failed to delete link %s: %v", tapDevice, err)
-	}
-	return nil
+
+	return retErr
 }
 
 func deleteIngressQdisc(link netlink.Link) error {

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -71,6 +71,10 @@ func killProcess(pid int) error {
 	const timeout = 2 * time.Second
 	err := syscall.Kill(pid, unix.SIGKILL)
 	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			// Process already dead, nothing to do
+			return nil
+		}
 		return err
 	}
 	deadline := time.Now().Add(timeout)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -585,10 +585,9 @@ func (u *Unikontainer) Kill() error {
 		return err
 	}
 
-	// TODO: tap0_urunc should not be hardcoded
-	err = network.Cleanup("tap0_urunc")
+	err = network.CleanupAllUruncTaps()
 	if err != nil {
-		uniklog.Errorf("failed to delete tap0_urunc: %v", err)
+		uniklog.Errorf("failed to cleanup tap devices: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fixed the issue where `vmm.Stop()` was returning an error if the process was already dead (like from a crash), which prevented network cleanup from running.

I updated `killProcess` in `utils.go` to treat `ESRCH` (process not found) as a success. If it's gone, it's gone, so we can proceed.

Also refactored `network.Cleanup` to actually scan for any `tap.*_urunc` interfaces instead of looking for a hardcoded string. This handles leftover devices much better.

Huge thanks to @sidneychang for the scanning logic in #407 — I integrated that here.

### Related issues

Fixes #408
Integrates #407

### How was this tested?

- `make lint` passes.
- Verified that killing the VMM process manually now properly triggers the network cleanup instead of failing.