### PR TITLE
docs: fix binary name in urunc installation from latest release

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -467,7 +467,7 @@ Alternatively, to get the latest
 
 ```bash
 URUNC_VERSION=$(curl -L -s -o /dev/null -w '%{url_effective}' "https://github.com/urunc-dev/urunc/releases/latest" | grep -oP "v\d+\.\d+\.\d+" | sed 's/v//')
-URUNC_BINARY_FILENAME="urunc_static_v${URUNC_VERSION}_$(dpkg --print-architecture)"
+URUNC_BINARY_FILENAME="urunc_static_$(dpkg --print-architecture)"
 wget -q https://github.com/urunc-dev/urunc/releases/download/v$URUNC_VERSION/$URUNC_BINARY_FILENAME
 chmod +x $URUNC_BINARY_FILENAME
 sudo mv $URUNC_BINARY_FILENAME /usr/local/bin/urunc
@@ -476,7 +476,7 @@ sudo mv $URUNC_BINARY_FILENAME /usr/local/bin/urunc
 And for `containerd-shim-urunc-v2`:
 
 ```bash
-CONTAINERD_BINARY_FILENAME="containerd-shim-urunc-v2_static_v${URUNC_VERSION}_$(dpkg --print-architecture)"
+CONTAINERD_BINARY_FILENAME="containerd-shim-urunc-v2_static_$(dpkg --print-architecture)"
 wget -q https://github.com/urunc-dev/urunc/releases/download/v$URUNC_VERSION/$CONTAINERD_BINARY_FILENAME
 chmod +x $CONTAINERD_BINARY_FILENAME
 sudo mv $CONTAINERD_BINARY_FILENAME /usr/local/bin/containerd-shim-urunc-v2

--- a/docs/tutorials/knative.md
+++ b/docs/tutorials/knative.md
@@ -17,6 +17,7 @@ image building and deployment.
 Install [Docker](/quickstart/#install-docker), Go >= 1.21, and `ko`:
 
 ### Install Go 1.21  
+
 ```bash
 sudo mkdir /usr/local/go1.21
 wget https://go.dev/dl/go1.21.5.linux-amd64.tar.gz


### PR DESCRIPTION
## Description

Change the code snippet in installing `urunc` from the latest release, because of naming issues.

### Related issues

No opened issue, but downloading `urunc` from its latest release does not work.

### How was this tested?

Following the steps in the installation guide.

### LLM usage

No

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
