### PR TITLE
fix(ci): propagate closing keywords to merge PR body

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -52,12 +52,24 @@ jobs:
           PR_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           PR_BRANCH=${{ github.event.pull_request.base.ref }}
+          PR_NUMBER=${PR_BRANCH#main-pr}
+
+          # Use GitHub's API to get issues referenced with closing keywords
+          CLOSING_ISSUES=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[].number' || true)
+
+          BODY="This PR was automatically created by GitHub Actions to merge changes from $PR_BRANCH into main."
+          if [ -n "$CLOSING_ISSUES" ]; then
+            while IFS= read -r issue; do
+              BODY="$BODY"$'\n'"Closes #$issue"
+            done <<< "$CLOSING_ISSUES"
+          fi
 
           # Create the pull request
           PR_URL=$(gh pr create \
             --head "$PR_BRANCH" \
             --base main \
             --title "Merge External PR: Merge $PR_BRANCH into main" \
-            --body "This PR was automatically created by GitHub Actions to merge changes from $PR_BRANCH into main.")
+            --body "$BODY")
 
           gh pr merge "$PR_URL" --rebase --admin --delete-branch


### PR DESCRIPTION
## Description

<!-- Describe the changes and why they are needed. -->

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #557 

### How was this tested?

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->
Full testing requires an actual PR merge workflow run.

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->
Claude Opus 4.6

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
