### PR TITLE
ci: add checksum and signing support for release binaries

### DIFF
--- a/.github/workflows/release-trigger.yaml
+++ b/.github/workflows/release-trigger.yaml
@@ -99,6 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci,parse-version-manifest]
     if: needs.parse-version-manifest.outputs.version != ''
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -110,32 +113,57 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download urunc amd64 build artifact 
+      - name: Download urunc amd64 build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: urunc_static_amd64-${{ github.run_id }}
           path: ${{ env.ARTIFACTS_PATH }}
           merge-multiple: true
-      - name: Download shim amd64 build artifact 
+      - name: Download shim amd64 build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: containerd-shim-urunc-v2_static_amd64-${{ github.run_id }}
           path: ${{ env.ARTIFACTS_PATH }}
           merge-multiple: true
 
-      - name: Download urunc arm64 build artifact 
+      - name: Download urunc arm64 build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: urunc_static_arm64-${{ github.run_id }}
           path: ${{ env.ARTIFACTS_PATH }}
           merge-multiple: true
 
-      - name: Download shim arm64 build artifact 
+      - name: Download shim arm64 build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: containerd-shim-urunc-v2_static_arm64-${{ github.run_id }}
           path: ${{ env.ARTIFACTS_PATH }}
           merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd ${{ env.ARTIFACTS_PATH }}
+          sha256sum urunc_static_amd64 > urunc_static_amd64.sha256
+          sha256sum urunc_static_arm64 > urunc_static_arm64.sha256
+          sha256sum containerd-shim-urunc-v2_static_amd64 > containerd-shim-urunc-v2_static_amd64.sha256
+          sha256sum containerd-shim-urunc-v2_static_arm64 > containerd-shim-urunc-v2_static_arm64.sha256
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        with:
+          cosign-release: 'v2.5.3'
+
+      - name: Sign binaries with cosign
+        run: |
+          cd ${{ env.ARTIFACTS_PATH }}
+          for bin in urunc_static_amd64 urunc_static_arm64 \
+                     containerd-shim-urunc-v2_static_amd64 \
+                     containerd-shim-urunc-v2_static_arm64; do
+            cosign sign-blob --yes \
+              --output-signature "${bin}.sig" \
+              --output-certificate "${bin}.crt" \
+              "${bin}"
+          done
 
       - name: Generate urunc-bot token
         id: generate-token
@@ -143,7 +171,6 @@ jobs:
         with:
           app-id: ${{ vars.URUNC_BOT_APP_ID }}
           private-key: ${{ secrets.URUNC_BOT_PRIVATE_KEY }}
-
 
       - name: Extract release notes for ${{ needs.parse-version-manifest.outputs.version }}
         id: extract_notes
@@ -163,15 +190,27 @@ jobs:
         id: create_release
         with:
           files: |
-            ${{ env.ARTIFACTS_PATH}}/urunc_static_amd64
-            ${{ env.ARTIFACTS_PATH}}/urunc_static_arm64
-            ${{ env.ARTIFACTS_PATH}}/containerd-shim-urunc-v2_static_amd64
-            ${{ env.ARTIFACTS_PATH}}/containerd-shim-urunc-v2_static_arm64
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_amd64
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_amd64.sha256
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_amd64.sig
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_amd64.crt
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_arm64
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_arm64.sha256
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_arm64.sig
+            ${{ env.ARTIFACTS_PATH }}/urunc_static_arm64.crt
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_amd64
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_amd64.sha256
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_amd64.sig
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_amd64.crt
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_arm64
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_arm64.sha256
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_arm64.sig
+            ${{ env.ARTIFACTS_PATH }}/containerd-shim-urunc-v2_static_arm64.crt
           body: ${{ steps.extract_notes.outputs.release_notes }}
-          name: ${{needs.parse-version-manifest.outputs.version}}
+          name: ${{ needs.parse-version-manifest.outputs.version }}
           draft: false
           prerelease: false
           generate_release_notes: false
-          tag_name: ${{needs.parse-version-manifest.outputs.version}}
+          tag_name: ${{ needs.parse-version-manifest.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Welcome to `urunc`, the "runc for unikernels".
 10. [Contributing](#Contributing)
 11. [Security Policy](#security-policy)
 12. [Changelog](#changelog)
-13. [License](#Introduction)
-14. [Contact](#Introduction)
+13. [Verifying releases](#verifying-releases)
+14. [License](#Introduction)
+15. [Contact](#Introduction)
 
 ## Introduction
 
@@ -217,6 +218,35 @@ for guidelines on how to report it responsibly.
 
 See [CHANGELOG.md](https://github.com/urunc-dev/urunc/blob/main/CHANGELOG.md)
 for more information on what changed in the latest and previous releases.
+
+## Verifying releases
+
+Every release binary ships with SHA-256 checksums and
+[cosign](https://github.com/sigstore/cosign) keyless signatures (issued via
+Sigstore). You can verify a downloaded binary as follows:
+
+### 1. Verify the checksum
+
+```bash
+sha256sum -c urunc_static_amd64.sha256
+```
+
+### 2. Verify the cosign signature
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/),
+then run:
+
+```bash
+cosign verify-blob \
+  --signature urunc_static_amd64.sig \
+  --certificate urunc_static_amd64.crt \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github\.com/urunc-dev/urunc/' \
+  urunc_static_amd64
+```
+
+Replace `urunc_static_amd64` with the relevant binary name
+(`urunc_static_arm64`, `containerd-shim-urunc-v2_static_amd64`, etc.).
 
 ## License
 


### PR DESCRIPTION
Resolves: #199

## Description
Add SHA256 checksum generation and **cosign** keyless signing to the release pipeline.  
This generates `.sha256`, `.sig`, and `.crt` files for all release binaries **only during releases**, attaches them to GitHub Releases for verifiable artifacts, and removes legacy S3 upload workflows to keep daily CI fast.

### Related issues
- Resolves #199

### How was this tested?
- Build and lint

### LLM usage
None

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
