### PR TITLE
feat: opt-in KSM support for VMM guest memory

### DIFF
--- a/deployment/urunc-deploy/scripts/install.sh
+++ b/deployment/urunc-deploy/scripts/install.sh
@@ -35,8 +35,67 @@ urunc_config_file="${urunc_config_dir}/config.toml"
 HYPERVISORS="${HYPERVISORS:-"firecracker qemu solo5-hvt solo5-spt"}"
 IFS=' ' read -a hypervisors <<< "$HYPERVISORS"
 
+# ENABLE_KSM opts this node into kernel same-page merging for VMM
+# memory. Off by default — operators must set ENABLE_KSM=true on the
+# daemonset to turn it on. When enabled, install.sh:
+#   1. starts the host's ksmd (/sys/kernel/mm/ksm/run=1) and tunes it
+#   2. writes [ksm] enable = true into /etc/urunc/config.toml so urunc
+#      calls prctl(PR_SET_MEMORY_MERGE) on every VMM launch
+# Both halves are required for actual merging — ksmd without the prctl
+# has nothing eligible to merge; the prctl without ksmd has no scanner.
+ENABLE_KSM="${ENABLE_KSM:-false}"
+
+# KSM_PAGES_TO_SCAN tunes how aggressively ksmd walks the candidate set.
+# Default is 100 pages per sleep interval which is too slow to reach
+# steady state on hosts running many 512 MiB VMs. 1000 scans ~4 MiB per
+# 20 ms sleep (the default sleep_millisecs), so a 512 MiB VM reaches
+# merge steady state in single-digit seconds.
+KSM_PAGES_TO_SCAN="${KSM_PAGES_TO_SCAN:-1000}"
+
 function host_systemctl() {
     nsenter --target 1 --mount systemctl "${@}"
+}
+
+function host_write_sysfs() {
+    # Write a value to a host sysfs path from inside the daemonset pod.
+    # Goes through nsenter into PID 1's mount namespace so /sys is the
+    # host's sysfs, not the container's.
+    local path="$1"
+    local value="$2"
+    nsenter --target 1 --mount sh -c "echo $value > $path"
+}
+
+function configure_ksm() {
+    if [ "${ENABLE_KSM}" != "true" ]; then
+        echo "ENABLE_KSM=${ENABLE_KSM}; leaving host KSM settings unchanged"
+        return 0
+    fi
+    if [ ! -d /host/sys/kernel/mm/ksm ]; then
+        echo "WARNING: host kernel has no /sys/kernel/mm/ksm (CONFIG_KSM not enabled); skipping KSM setup"
+        return 0
+    fi
+
+    echo "Enabling ksmd on host (pages_to_scan=${KSM_PAGES_TO_SCAN})"
+    host_write_sysfs /sys/kernel/mm/ksm/run 1
+    host_write_sysfs /sys/kernel/mm/ksm/pages_to_scan "${KSM_PAGES_TO_SCAN}"
+    # use_zero_pages defaults to 0 on some kernels; ensure zero-filled
+    # guest RAM regions are eligible for merging with the shared zero
+    # page. That's where the biggest win comes from for mostly-idle
+    # unikernels.
+    if [ -w /host/sys/kernel/mm/ksm/use_zero_pages ]; then
+        host_write_sysfs /sys/kernel/mm/ksm/use_zero_pages 1
+    fi
+}
+
+function cleanup_ksm() {
+    if [ ! -d /host/sys/kernel/mm/ksm ]; then
+        return 0
+    fi
+    # Stop the scanner but leave the MERGEABLE marks alone. Setting run=0
+    # halts scanning without unmerging existing pages, which would cause
+    # a CoW burst across every VMM running on the node.
+    echo "Stopping ksmd on host (keeping already-merged pages)"
+    host_write_sysfs /sys/kernel/mm/ksm/run 0 || true
 }
 
 function print_usage() {
@@ -97,6 +156,13 @@ function install_urunc_config() {
     echo "Installing urunc configuration file"
     mkdir -p /host${urunc_config_dir}
     cp /deployment/config.toml /host${urunc_config_file}
+    if [ "${ENABLE_KSM}" == "true" ]; then
+        # tomlq edits the file in place so urunc sees [ksm] enable = true
+        # on next reload. Keeps the wire format honest instead of relying
+        # on env-var side channels between install.sh and urunc.
+        tomlq -i -t '.ksm.enable = true' /host${urunc_config_file}
+        echo "ksm.enable=true written to ${urunc_config_file}"
+    fi
     echo "urunc configuration file installed at ${urunc_config_file}"
 }
 
@@ -370,6 +436,7 @@ function main() {
             fi
             install_artifacts
             install_urunc_config
+            configure_ksm
             configure_cri_runtime "$runtime"
             kubectl label node "$NODE_NAME" --overwrite urunc.io/urunc-runtime=true
             echo "urunc-deploy completed successfully"
@@ -381,6 +448,7 @@ function main() {
             fi
 
             cleanup_cri_runtime "$runtime"
+            cleanup_ksm
             local urunc_deploy_installations=$(kubectl -n kube-system get ds | grep urunc-deploy | wc -l)
             if [ $urunc_deploy_installations -eq 0 ]; then
                 kubectl label node "$NODE_NAME" --overwrite urunc.io/urunc-runtime=cleanup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@ syslog = false
 enabled = false
 destination = "/var/log/urunc/timestamps.log"
 
+[ksm]
+enable = false
+
 [monitors.qemu]
 default_memory_mb = 512
 default_vcpus = 2
@@ -88,6 +91,40 @@ destination = "/tmp/urunc-timestamps.log"
 ```
 
 When enabled, `urunc` will log performance timestamps to help with debugging and optimization.
+
+### KSM Configuration
+
+The `[ksm]` section controls whether `urunc` opts each VMM process into Linux
+Kernel Same-page Merging (KSM) before `execve`. When enabled, `urunc` calls
+`prctl(PR_SET_MEMORY_MERGE, 1)` on itself prior to exec, which sets
+`MMF_VM_MERGE_ANY` on the process's `mm_struct`. Because this flag lives in
+`MMF_INIT_MASK`, it survives `execve` into the VMM, and every anonymous mapping
+the VMM creates afterwards (including guest RAM) is auto-marked
+`MADV_MERGEABLE`. The host's `ksmd` then deduplicates identical pages across
+VMM processes that have the bit set.
+
+This matters in particular for Firecracker, whose seccomp filter only permits
+`madvise(MADV_DONTNEED)`, so the VMM cannot opt itself in. Performing the
+`prctl` in `urunc` before exec is the only portable way to make Firecracker
+guest memory KSM-eligible.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enable` | boolean | `false` | Call `prctl(PR_SET_MEMORY_MERGE, 1)` before execing the VMM |
+
+**Example:**
+
+```toml
+[ksm]
+enable = true
+```
+
+**Requirements:**
+
+- Linux 6.4 or newer with `CONFIG_KSM=y` (older kernels lack
+  `PR_SET_MEMORY_MERGE`; `urunc` logs a warning and continues without KSM).
+- The host's `ksmd` must be running (`/sys/kernel/mm/ksm/run=1`) for any actual
+  merging to happen. `urunc` does not manage `ksmd` itself.
 
 ### Monitor Configuration
 
@@ -224,6 +261,9 @@ syslog = false
 [timestamps]
 enabled = false
 destination = "/var/log/urunc/timestamps.log"
+
+[ksm]
+enable = false
 
 [monitors.qemu]
 default_memory_mb = 256

--- a/pkg/unikontainers/ksm_linux.go
+++ b/pkg/unikontainers/ksm_linux.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package unikontainers
+
+import "golang.org/x/sys/unix"
+
+// enableProcessKSM sets MMF_VM_MERGE_ANY on the current mm via
+// prctl(PR_SET_MEMORY_MERGE, 1) so every future anonymous mmap is
+// auto-marked MADV_MERGEABLE. The kernel's ksmd (gated by
+// /sys/kernel/mm/ksm/run=1 on the host) then dedups identical pages
+// across processes that have the bit set.
+//
+// MMF_VM_MERGE_ANY is in MMF_INIT_MASK, so the flag survives the
+// subsequent syscall.Exec into the VMM — firecracker/qemu/etc. don't
+// need to opt in themselves, and they don't need to call madvise on
+// their guest RAM. This matters for firecracker in particular, whose
+// seccomp filter only allows madvise(DONTNEED).
+//
+// Best-effort. prctl returns EINVAL on kernels older than 6.4 or
+// without CONFIG_KSM=y; we log and continue — the VMM still boots, it
+// just won't benefit from KSM.
+func enableProcessKSM() {
+	if err := unix.Prctl(unix.PR_SET_MEMORY_MERGE, 1, 0, 0, 0); err != nil {
+		uniklog.WithError(err).Warn("PR_SET_MEMORY_MERGE unsupported; skipping KSM opt-in for this VMM")
+		return
+	}
+	uniklog.Debug("PR_SET_MEMORY_MERGE enabled; VMM guest memory will be KSM-eligible after execve")
+}

--- a/pkg/unikontainers/ksm_other.go
+++ b/pkg/unikontainers/ksm_other.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package unikontainers
+
+// enableProcessKSM is a no-op on non-Linux platforms. KSM is a Linux
+// kernel feature; VMMs can't run here anyway.
+func enableProcessKSM() {}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -521,6 +521,21 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
+	// Opt this process into system-wide KSM before execing the VMM so that
+	// the VMM's guest RAM pages (huge anon mmaps it will create after
+	// exec) are auto-marked MADV_MERGEABLE by the kernel. The host must
+	// also have ksmd running (/sys/kernel/mm/ksm/run=1) for merges to
+	// actually happen.
+	//
+	// Off by default; enable via [ksm] enable = true in /etc/urunc/config.toml.
+	//
+	// Must run before vmm.PreExec: HVT installs a seccomp filter on this
+	// process that does not allow prctl(PR_SET_MEMORY_MERGE), so calling
+	// this after PreExec would be killed on HVT.
+	if u.UruncCfg != nil && u.UruncCfg.KSM.Enable {
+		enableProcessKSM()
+	}
+
 	// Perform any monitor-specific pre-exec setup (e.g., seccomp filters for HVT).
 	err = vmm.PreExec(vmmArgs)
 	if err != nil {

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -34,9 +34,18 @@ type UruncTimestamps struct {
 	Destination string `toml:"destination"` // Used to specify a file for timestamps
 }
 
+// UruncKSM controls whether urunc opts every VMM process into kernel
+// same-page merging before execve. When Enable is true urunc calls
+// prctl(PR_SET_MEMORY_MERGE, 1); the kernel's ksmd must also be running
+// on the host for any actual merging to happen. Off by default.
+type UruncKSM struct {
+	Enable bool `toml:"enable"`
+}
+
 type UruncConfig struct {
 	Log        UruncLog                        `toml:"log"`
 	Timestamps UruncTimestamps                 `toml:"timestamps"`
+	KSM        UruncKSM                        `toml:"ksm"`
 	Monitors   map[string]types.MonitorConfig  `toml:"monitors"`
 	ExtraBins  map[string]types.ExtraBinConfig `toml:"extra_binaries"`
 }
@@ -94,10 +103,15 @@ func defaultExtraBinConfig() map[string]types.ExtraBinConfig {
 	}
 }
 
+func defaultKSMConfig() UruncKSM {
+	return UruncKSM{Enable: false}
+}
+
 func defaultUruncConfig() *UruncConfig {
 	return &UruncConfig{
 		Log:        defaultLogConfig(),
 		Timestamps: defaultTimestampsConfig(),
+		KSM:        defaultKSMConfig(),
 		Monitors:   defaultMonitorsConfig(),
 		ExtraBins:  defaultExtraBinConfig(),
 	}
@@ -120,6 +134,8 @@ func (p *UruncConfig) Map() map[string]string {
 	// them to this map. this map will be used to save the rest of the urunc config to state.json
 	cfgMap := make(map[string]string)
 
+	cfgMap["urunc_config.ksm.enable"] = strconv.FormatBool(p.KSM.Enable)
+
 	for hv, hvCfg := range p.Monitors {
 		prefix := "urunc_config.monitors." + hv + "."
 		cfgMap[prefix+"default_memory_mb"] = strconv.FormatUint(uint64(hvCfg.DefaultMemoryMB), 10)
@@ -140,8 +156,17 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 	// since log and timestamps are loaded at the start of urunc, we will not be reading
 	// them from this map. this map will be used to parse the rest of the urunc config from state.json
 	cfg := &UruncConfig{
+		KSM:       defaultKSMConfig(),
 		Monitors:  defaultMonitorsConfig(),
 		ExtraBins: defaultExtraBinConfig(),
+	}
+
+	if val, ok := cfgMap["urunc_config.ksm.enable"]; ok {
+		if boolVal, err := strconv.ParseBool(val); err == nil {
+			cfg.KSM.Enable = boolVal
+		} else {
+			uniklog.Warnf("Invalid ksm.enable value '%s': %v. Using default (false).", val, err)
+		}
 	}
 
 	for key, val := range cfgMap {

--- a/pkg/unikontainers/urunc_config_test.go
+++ b/pkg/unikontainers/urunc_config_test.go
@@ -354,6 +354,28 @@ func TestUruncConfigFromMap(t *testing.T) {
 		assert.False(t, qemuConfig.Vhost, "invalid vhost value should default to false")
 	})
 
+	t.Run("ksm disabled by default", func(t *testing.T) {
+		t.Parallel()
+		config := UruncConfigFromMap(map[string]string{})
+		assert.False(t, config.KSM.Enable)
+	})
+
+	t.Run("ksm enabled when round-tripped", func(t *testing.T) {
+		t.Parallel()
+		config := UruncConfigFromMap(map[string]string{
+			"urunc_config.ksm.enable": "true",
+		})
+		assert.True(t, config.KSM.Enable)
+	})
+
+	t.Run("invalid ksm.enable value defaults to false", func(t *testing.T) {
+		t.Parallel()
+		config := UruncConfigFromMap(map[string]string{
+			"urunc_config.ksm.enable": "bogus",
+		})
+		assert.False(t, config.KSM.Enable)
+	})
+
 }
 
 func TestUruncConfigMap(t *testing.T) {


### PR DESCRIPTION
This adds a new opt-in configuration to allow host nodes to deduplicate same memory pages using the kernels [KSM](https://docs.kernel.org/admin-guide/mm/ksm.html) feature. 

We add a `[ksm]` section to the urunc configuration that causes urunc to call `prctl(PR_SET_MEMORY_MERGE, 1)` on itself before execing the VMM. The flag lives in `MMF_INIT_MASK` so it survives `execve`, and every anonymous mapping the VMM creates afterwards (including guest RAM) is auto-marked `MADV_MERGEABLE`. The host's `ksmd` then deduplicates identical pages across VMM processes.

This matters in particular for Firecracker, whose seccomp filter only permits `madvise(MADV_DONTNEED)`, so the VMM cannot opt itself in. Doing the `prctl` in urunc before exec is the only portable way to make Firecracker guest memory KSM-eligible.

## Usage

Off by default. Opt in via `/etc/urunc/config.toml`:

```toml
[ksm]
enable = true
```

Configuration follows the existing `[log]` / `[timestamps]` pattern: the value is loaded at `urunc create`, stored in `state.json` annotations, and round-tripped through `UruncConfig.Map` / `UruncConfigFromMap` so it survives reexec.

urunc-deploy gains an `ENABLE_KSM` env var (default `false`) that writes `ksm.enable=true` into the installed `config.toml` via `tomlq`.

Note that KSM tends to be disabled by default because it presents a side channel timing attack where attacker guests can profile what other guests have pages in memory. See https://www.sentinelone.com/vulnerability-database/cve-2024-0564/ for more details. I think the considerations of turning KSM on or off are upstream of `urunc`, but I think this means we should be defaulting it to off (and not changing behaviour at all).

## Requirements

- Linux 6.4+ with `CONFIG_KSM=y`. On older kernels `prctl` returns `EINVAL`; urunc logs a warning and continues without KSM.
- Host `ksmd` must be running (`/sys/kernel/mm/ksm/run=1`) for actual merging to happen. urunc does not manage `ksmd` itself.

## Implementation notes

- The `prctl` call must happen before `vmm.PreExec`, since HVT's `PreExec` installs a seccomp filter that does not permit `prctl(PR_SET_MEMORY_MERGE)`.
- Platform split: `ksm_linux.go` / `ksm_other.go` with build tags so non-Linux builds still compile (the non-Linux stub is a no-op).

## Observed impact

Measured on a 3-node GKE cluster running 14 firecracker-backed workerd unikernels: ~90% of each firecracker's guest RAM merged once `ksmd` settled, +5.3 GiB cluster-wide RSS savings vs. the same workload without KSM.

