### PR TITLE
test(e2e): migrate nerdctl tests to Ginkgo framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,14 +265,14 @@ test_hypervisors:
 .PHONY: test_nerdctl
 test_nerdctl:
 	@echo "Testing nerdctl"
-	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -run TestNerdctl -v
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -run TestE2E -v --ginkgo.v --ginkgo.focus="Nerdctl"
 	@echo " "
 
 ## test_ctr Run all end-to-end tests with ctr
 .PHONY: test_ctr
 test_ctr:
 	@echo "Testing ctr"
-	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -run TestCtr -v --ginkgo.v
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -run TestE2E -v --ginkgo.v --ginkgo.focus="Ctr"
 	@echo " "
 
 ## test_crictl Run all end-to-end tests with crictl
@@ -293,14 +293,14 @@ test_docker:
 .PHONY: test_nerdctl_%
 test_nerdctl_%:
 	@echo "Testing nerdctl"
-	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -v -run "TestNerdctl/$*"
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -v --ginkgo.v -run TestE2E --ginkgo.focus="Nerdctl.*$*"
 	@echo " "
 
 ## test_ctr_[pattern] Run all end-to-end tests with ctr that match pattern
 .PHONY: test_ctr_%
 test_ctr_%:
 	@echo "Testing ctr"
-	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -v --ginkgo.v -run TestCtr --ginkgo.focus="$*"
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./tests/e2e -v --ginkgo.v -run TestE2E --ginkgo.focus="Ctr.*$*"
 	@echo " "
 
 ## test_crictl_[pattern] Run all end-to-end tests with crictl that match pattern

--- a/tests/e2e/ctr_test.go
+++ b/tests/e2e/ctr_test.go
@@ -25,10 +25,7 @@ import (
 const testCtr = "TestCtr"
 
 var _ = Describe("Ctr", Ordered, ContinueOnFailure, func() {
-	var (
-		tool *ctrInfo
-		cwd  string
-	)
+	var tool *ctrInfo
 
 	BeforeAll(func() {
 		cases := ctrTestCases()
@@ -42,15 +39,7 @@ var _ = Describe("Ctr", Ordered, ContinueOnFailure, func() {
 	})
 
 	BeforeEach(func() {
-		var err error
-		cwd, err = os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-		testDir := GinkgoT().TempDir()
-		Expect(os.Chdir(testDir)).To(Succeed())
-
-		DeferCleanup(func() {
-			Expect(os.Chdir(cwd)).To(Succeed())
-		})
+		setupTestDir()
 	})
 
 	ReportAfterEach(func(report SpecReport) {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -18,16 +18,6 @@ import (
 	"testing"
 )
 
-func TestNerdctl(t *testing.T) {
-	tests := nerdctlTestCases()
-	for _, tc := range tests {
-		t.Run(tc.Name, func(t *testing.T) {
-			nerdctlTool := newNerdctlTool(tc)
-			runTest(nerdctlTool, t)
-		})
-	}
-}
-
 func TestCrictl(t *testing.T) {
 	tests := crictlTestCases()
 	for _, tc := range tests {

--- a/tests/e2e/nerdctl_test.go
+++ b/tests/e2e/nerdctl_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package urunce2etesting
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const testNerdctl = "TestNerdctl"
+
+var _ = Describe("Nerdctl", Ordered, ContinueOnFailure, func() {
+	var tool *nerdctlInfo
+
+	BeforeAll(func() {
+		cases := nerdctlTestCases()
+		images := getTestImages(cases)
+		err := pullAllImages(testNerdctl, images)
+		Expect(err).NotTo(HaveOccurred(), "Failed to pull nerdctl images")
+
+		DeferCleanup(func() {
+			removeAllImages(testNerdctl, images)
+		})
+	})
+
+	BeforeEach(func() {
+		setupTestDir()
+	})
+
+	ReportAfterEach(func(report SpecReport) {
+		if report.Failed() && tool != nil {
+			AddReportEntry("test-args", tool.getTestArgs())
+		}
+	})
+
+	Context("foreground containers", func() {
+		DescribeTable("unikernel containers",
+			func(tc containerTestArgs) {
+				for _, vol := range tc.Volumes {
+					if _, err := os.Stat(vol.Source); err != nil {
+						Skip(fmt.Sprintf("Could not find %s", vol.Source))
+					}
+				}
+
+				tool = newNerdctlTool(tc)
+				tool.setContainerID(tc.Name)
+
+				DeferCleanup(func() {
+					if tool != nil && tool.getContainerID() != "" {
+						By("Cleaning up container")
+						if err := testCleanup(tool); err != nil {
+							GinkgoLogr.Error(err, "Container cleanup failed")
+						}
+					}
+				})
+
+				By("Running container")
+				output, err := tool.runContainer(false)
+				Expect(err).NotTo(HaveOccurred(), "Failed to run container: %s", output)
+
+				By("Verifying container output")
+				Expect(output).To(ContainSubstring(tc.ExpectOut))
+			},
+			toTableEntries(selectTestCases(nerdctlTestCases(), false)),
+		)
+	})
+
+	Context("detached containers", func() {
+		DescribeTable("unikernel containers",
+			func(tc containerTestArgs) {
+				for _, vol := range tc.Volumes {
+					if _, err := os.Stat(vol.Source); err != nil {
+						Skip(fmt.Sprintf("Could not find %s", vol.Source))
+					}
+				}
+
+				tool = newNerdctlTool(tc)
+
+				By("Creating container")
+				cID, err := tool.createContainer()
+				Expect(err).NotTo(HaveOccurred(), "Failed to create container: %s", cID)
+				tool.setContainerID(cID)
+
+				DeferCleanup(func() {
+					if tool != nil && tool.getContainerID() != "" {
+						By("Stopping container")
+						if err := tool.stopContainer(); err != nil {
+							GinkgoLogr.Error(err, "Failed to stop container")
+						}
+						By("Removing container")
+						if err := tool.rmContainer(); err != nil {
+							GinkgoLogr.Error(err, "Failed to remove container")
+						}
+						By("Verifying container removal")
+						if err := testVerifyRm(tool); err != nil {
+							GinkgoLogr.Error(err, "Failed to verify removal")
+						}
+					}
+				})
+
+				By("Starting container")
+				output, err := tool.startContainer(true)
+				Expect(err).NotTo(HaveOccurred(), "Failed to start container: %s", output)
+
+				By("Running test function")
+				Eventually(func() error {
+					return tc.TestFunc(tool)
+				}, defaultTimeout, defaultInterval).Should(Succeed())
+			},
+			toTableEntries(selectTestCases(nerdctlTestCases(), true)),
+		)
+	})
+})

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	testNerdctl    = "TestNerdctl"
+	testE2E        = "TestE2E"
 	testCrictl     = "TestCrictl"
 	testDocker     = "TestDocker"
 	maxPullRetries = 5
@@ -68,10 +68,8 @@ func parseTestPattern() (string, string) {
 
 func getTestCases(testFunc string) []containerTestArgs {
 	switch testFunc {
-	case testNerdctl:
-		return nerdctlTestCases()
-	case testCtr:
-		// Images managed by BeforeAll in ctr_test.go
+	case testE2E:
+		// Images managed by BeforeAll in Ginkgo specs
 		return []containerTestArgs{}
 	case testCrictl:
 		return crictlTestCases()
@@ -79,7 +77,6 @@ func getTestCases(testFunc string) []containerTestArgs {
 		return dockerTestCases()
 	default:
 		var allCases []containerTestArgs
-		allCases = append(allCases, nerdctlTestCases()...)
 		allCases = append(allCases, crictlTestCases()...)
 		allCases = append(allCases, dockerTestCases()...)
 		return allCases

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -15,17 +15,35 @@
 package urunce2etesting
 
 import (
+	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 )
 
-func TestCtr(t *testing.T) {
+const (
+	defaultTimeout  = 10 * time.Second
+	defaultInterval = 1 * time.Second
+)
+
+func TestE2E(t *testing.T) {
 	format.MaxLength = 0 // Do not truncate failure output
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Ctr E2E Suite")
+	RunSpecs(t, "E2E Suite")
+}
+
+// setupTestDir switches to a temp directory, restored via DeferCleanup.
+func setupTestDir() {
+	cwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+	testDir := GinkgoT().TempDir()
+	Expect(os.Chdir(testDir)).To(Succeed())
+	DeferCleanup(func() {
+		Expect(os.Chdir(cwd)).To(Succeed())
+	})
 }
 
 // toTableEntries converts a slice of containerTestArgs into Ginkgo TableEntry
@@ -36,4 +54,15 @@ func toTableEntries(cases []containerTestArgs) []TableEntry {
 		entries = append(entries, Entry(tc.Name, tc))
 	}
 	return entries
+}
+
+// selectTestCases returns cases with or without a TestFunc.
+func selectTestCases(cases []containerTestArgs, hasTestFunc bool) []containerTestArgs {
+	var out []containerTestArgs
+	for _, tc := range cases {
+		if (tc.TestFunc != nil) == hasTestFunc {
+			out = append(out, tc)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Description

<!-- Describe the changes and why they are needed. -->
Migrate the `nerdctl` e2e tests from the standard Go testing package to Ginkgo. This includes changes such as:

- Renaming the test entry point from `TestCtr` to `TestE2E` so that all Ginkgo specs run under a single function. The Makefile targets use `--ginkgo.focus` to select which suite (Ctr or Nerdctl) to run.
- Deduplicating the `BeforeEach` logic in `ctr_test.go` by introducing a shared `setupTestDir` helper.

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Part of #381 

### How was this tested?

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->
- `make test_nerdctl`
- `make test_nerdctl_Qemu`
- `make test_ctr_Hvt`

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->
Claude Code (Opus 4.6)

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
