### PR TITLE
docs: fix line breaks when copying commands from website

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -71,3 +71,6 @@ users:
   Mysterio-17:
     name: Mradul Tiwari
     email: mradultiwari1708@gmail.com
+  Git-HimanshuRathi:
+    name: Himanshu Rathi
+    email: himanshurathiwork@gmail.com

--- a/docs/assets/stylesheets/theme.css
+++ b/docs/assets/stylesheets/theme.css
@@ -130,6 +130,20 @@
 }
 
 /* =======================
+   Code Block Copy Fix
+   ======================= */
+.md-code__content a[id^="__codelineno"] {
+  display: contents !important;
+  user-select: none !important;
+  -moz-user-select: none !important;
+  pointer-events: none !important;
+}
+
+.md-code__content > span > span {
+  display: inline !important;
+}
+
+/* =======================
    General Typography (Optional)
    ======================= */
 .md-typeset h1 {


### PR DESCRIPTION
The MkDocs Material theme's CSS rule for .md-code__content applies display: block to all child span elements, including token-level spans (keywords, whitespace, variables) and hidden anchor tags. This causes browsers to insert line breaks between these elements when users copy code snippets from the documentation.

Add CSS overrides scoped to .md-code__content to force token-level spans and anchor tags inside line spans to display: inline, fixing the copy behavior.

Fixes: #482


## Description

This change fixes an issue where copying commands from the documentation resulted in unwanted line breaks (e.g., `wget\n -q` instead of `wget -q`).

The root cause was a broad CSS rule in the MkDocs Material theme that sets
`display: block` on all spans inside `.md-code__content`. This PR adds scoped
CSS overrides so that only line-level spans remain block elements, while
token-level spans and anchor tags render inline. This preserves syntax
highlighting and layout while ensuring correct copy behavior.

### How was this tested?

Tested locally by running the MkDocs development server and navigating to the
installation guide. Verified that copying commands using both manual text
selection and the copy button preserves correct formatting without unwanted
line breaks.

Before fix (copied text):

```
wget
 -q https://github.com/...
sudo
 install -m 755 ...
```

After fix (copied text):

```
wget -q https://github.com/...
sudo install -m 755 ...
rm -f ./runc...
```


### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).