### PR TITLE
fix(netwotk): Get MTU from tap device and set it in Qemu and clh args

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -47,6 +47,7 @@ type Interface struct {
 	Mask           string
 	Interface      string
 	MAC            string
+	MTU            int
 }
 
 func NewNetworkManager(networkType string) (Manager, error) {
@@ -169,6 +170,7 @@ func getInterfaceInfo(iface string) (Interface, error) {
 		Mask:           mask,
 		Interface:      iface,
 		MAC:            IfMAC,
+		MTU:            ief.MTU,
 	}, nil
 }
 

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -95,7 +95,7 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 		netCli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
 		if netCli == "" {
 			// Default network configuration for Cloud Hypervisor
-			exArgs = append(exArgs, "--net", fmt.Sprintf("tap=%s,mac=%s", args.Net.TapDev, args.Net.MAC))
+			exArgs = append(exArgs, "--net", fmt.Sprintf("tap=%s,mac=%s,mtu=%d", args.Net.TapDev, args.Net.MAC, args.Net.MTU))
 		} else {
 			exArgs = append(exArgs, strings.Split(strings.TrimSpace(netCli), " ")...)
 		}

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -91,13 +91,12 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 	if args.Net.TapDev != "" {
 		netcli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
 		if netcli == "" {
-			netcli += " -net nic,model=virtio,macaddr="
-			netcli += args.Net.MAC
-			netcli += " -net tap,script=no,downscript=no,ifname="
+			netcli += " -netdev tap,id=net0,script=no,downscript=no,ifname="
 			netcli += args.Net.TapDev
 			if q.vhost {
 				netcli += ",vhost=on"
 			}
+			netcli += fmt.Sprintf(" %s,host_mtu=%d,mac=%s", getVirtioNetArg(), args.Net.MTU, args.Net.MAC)
 		}
 		cmdString += netcli
 	} else {
@@ -146,4 +145,12 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 // PreExec performs pre-execution setup. QEMU has no special pre-exec requirements.
 func (q *Qemu) PreExec(_ types.ExecArgs) error {
 	return nil
+}
+
+func getVirtioNetArg() string {
+	devType := "virtio-net-pci"
+	if runtime.GOARCH == "arm64" {
+		devType = "virtio-net-device"
+	}
+	return "-device " + devType + ",netdev=net0"
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -47,6 +47,7 @@ type NetDevParams struct {
 	Gateway string // The veth device gateway
 	MAC     string // The MAC address of the guest network device
 	TapDev  string // The tap device name
+	MTU     int    // The MTU value of the tap device
 }
 
 type BlockDevParams struct {

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -195,6 +195,7 @@ func (u *Unikontainer) SetupNet() (types.NetDevParams, error) {
 		// The MAC address for the guest network device is the same as the
 		// virtual ethernet interface inside the namespace
 		netArgs.MAC = networkInfo.EthDevice.MAC
+		netArgs.MTU = networkInfo.EthDevice.MTU
 	}
 
 	return netArgs, nil


### PR DESCRIPTION
## Description

Qemu and Cloud hypervisor support setting the MTU value in the command line arguments of the network device. Therefore, get the MTU value from the network interface of the host that we associate with the tap device and set it as the MTU for Qemu's and cloud hypervisor's virtio network device.

### Related issues

Related to https://github.com/urunc-dev/urunc/issues/547 but since Firecracker does not accept any option to set the MTU or to retrieve it form the tap device, the issue will remain open.

### How was this tested?

In a k3s environment using flannel, which uses 1450 for MTU, qemu and clh based images where deployed and checked the MTUs of the network interface inside the VM.

e.g. for a pod configuration:
```
    spec:
      runtimeClassName: urunc
      containers:
      - image: harbor.nbfc.io/nubificus/urunc/busybox-cloud-hypervisor-linux-raw:latest
        args: ["ip", "a"]
```

### LLM usage

N/A

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
