### PR TITLE
fix: correct typos and handle swallowed json.Marshal error

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -183,7 +183,7 @@ func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (
 		consoleSocket := cmd.String("console-socket")
 		conn, err := net.Dial("unix", consoleSocket)
 		if err != nil {
-			err = fmt.Errorf("failed to dial console socker: %w", err)
+			err = fmt.Errorf("failed to dial console socket: %w", err)
 			return err
 		}
 		defer conn.Close()

--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -33,9 +33,9 @@ var deleteCommand = &cli.Command{
 Where "<container-id>" is the name for the instance of the container.
 
 EXAMPLE:
-For example, if the container id is "ubuntu01" and runc list currently shows the
+For example, if the container id is "ubuntu01" and urunc list currently shows the
 status of "ubuntu01" as "stopped" the following will delete resources held for
-"ubuntu01" removing "ubuntu01" from the runc list of containers:
+"ubuntu01" removing "ubuntu01" from the urunc list of containers:
 
 	# urunc delete ubuntu01`,
 	Flags: []cli.Flag{

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -86,7 +86,7 @@ func main() {
 			&cli.StringFlag{
 				Name:  "log",
 				Value: "",
-				Usage: "set the log file to write runc logs to (default is '/dev/stderr')",
+				Usage: "set the log file to write urunc logs to (default is '/dev/stderr')",
 			},
 			&cli.StringFlag{
 				Name:  "log-format",

--- a/cmd/urunc/run.go
+++ b/cmd/urunc/run.go
@@ -36,7 +36,7 @@ filesystem.
 The specification file includes an args parameter. The args parameter is used
 to specify command(s) that get run when the container is started. To change the
 command(s) that get executed on start, edit the args parameter of the spec. See
-"runc spec --help" for more explanation.`
+"urunc spec --help" for more explanation.`
 
 var runCommand = &cli.Command{
 	Name:        "run",

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -186,8 +186,11 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 		NetIfs:  FCNet,
 		VSock:   FCVSockDev,
 	}
-	FCConfigJSON, _ := json.Marshal(FCConfig)
-	if err := os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
+	FCConfigJSON, err := json.Marshal(FCConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Firecracker config: %w", err)
+	}
+	if err = os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
 		return nil, fmt.Errorf("failed to save Firecracker json config: %w", err)
 	}
 	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -274,7 +274,7 @@ func pivotRootfs(newRoot string) error {
 	// We no longer need the old rootfs
 	err = os.RemoveAll("old_root")
 	if err != nil {
-		return fmt.Errorf("failed to remobe old_root: %w", err)
+		return fmt.Errorf("failed to remove old_root: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
### Description
Fix typos, correct `runc` → `urunc` references in user-facing strings, and handle a previously swallowed `json.Marshal` error in the Firecracker config path.

---

### Related issues
None

---

### How was this tested?
lint and build

---

### LLM usage
No

---

### Checklist
- [x] I have read the contribution guide.
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the llm policy.
