### PR TITLE
Fix block and ref rootfs

### DIFF
--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -30,12 +30,15 @@ import (
 
 var ErrMountpoint = errors.New("no FS is mounted in this mountpoint")
 
-// getMountInfo checks if the path (given as argument) is a mountpoint
-// looking at /proc/self/mountinfo.
-// If the path is indeed a mount point then getMountInfo stores and returns
-// the respective info in a BlockDevParams struct.
-// If the path is not a mount point (not present in /proc/self/mountinfo)
-// then getMountInfo returns an empty BlockDevParams struct and ErrMountpoint error.
+// getMountInfo determines whether the provided path is a mount point
+// by inspecting /proc/self/mountinfo.
+// If the path is a mount point, it populates and returns a BlockDevParams struct.
+// Otherwise, it returns an error along with an empty BlockDevParams.
+// Additionally, when the path is a mount point, getMountInfo verifies
+// the mount source to ensure it can use the source as a block device.
+// There are cases (e.g. bind mounts) where mounts use the same underlying
+// source device as the original mount, so they can appear identical to
+// regular mounts when inspecting mount information.
 func getMountInfo(path string) (types.BlockDevParams, error) {
 	selfProcMountInfo := "/proc/self/mountinfo"
 
@@ -45,6 +48,8 @@ func getMountInfo(path string) (types.BlockDevParams, error) {
 	}
 	defer file.Close()
 
+	blockDev := types.BlockDevParams{}
+	nonSpecialSources := make(map[string]struct{})
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {
@@ -54,29 +59,48 @@ func getMountInfo(path string) (types.BlockDevParams, error) {
 			return types.BlockDevParams{}, fmt.Errorf("invalid mountinfo line in /proc/self/mountinfo")
 		}
 
-		fields := strings.Fields(parts[0])
-		if len(fields) < 5 || fields[4] != path {
+		preDash := strings.Fields(parts[0])
+		if len(preDash) < 5 {
 			continue
 		}
-		fields = strings.Fields(parts[1])
-		if len(fields) < 2 {
+		postDash := strings.Fields(parts[1])
+		if len(postDash) < 2 {
 			continue
 		}
-		uniklog.WithFields(logrus.Fields{
-			"mounted at": path,
-			"device":     fields[1],
-			"fstype":     fields[0],
-		}).Debug("Found container rootfs mount")
+		if preDash[4] == path {
+			uniklog.WithFields(logrus.Fields{
+				"mounted at": path,
+				"device":     postDash[1],
+				"fstype":     postDash[0],
+			}).Debug("Found block device")
 
-		return types.BlockDevParams{
-			Source:     fields[1],
-			FsType:     fields[0],
-			MountPoint: path,
-			ID:         "",
-		}, nil
+			blockDev.Source = postDash[1]
+			blockDev.FsType = postDash[0]
+			blockDev.MountPoint = path
+			blockDev.ID = ""
+			continue
+		}
+		// Store the source of all mounts with non-special fs
+		// (e.g. overlay, tmpfs) in a map
+		if postDash[0] != postDash[1] {
+			nonSpecialSources[postDash[1]] = struct{}{}
+		}
 	}
 
-	return types.BlockDevParams{}, ErrMountpoint
+	if blockDev.Source == "" {
+		return types.BlockDevParams{}, ErrMountpoint
+	}
+
+	// Check if the source of the mountpoint that refers to path
+	// exists i the map with the found sources. If this is the case,
+	// then we are not dealing with a mount regarding a block device
+	// that we can attach to the sandbox.
+	_, ok := nonSpecialSources[blockDev.Source]
+	if ok {
+		return types.BlockDevParams{}, ErrMountpoint
+	}
+
+	return blockDev, nil
 }
 
 // extractUnikernelFromBlock moves unikernel binary, initrd and urunc.json

--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -147,29 +147,6 @@ func extractBootFiles(rootfsPath string, newRootfsPath string, unikernel string,
 	return nil
 }
 
-// prepareDMAsBLock copies the files needed for the unikernel boot (e.g.
-// unikernel binary, initrd file) and the urunc.json file in a new temporary
-// directory. Then it unmounts the devmapper device and renames the temporary
-// directory as the container rootfs. This is needed to keep the same paths
-// for the unikernel files.
-func extractAndUnmount(rootfsPath string, newRootfsPath string, unikernel string, uruncJSON string, initrd string) error {
-	// extract unikernel
-	// FIXME: This approach fills up /run with unikernel binaries and
-	// urunc.json files for each unikernel instance we run
-	err := extractBootFiles(rootfsPath, newRootfsPath, unikernel, uruncJSON, initrd)
-	if err != nil {
-		return err
-	}
-	// unmount block device
-	// FIXME: umount and rm might need some retries
-	err = mount.Unmount(rootfsPath)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func copyMountfiles(targetPath string, mounts []specs.Mount) error {
 	for _, m := range mounts {
 		if m.Type != "bind" {
@@ -202,38 +179,6 @@ func handleExplicitBlockImage(blockImg string, mountPoint string) (types.BlockDe
 		Source:     blockImg,
 		MountPoint: mountPoint,
 		ID:         id,
-	}, nil
-}
-
-func handleCntrRootfsAsBlock(rfs types.RootfsParams, unikernelType string, unikernelPath string, uruncJSONFilename string, initrdPath string, mounts []specs.Mount) (types.BlockDevParams, error) {
-	err := copyMountfiles(rfs.MountedPath, mounts)
-	if err != nil {
-		return types.BlockDevParams{}, err
-	}
-
-	err = extractAndUnmount(rfs.MountedPath, rfs.MonRootfs, unikernelPath, uruncJSONFilename, initrdPath)
-	if err != nil {
-		return types.BlockDevParams{}, err
-	}
-
-	err = setupDev(rfs.MonRootfs, rfs.Path)
-	if err != nil {
-		return types.BlockDevParams{}, err
-	}
-
-	mp := "/"
-	// NOTE: Rumprun does not allow us to mount
-	// anything at '/'. As a result, we use the
-	// /data mount point for Rumprun. For all the
-	// other guests we use '/'.
-	if unikernelType == "rumprun" {
-		mp = "/data"
-	}
-
-	return types.BlockDevParams{
-		Source:     rfs.Path,
-		MountPoint: mp,
-		ID:         "rootfs",
 	}, nil
 }
 

--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -30,6 +30,18 @@ import (
 
 var ErrMountpoint = errors.New("no FS is mounted in this mountpoint")
 
+type blockRootfs struct {
+	mounts        []specs.Mount
+	monRootfs     string
+	mountedPath   string
+	path          string
+	kernelPath    string
+	initrdPath    string
+	uruncJSONPath string
+	guestType     string
+	guest         types.Unikernel
+}
+
 // getMountInfo determines whether the provided path is a mount point
 // by inspecting /proc/self/mountinfo.
 // If the path is a mount point, it populates and returns a BlockDevParams struct.
@@ -107,7 +119,7 @@ func getMountInfo(path string) (types.BlockDevParams, error) {
 // files from old rootfsPath to newRootfsPath
 // FIXME: This approach fills up /run with unikernel binaries, initrds and urunc.json
 // files for each unikernel we run
-func extractFilesFromBlock(rootfsPath string, newRootfsPath string, unikernel string, uruncJSON string, initrd string) error {
+func extractBootFiles(rootfsPath string, newRootfsPath string, unikernel string, uruncJSON string, initrd string) error {
 	currentUnikernelPath := filepath.Join(rootfsPath, unikernel)
 	targetUnikernelPath := filepath.Join(newRootfsPath, unikernel)
 	targetUnikernelDir, _ := filepath.Split(targetUnikernelPath)
@@ -140,11 +152,11 @@ func extractFilesFromBlock(rootfsPath string, newRootfsPath string, unikernel st
 // directory. Then it unmounts the devmapper device and renames the temporary
 // directory as the container rootfs. This is needed to keep the same paths
 // for the unikernel files.
-func prepareDMAsBlock(rootfsPath string, newRootfsPath string, unikernel string, uruncJSON string, initrd string) error {
+func extractAndUnmount(rootfsPath string, newRootfsPath string, unikernel string, uruncJSON string, initrd string) error {
 	// extract unikernel
 	// FIXME: This approach fills up /run with unikernel binaries and
 	// urunc.json files for each unikernel instance we run
-	err := extractFilesFromBlock(rootfsPath, newRootfsPath, unikernel, uruncJSON, initrd)
+	err := extractBootFiles(rootfsPath, newRootfsPath, unikernel, uruncJSON, initrd)
 	if err != nil {
 		return err
 	}
@@ -199,7 +211,7 @@ func handleCntrRootfsAsBlock(rfs types.RootfsParams, unikernelType string, unike
 		return types.BlockDevParams{}, err
 	}
 
-	err = prepareDMAsBlock(rfs.MountedPath, rfs.MonRootfs, unikernelPath, uruncJSONFilename, initrdPath)
+	err = extractAndUnmount(rfs.MountedPath, rfs.MonRootfs, unikernelPath, uruncJSONFilename, initrdPath)
 	if err != nil {
 		return types.BlockDevParams{}, err
 	}
@@ -263,27 +275,73 @@ func getBlockVolumes(monRootfs string, mounts []specs.Mount, ukernel types.Unike
 	return blkImgs, nil
 }
 
-func handleBlockBasedRootfs(rfs types.RootfsParams, ukernel types.Unikernel, unikernelType string, unikernelPath string, uruncJSONFilename string, initrdPath string, mounts []specs.Mount) ([]types.BlockDevParams, error) {
-	var blockArgs []types.BlockDevParams
-	var rootfsBlock types.BlockDevParams
-	var err error
-	if rfs.MountedPath == "" {
-		// The Mountpoint in the annotation was "/" and hence the rootfs
-		// of the guest is a block Image inside the container's image.
-		rootfsBlock, err = handleExplicitBlockImage(rfs.Path, "/")
-	} else {
-		rootfsBlock, err = handleCntrRootfsAsBlock(rfs, unikernelType, unikernelPath, uruncJSONFilename, initrdPath, mounts)
+func (b blockRootfs) preSetup() error {
+	if b.mountedPath == "" {
+		return nil
 	}
+
+	err := copyMountfiles(b.mountedPath, b.mounts)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to copy files from mount list: %w", err)
 	}
-	rootfsBlock.ID = "rootfs"
+
+	// FIXME: This approach fills up /run with unikernel binaries and
+	// urunc.json files for each unikernel instance we run
+	err = extractBootFiles(b.mountedPath, b.monRootfs, b.kernelPath, b.uruncJSONPath, b.initrdPath)
+	if err != nil {
+		return fmt.Errorf("failed to extract boot files from rootfs: %w", err)
+	}
+
+	err = mount.Unmount(b.mountedPath)
+	if err != nil {
+		return fmt.Errorf("failed to unmount rootfs: %w", err)
+	}
+
+	return nil
+}
+
+func (b blockRootfs) postSetup() error {
+	if b.mountedPath != "" {
+		err := setupDev(b.monRootfs, b.path)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b blockRootfs) getBlockDevs() ([]types.BlockDevParams, error) {
+	var blockArgs []types.BlockDevParams
+	rootfsBlock := types.BlockDevParams{
+		Source:     b.path,
+		MountPoint: "/",
+		ID:         "rootfs",
+	}
+
+	// NOTE: Rumprun does not allow us to mount
+	// anything at '/'. As a result, we use the
+	// /data mount point for Rumprun. For all the
+	// other guests we use '/'.
+	if b.guestType == "rumprun" {
+		rootfsBlock.MountPoint = "/data"
+	}
+
 	blockArgs = append(blockArgs, rootfsBlock)
-	blockFromMounts, err := getBlockVolumes(rfs.MonRootfs, mounts, ukernel)
+	blockFromMounts, err := getBlockVolumes(b.monRootfs, b.mounts, b.guest)
 	if err != nil {
 		return nil, err
 	}
 	blockArgs = append(blockArgs, blockFromMounts...)
 
 	return blockArgs, nil
+}
+
+// TODO: Return an array instead of a single struct
+func (b blockRootfs) getSharedDirs() (types.SharedfsParams, error) {
+	return types.SharedfsParams{}, nil
+}
+
+func (b blockRootfs) preStart() error {
+	return nil
 }

--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -22,11 +22,16 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/moby/sys/mount"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
+
+// TODO: Find and set the correct size for the tmpfs in the host
+const tmpfsSizeForBlockRootfs = "65536k"
 
 var ErrMountpoint = errors.New("no FS is mounted in this mountpoint")
 
@@ -253,7 +258,14 @@ func (b blockRootfs) postSetup() error {
 		}
 	}
 
-	return nil
+	err := createTmpfs(b.monRootfs, "/tmp",
+		unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_STRICTATIME,
+		"1777", tmpfsSizeForBlockRootfs)
+	if err != nil {
+		err = fmt.Errorf("failed to create tmpfs for monitor's execution environment: %w", err)
+	}
+
+	return err
 }
 
 func (b blockRootfs) getBlockDevs() ([]types.BlockDevParams, error) {

--- a/pkg/unikontainers/initrd_rootfs.go
+++ b/pkg/unikontainers/initrd_rootfs.go
@@ -17,13 +17,19 @@ package unikontainers
 import (
 	"fmt"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/initrd"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
+// TODO: Find and set the correct size for the tmpfs in the host
+const tmpfsSizeForInitrdRootfs = "65536k"
+
 type initrdRootfs struct {
 	mounts             []specs.Mount
+	monRootfs          string
 	initrdHostFullPath string
 }
 
@@ -34,7 +40,14 @@ func (i initrdRootfs) preSetup() error {
 func (i initrdRootfs) postSetup() error {
 	err := initrd.CopyFileMountsToInitrd(i.initrdHostFullPath, i.mounts)
 	if err != nil {
-		err = fmt.Errorf("failed to update guest's initrd: %w", err)
+		return fmt.Errorf("failed to update guest's initrd: %w", err)
+	}
+
+	err = createTmpfs(i.monRootfs, "/tmp",
+		unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_STRICTATIME,
+		"1777", tmpfsSizeForInitrdRootfs)
+	if err != nil {
+		err = fmt.Errorf("failed to create tmpfs for monitor's execution environment: %w", err)
 	}
 
 	return err

--- a/pkg/unikontainers/initrd_rootfs.go
+++ b/pkg/unikontainers/initrd_rootfs.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikontainers
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/initrd"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+type initrdRootfs struct {
+	mounts             []specs.Mount
+	initrdHostFullPath string
+}
+
+func (i initrdRootfs) preSetup() error {
+	return nil
+}
+
+func (i initrdRootfs) postSetup() error {
+	err := initrd.CopyFileMountsToInitrd(i.initrdHostFullPath, i.mounts)
+	if err != nil {
+		err = fmt.Errorf("failed to update guest's initrd: %w", err)
+	}
+
+	return err
+}
+
+func (i initrdRootfs) getBlockDevs() ([]types.BlockDevParams, error) {
+	return nil, nil
+}
+
+// TODO: Return an array instead of a single struct
+func (i initrdRootfs) getSharedDirs() (types.SharedfsParams, error) {
+	return types.SharedfsParams{}, nil
+}
+
+func (i initrdRootfs) preStart() error {
+	return nil
+}

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -25,6 +25,14 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
+type rootfsBuilder interface {
+	preSetup() error
+	postSetup() error
+	getBlockDevs() ([]types.BlockDevParams, error)
+	getSharedDirs() (types.SharedfsParams, error)
+	preStart() error
+}
+
 // rootfsSelector encapsulates the context for rootfs selection
 type rootfsSelector struct {
 	bundle     string
@@ -36,7 +44,9 @@ type rootfsSelector struct {
 }
 
 type noRootfs struct {
-	monRootfs string
+	monRootfs            string
+	annotBlockPath       string
+	annotBlockMountPoint string
 }
 
 func (n noRootfs) preSetup() error {
@@ -48,7 +58,21 @@ func (n noRootfs) postSetup() error {
 }
 
 func (n noRootfs) getBlockDevs() ([]types.BlockDevParams, error) {
-	return nil, nil
+	blkImgs := []types.BlockDevParams{}
+	blockFromAnnot, err := handleExplicitBlockImage(n.annotBlockPath,
+		n.annotBlockMountPoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if blockFromAnnot.Source != "" && blockFromAnnot.MountPoint != "/" {
+		// TODO: Add proper support for multiple block Images from the container's
+		// image. This requires adding more annotations too.
+		blockFromAnnot.ID = "annot_vol"
+		blkImgs = append(blkImgs, blockFromAnnot)
+	}
+
+	return blkImgs, nil
 }
 
 // TODO: Return an array instead of a single struct

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -35,6 +35,31 @@ type rootfsSelector struct {
 	vfsdPath   string
 }
 
+type noRootfs struct {
+	monRootfs string
+}
+
+func (n noRootfs) preSetup() error {
+	return nil
+}
+
+func (n noRootfs) postSetup() error {
+	return nil
+}
+
+func (n noRootfs) getBlockDevs() ([]types.BlockDevParams, error) {
+	return nil, nil
+}
+
+// TODO: Return an array instead of a single struct
+func (n noRootfs) getSharedDirs() (types.SharedfsParams, error) {
+	return types.SharedfsParams{}, nil
+}
+
+func (n noRootfs) preStart() error {
+	return nil
+}
+
 // newRootfsResult creates a RootfsParams with common defaults
 func newRootfsResult(rootfsType string, path string, mountedPath string, monRootfs string) types.RootfsParams {
 	return types.RootfsParams{

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -187,53 +187,6 @@ func switchMonRootfs(res types.RootfsParams, bundle string) (types.RootfsParams,
 	return res, nil
 }
 
-// chooseRootfs determines the best rootfs configuration based on available options
-// Priority order:
-//  1. Initrd (if specified)
-//  2. Explicit block device annotation (if mounted at /)
-//  3. Container rootfs as block device (if MountRootfs=true and supported)
-//  4. Container rootfs as shared-fs: virtiofs > 9pfs (if MountRootfs=true and supported)
-//  5. No rootfs
-func chooseRootfs(bundle string, cntrRootfs string, annot map[string]string,
-	unikernel types.Unikernel, vmm types.VMM, vfsdPath string) (types.RootfsParams, error) {
-
-	selector := &rootfsSelector{
-		bundle:     bundle,
-		cntrRootfs: cntrRootfs,
-		annot:      annot,
-		unikernel:  unikernel,
-		vmm:        vmm,
-		vfsdPath:   vfsdPath,
-	}
-
-	// Priority 1: Initrd
-	result, ok := selector.tryInitrd()
-	if ok {
-		return result, nil
-	}
-
-	// Priority 2: Explicit block annotation
-	result, ok = selector.tryExplicitBlock()
-	if ok {
-		return result, nil
-	}
-
-	// Priority 3 & 4: Container rootfs (block or shared-fs)
-	result, ok = selector.tryContainerRootfs()
-	if ok {
-		return switchMonRootfs(result, bundle)
-	}
-
-	if selector.shouldMountContainerRootfs() {
-		return types.RootfsParams{}, fmt.Errorf("can not use the container rootfs as the sandbox's guest rootfs through block or shared-fs")
-	}
-
-	uniklog.Info("no rootfs configured for guest")
-	result.MonRootfs = cntrRootfs
-	return result, nil
-
-}
-
 // pivotRootfs changes rootfs with pivot
 // It should be called with CWD being the new rootfs
 func pivotRootfs(newRoot string) error {

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -25,6 +25,9 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
+// TODO: Find and set the correct size for the tmpfs in the host
+const tmpfsSizeForNoRootfs = "65536k"
+
 type rootfsBuilder interface {
 	preSetup() error
 	postSetup() error
@@ -54,7 +57,14 @@ func (n noRootfs) preSetup() error {
 }
 
 func (n noRootfs) postSetup() error {
-	return nil
+	err := createTmpfs(n.monRootfs, "/tmp",
+		unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_STRICTATIME,
+		"1777", tmpfsSizeForNoRootfs)
+	if err != nil {
+		err = fmt.Errorf("failed to create tmpfs for monitor's execution environment: %w", err)
+	}
+
+	return err
 }
 
 func (n noRootfs) getBlockDevs() ([]types.BlockDevParams, error) {

--- a/pkg/unikontainers/shared_fs.go
+++ b/pkg/unikontainers/shared_fs.go
@@ -26,6 +26,9 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
+// TODO: Find and set the correct size for the tmpfs in the host
+const tmpfsSizeFor9pfsRootfs = "65536k"
+
 type sharedfsRootfs struct {
 	mounts      []specs.Mount
 	vfsdConfig  types.ExtraBinConfig
@@ -33,6 +36,7 @@ type sharedfsRootfs struct {
 	monRootfs   string
 	mountedPath string
 	sfsType     string
+	memory      uint64
 }
 
 func (s sharedfsRootfs) preSetup() error {
@@ -60,7 +64,15 @@ func (s sharedfsRootfs) postSetup() error {
 		}
 	}
 
-	return nil
+	tmpfsSize := chooseTmpfsSize(s.sfsType, s.memory)
+	err = createTmpfs(s.monRootfs, "/tmp",
+		unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_STRICTATIME,
+		"1777", tmpfsSize)
+	if err != nil {
+		err = fmt.Errorf("failed to create tmpfs for monitor's execution environment: %w", err)
+	}
+
+	return err
 }
 
 func (s sharedfsRootfs) getBlockDevs() ([]types.BlockDevParams, error) {
@@ -96,7 +108,11 @@ func (s sharedfsRootfs) preStart() error {
 	return err
 }
 
-func chooseTmpfsSize(mem uint64) string {
+func chooseTmpfsSize(sfsType string, mem uint64) string {
+	if sfsType == "9pfs" {
+		return tmpfsSizeFor9pfsRootfs
+	}
+
 	// For virtiofs, Qemu and virtiofsd are using a host file
 	// to share the VM's RAM and hence the size of this file
 	// should be the same as guest's memory. This file will

--- a/pkg/unikontainers/shared_fs.go
+++ b/pkg/unikontainers/shared_fs.go
@@ -17,6 +17,7 @@ package unikontainers
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/unix"
 
@@ -27,7 +28,8 @@ import (
 
 type sharedfsRootfs struct {
 	mounts      []specs.Mount
-	vfsPath     string
+	vfsdConfig  types.ExtraBinConfig
+	sharedPath  string
 	monRootfs   string
 	mountedPath string
 	sfsType     string
@@ -52,9 +54,9 @@ func (s sharedfsRootfs) postSetup() error {
 
 	if s.sfsType == "virtiofs" {
 		// Get the virtiofsd binary from host in monRootfs
-		err = fileFromHost(s.monRootfs, s.vfsPath, "", unix.MS_BIND|unix.MS_PRIVATE, false)
+		err = fileFromHost(s.monRootfs, s.vfsdConfig.Path, "", unix.MS_BIND|unix.MS_PRIVATE, false)
 		if err != nil {
-			return fmt.Errorf("Could not bind mount %s: %w", s.vfsPath, err)
+			return fmt.Errorf("Could not bind mount %s: %w", s.vfsdConfig.Path, err)
 		}
 	}
 
@@ -73,7 +75,25 @@ func (s sharedfsRootfs) getSharedDirs() (types.SharedfsParams, error) {
 }
 
 func (s sharedfsRootfs) preStart() error {
-	return nil
+	if s.sfsType == "9pfs" {
+		return nil
+	}
+	// Start the virtiofsd process
+	args := []string{
+		"--socket-path=/tmp/vhostqemu",
+		"--shared-dir",
+		s.sharedPath,
+	}
+
+	if s.vfsdConfig.Options != "" {
+		args = append(args, strings.Fields(s.vfsdConfig.Options)...)
+	}
+
+	err := spawnProcess(s.vfsdConfig.Path, args)
+	if err != nil {
+		err = fmt.Errorf("failed to start virtiofsd: %w", err)
+	}
+	return err
 }
 
 func chooseTmpfsSize(mem uint64) string {

--- a/pkg/unikontainers/shared_fs.go
+++ b/pkg/unikontainers/shared_fs.go
@@ -25,6 +25,57 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
+type sharedfsRootfs struct {
+	mounts      []specs.Mount
+	vfsPath     string
+	monRootfs   string
+	mountedPath string
+	sfsType     string
+}
+
+func (s sharedfsRootfs) preSetup() error {
+	return nil
+}
+
+func (s sharedfsRootfs) postSetup() error {
+	// Mount the container's rootfs inside the monitor rootfs
+	err := fileFromHost(s.monRootfs, s.mountedPath, containerRootfsMountPath, unix.MS_BIND|unix.MS_PRIVATE, false)
+	if err != nil {
+		return fmt.Errorf("failed to mount container's rootfs in monitor rootfs; %w", err)
+	}
+
+	newCntrRootfs := filepath.Join(s.monRootfs, containerRootfsMountPath)
+	err = mountVolumes(newCntrRootfs, s.mounts)
+	if err != nil {
+		return fmt.Errorf("failed to mount volumes in container's rootfs; %w", err)
+	}
+
+	if s.sfsType == "virtiofs" {
+		// Get the virtiofsd binary from host in monRootfs
+		err = fileFromHost(s.monRootfs, s.vfsPath, "", unix.MS_BIND|unix.MS_PRIVATE, false)
+		if err != nil {
+			return fmt.Errorf("Could not bind mount %s: %w", s.vfsPath, err)
+		}
+	}
+
+	return nil
+}
+
+func (s sharedfsRootfs) getBlockDevs() ([]types.BlockDevParams, error) {
+	return nil, nil
+}
+
+func (s sharedfsRootfs) getSharedDirs() (types.SharedfsParams, error) {
+	return types.SharedfsParams{
+		Path: containerRootfsMountPath,
+		Type: s.sfsType,
+	}, nil
+}
+
+func (s sharedfsRootfs) preStart() error {
+	return nil
+}
+
 func chooseTmpfsSize(mem uint64) string {
 	// For virtiofs, Qemu and virtiofsd are using a host file
 	// to share the VM's RAM and hence the size of this file
@@ -37,30 +88,6 @@ func chooseTmpfsSize(mem uint64) string {
 	tmpMountMemStr := hypervisors.BytesToStringMB(tmpMountMem) + "m"
 
 	return tmpMountMemStr
-}
-
-func setupSharedfsBasedRootfs(rfs types.RootfsParams, vfsdBin string, mounts []specs.Mount) error {
-	// Mount the container's image rootfs inside the monitor rootfs
-	err := fileFromHost(rfs.MonRootfs, rfs.MountedPath, containerRootfsMountPath, unix.MS_BIND|unix.MS_PRIVATE, false)
-	if err != nil {
-		return err
-	}
-
-	newCntrRootfs := filepath.Join(rfs.MonRootfs, containerRootfsMountPath)
-	err = mountVolumes(newCntrRootfs, mounts)
-	if err != nil {
-		return err
-	}
-
-	if rfs.Type == "virtiofs" {
-		// Get the virtiofsd binary from host in monRootfs
-		err = fileFromHost(rfs.MonRootfs, vfsdBin, "", unix.MS_BIND|unix.MS_PRIVATE, false)
-		if err != nil {
-			return fmt.Errorf("Could not bind mount %s: %w", vfsdBin, err)
-		}
-	}
-
-	return nil
 }
 
 // adjustPathsForSharedFS updates paths to be relative to container rootfs mount

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -402,6 +402,25 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
+	if rootfsParams.Type == "block" {
+		bRootfs := blockRootfs{
+			mounts:        u.Spec.Mounts,
+			monRootfs:     rootfsParams.MonRootfs,
+			mountedPath:   rootfsParams.MountedPath,
+			path:          rootfsParams.Path,
+			kernelPath:    unikernelPath,
+			initrdPath:    initrdPath,
+			uruncJSONPath: uruncJSONFilename,
+			guestType:     unikernelType,
+			guest:         unikernel,
+		}
+
+		err = bRootfs.preSetup()
+		if err != nil {
+			return fmt.Errorf("failed to perapre block based rootfs: %w", err)
+		}
+	}
+
 	// Prepare Monitor rootfs
 	// Make sure that rootfs is mounted with the correct propagation
 	// flags so we can later pivot if needed.
@@ -426,10 +445,26 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	tmpfsSize := "65536k"
 	switch rootfsParams.Type {
 	case "block":
-		blockArgs, err = handleBlockBasedRootfs(rootfsParams, unikernel, unikernelType, unikernelPath, uruncJSONFilename, initrdPath, u.Spec.Mounts)
+		bRootfs := blockRootfs{
+			mounts:        u.Spec.Mounts,
+			monRootfs:     rootfsParams.MonRootfs,
+			mountedPath:   rootfsParams.MountedPath,
+			path:          rootfsParams.Path,
+			kernelPath:    unikernelPath,
+			initrdPath:    initrdPath,
+			uruncJSONPath: uruncJSONFilename,
+			guestType:     unikernelType,
+			guest:         unikernel,
+		}
+
+		err = bRootfs.postSetup()
 		if err != nil {
-			uniklog.Errorf("could not setup block based rootfs: %v", err)
-			return err
+			return fmt.Errorf("post setup step for block based rootfs failed: %w", err)
+		}
+
+		blockArgs, err = bRootfs.getBlockDevs()
+		if err != nil {
+			return fmt.Errorf("failed to get block devices to attach in sandbox: %w", err)
 		}
 	case "initrd":
 		initrdHostFullPath := filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -401,8 +401,16 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	if rootfsParams.Type == "block" {
-		bRootfs := blockRootfs{
+	// TODO: Add support for using both an existing
+	// block based snapshot of the container's rootfs
+	// and an auxiliary block image placed in the container's image
+	// Currently if a block Image is present in the container's image, then
+	// we will just use this image.
+	var rfsBuilder rootfsBuilder
+	tmpfsSize := "65536k"
+	switch rootfsParams.Type {
+	case "block":
+		rfsBuilder = blockRootfs{
 			mounts:        u.Spec.Mounts,
 			monRootfs:     rootfsParams.MonRootfs,
 			mountedPath:   rootfsParams.MountedPath,
@@ -413,11 +421,38 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 			guestType:     unikernelType,
 			guest:         unikernel,
 		}
-
-		err = bRootfs.preSetup()
-		if err != nil {
-			return fmt.Errorf("failed to perapre block based rootfs: %w", err)
+	case "initrd":
+		rfsBuilder = initrdRootfs{
+			mounts:             u.Spec.Mounts,
+			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
 		}
+	case "virtiofs":
+		tmpfsSize = chooseTmpfsSize(vmmArgs.MemSizeB)
+		fallthrough
+	case "9pfs":
+		rfsBuilder = sharedfsRootfs{
+			mounts:      u.Spec.Mounts,
+			monRootfs:   rootfsParams.MonRootfs,
+			mountedPath: rootfsParams.MountedPath,
+			sfsType:     rootfsParams.Type,
+			vfsdConfig:  virtiofsdConfig,
+			sharedPath:  containerRootfsMountPath,
+		}
+		// Update the paths of the files we need to pass in the monitor process.
+		vmmArgs.UnikernelPath = adjustPathsForSharedfs(vmmArgs.UnikernelPath)
+		vmmArgs.InitrdPath = adjustPathsForSharedfs(vmmArgs.InitrdPath)
+	default:
+		uniklog.Debug("No rootfs for guest")
+		rfsBuilder = noRootfs{
+			monRootfs:            rootfsParams.MonRootfs,
+			annotBlockPath:       u.State.Annotations[annotBlock],
+			annotBlockMountPoint: u.State.Annotations[annotBlockMntPoint],
+		}
+	}
+
+	err = rfsBuilder.preSetup()
+	if err != nil {
+		return fmt.Errorf("pre setup step for rootfs failed: %w", err)
 	}
 
 	// Prepare Monitor rootfs
@@ -434,76 +469,23 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	if err != nil {
 		return err
 	}
-	// TODO: Add support for using both an existing
-	// block based snapshot of the container's rootfs
-	// and an auxiliary block image placed in the container's image
-	// Currently if a block Image is present in the container's image, then
-	// we will just use this image.
-	blockArgs := []types.BlockDevParams{}
-	sharedfsArgs := types.SharedfsParams{}
-	tmpfsSize := "65536k"
-	switch rootfsParams.Type {
-	case "block":
-		bRootfs := blockRootfs{
-			mounts:        u.Spec.Mounts,
-			monRootfs:     rootfsParams.MonRootfs,
-			mountedPath:   rootfsParams.MountedPath,
-			path:          rootfsParams.Path,
-			kernelPath:    unikernelPath,
-			initrdPath:    initrdPath,
-			uruncJSONPath: uruncJSONFilename,
-			guestType:     unikernelType,
-			guest:         unikernel,
-		}
 
-		err = bRootfs.postSetup()
-		if err != nil {
-			return fmt.Errorf("post setup step for block based rootfs failed: %w", err)
-		}
-
-		blockArgs, err = bRootfs.getBlockDevs()
-		if err != nil {
-			return fmt.Errorf("failed to get block devices to attach in sandbox: %w", err)
-		}
-	case "initrd":
-		iRootfs := initrdRootfs{
-			mounts:             u.Spec.Mounts,
-			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
-		}
-
-		err = iRootfs.postSetup()
-		if err != nil {
-			uniklog.Errorf("cpost setup step of initrd based rootfs failed: %v", err)
-			return err
-		}
-	case "virtiofs":
-		tmpfsSize = chooseTmpfsSize(vmmArgs.MemSizeB)
-		fallthrough
-	case "9pfs":
-		sRootfs := sharedfsRootfs{
-			mounts:      u.Spec.Mounts,
-			monRootfs:   rootfsParams.MonRootfs,
-			mountedPath: rootfsParams.MountedPath,
-			sfsType:     rootfsParams.Type,
-			vfsPath:     virtiofsdConfig.Path,
-		}
-
-		err = sRootfs.postSetup()
-		if err != nil {
-			uniklog.Errorf("cpost setup step of shared-fs based rootfs failed: %v", err)
-			return err
-		}
-		// Update the paths of the files we need to pass in the monitor process.
-		vmmArgs.UnikernelPath = adjustPathsForSharedfs(vmmArgs.UnikernelPath)
-		vmmArgs.InitrdPath = adjustPathsForSharedfs(vmmArgs.InitrdPath)
-		sharedfsArgs, err = sRootfs.getSharedDirs()
-		if err != nil {
-			uniklog.Errorf("failed to get directories to share with sandbox: %v", err)
-			return err
-		}
-	default:
-		uniklog.Debug("No rootfs for guest")
+	err = rfsBuilder.postSetup()
+	if err != nil {
+		return fmt.Errorf("post setup step for block based rootfs failed: %w", err)
 	}
+
+	blockArgs, err := rfsBuilder.getBlockDevs()
+	if err != nil {
+		return fmt.Errorf("failed to get block devices to attach in sandbox: %w", err)
+	}
+
+	sharedfsArgs, err := rfsBuilder.getSharedDirs()
+	if err != nil {
+		uniklog.Errorf("failed to get directories to share with sandbox: %v", err)
+		return err
+	}
+
 	unikernelParams.Rootfs = rootfsParams
 
 	err = createTmpfs(rootfsParams.MonRootfs, "/tmp",
@@ -513,18 +495,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 	metrics.Capture(m.TS17)
-
-	blockFromAnnot, err := handleExplicitBlockImage(u.State.Annotations[annotBlock],
-		u.State.Annotations[annotBlockMntPoint])
-	if err != nil {
-		return err
-	}
-	if blockFromAnnot.Source != "" && blockFromAnnot.MountPoint != "/" {
-		// TODO: Add proper support for multiple block Images from the container's
-		// image. This requires adding more annotations too.
-		blockFromAnnot.ID = "annot_vol"
-		blockArgs = append(blockArgs, blockFromAnnot)
-	}
 
 	// unikernelParams
 	unikernelParams.Block = blockArgs
@@ -607,13 +577,9 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	// virtiofs
-	if rootfsParams.Type == "virtiofs" {
-		// Start the virtiofsd process
-		err = spawnVirtiofsd(virtiofsdConfig, containerRootfsMountPath)
-		if err != nil {
-			return err
-		}
+	err = rfsBuilder.preStart()
+	if err != nil {
+		return err
 	}
 
 	uniklog.Debug("calling vmm execve")

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -407,7 +407,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// Currently if a block Image is present in the container's image, then
 	// we will just use this image.
 	var rfsBuilder rootfsBuilder
-	tmpfsSize := "65536k"
 	switch rootfsParams.Type {
 	case "block":
 		rfsBuilder = blockRootfs{
@@ -425,11 +424,9 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		rfsBuilder = initrdRootfs{
 			mounts:             u.Spec.Mounts,
 			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
+			monRootfs:          rootfsParams.MonRootfs,
 		}
-	case "virtiofs":
-		tmpfsSize = chooseTmpfsSize(vmmArgs.MemSizeB)
-		fallthrough
-	case "9pfs":
+	case "virtiofs", "9pfs":
 		rfsBuilder = sharedfsRootfs{
 			mounts:      u.Spec.Mounts,
 			monRootfs:   rootfsParams.MonRootfs,
@@ -437,6 +434,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 			sfsType:     rootfsParams.Type,
 			vfsdConfig:  virtiofsdConfig,
 			sharedPath:  containerRootfsMountPath,
+			memory:      vmmArgs.MemSizeB,
 		}
 		// Update the paths of the files we need to pass in the monitor process.
 		vmmArgs.UnikernelPath = adjustPathsForSharedfs(vmmArgs.UnikernelPath)
@@ -488,12 +486,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	unikernelParams.Rootfs = rootfsParams
 
-	err = createTmpfs(rootfsParams.MonRootfs, "/tmp",
-		unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_STRICTATIME,
-		"1777", tmpfsSize)
-	if err != nil {
-		return err
-	}
 	metrics.Capture(m.TS17)
 
 	// unikernelParams

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/urunc-dev/urunc/pkg/network"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/hypervisors"
-	"github.com/urunc-dev/urunc/pkg/unikontainers/initrd"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 	"github.com/vishvananda/netlink/nl"
@@ -467,10 +466,14 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 			return fmt.Errorf("failed to get block devices to attach in sandbox: %w", err)
 		}
 	case "initrd":
-		initrdHostFullPath := filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path)
-		err = initrd.CopyFileMountsToInitrd(initrdHostFullPath, u.Spec.Mounts)
+		iRootfs := initrdRootfs{
+			mounts:             u.Spec.Mounts,
+			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
+		}
+
+		err = iRootfs.postSetup()
 		if err != nil {
-			uniklog.Errorf("could not update guest's initrd: %v", err)
+			uniklog.Errorf("cpost setup step of initrd based rootfs failed: %v", err)
 			return err
 		}
 	case "virtiofs":

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -201,6 +201,73 @@ func (u *Unikontainer) SetupNet() (types.NetDevParams, error) {
 	return netArgs, nil
 }
 
+// chooseRootfs determines the best rootfs configuration based on available options
+// Priority order:
+//  1. Initrd (if specified)
+//  2. Explicit block device annotation (if mounted at /)
+//  3. Container rootfs as block device (if MountRootfs=true and supported)
+//  4. Container rootfs as shared-fs: virtiofs > 9pfs (if MountRootfs=true and supported)
+//  5. No rootfs
+func (u *Unikontainer) chooseRootfs() (types.RootfsParams, error) {
+	bundleDir := filepath.Clean(u.State.Bundle)
+	rootfsDir := filepath.Clean(u.Spec.Root.Path)
+	rootfsDir, err := resolveAgainstBase(bundleDir, rootfsDir)
+	if err != nil {
+		uniklog.Errorf("could not resolve rootfs directory %s: %v", rootfsDir, err)
+		return types.RootfsParams{}, err
+	}
+
+	unikernelType := u.State.Annotations[annotType]
+	unikernel, err := unikernels.New(unikernelType)
+	if err != nil {
+		return types.RootfsParams{}, err
+	}
+
+	vmmType := u.State.Annotations[annotHypervisor]
+	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
+	if err != nil {
+		return types.RootfsParams{}, err
+	}
+
+	virtiofsdConfig := u.UruncCfg.ExtraBins["virtiofsd"]
+
+	selector := &rootfsSelector{
+		bundle:     bundleDir,
+		cntrRootfs: rootfsDir,
+		annot:      u.State.Annotations,
+		unikernel:  unikernel,
+		vmm:        vmm,
+		vfsdPath:   virtiofsdConfig.Path,
+	}
+
+	// Priority 1: Initrd
+	result, ok := selector.tryInitrd()
+	if ok {
+		return result, nil
+	}
+
+	// Priority 2: Explicit block annotation
+	result, ok = selector.tryExplicitBlock()
+	if ok {
+		return result, nil
+	}
+
+	// Priority 3 & 4: Container rootfs (block or shared-fs)
+	result, ok = selector.tryContainerRootfs()
+	if ok {
+		return switchMonRootfs(result, bundleDir)
+	}
+
+	if selector.shouldMountContainerRootfs() {
+		return types.RootfsParams{}, fmt.Errorf("can not use the container rootfs as the sandbox's guest rootfs through block or shared-fs")
+	}
+
+	uniklog.Info("no rootfs configured for guest")
+	result.MonRootfs = rootfsDir
+
+	return result, nil
+}
+
 // nolint:gocyclo
 func (u *Unikontainer) Exec(metrics m.Writer) error {
 	metrics.Capture(m.TS15)
@@ -329,7 +396,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// if the respective annotation is set then, depending on the guest
 	// (supports block or 9pfs), it will use the supported option. In case
 	// both ae supported, then the block option will be used by default.
-	rootfsParams, err := chooseRootfs(bundleDir, rootfsDir, u.State.Annotations, unikernel, vmm, virtiofsdConfig.Path)
+	rootfsParams, err := u.chooseRootfs()
 	if err != nil {
 		uniklog.Errorf("could not choose guest rootfs: %v", err)
 		return err

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -480,15 +480,27 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		tmpfsSize = chooseTmpfsSize(vmmArgs.MemSizeB)
 		fallthrough
 	case "9pfs":
-		err = setupSharedfsBasedRootfs(rootfsParams, virtiofsdConfig.Path, u.Spec.Mounts)
+		sRootfs := sharedfsRootfs{
+			mounts:      u.Spec.Mounts,
+			monRootfs:   rootfsParams.MonRootfs,
+			mountedPath: rootfsParams.MountedPath,
+			sfsType:     rootfsParams.Type,
+			vfsPath:     virtiofsdConfig.Path,
+		}
+
+		err = sRootfs.postSetup()
 		if err != nil {
+			uniklog.Errorf("cpost setup step of shared-fs based rootfs failed: %v", err)
 			return err
 		}
 		// Update the paths of the files we need to pass in the monitor process.
 		vmmArgs.UnikernelPath = adjustPathsForSharedfs(vmmArgs.UnikernelPath)
 		vmmArgs.InitrdPath = adjustPathsForSharedfs(vmmArgs.InitrdPath)
-		sharedfsArgs.Path = containerRootfsMountPath
-		sharedfsArgs.Type = rootfsParams.Type
+		sharedfsArgs, err = sRootfs.getSharedDirs()
+		if err != nil {
+			uniklog.Errorf("failed to get directories to share with sandbox: %v", err)
+			return err
+		}
 	default:
 		uniklog.Debug("No rootfs for guest")
 	}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -136,9 +136,33 @@ func Get(containerID string, rootDir string) (*Unikontainer, error) {
 // creates the Unikernel base directory and
 // saves the state.json file with the current Unikernel state
 func (u *Unikontainer) InitialSetup() error {
+	bundleDir := filepath.Clean(u.State.Bundle)
+	rootfsDir := filepath.Clean(u.Spec.Root.Path)
+	rootfsDir, err := resolveAgainstBase(bundleDir, rootfsDir)
+	if err != nil {
+		uniklog.Errorf("could not resolve rootfs directory %s: %v", rootfsDir, err)
+		return err
+	}
+
+	// Ensure the container's rootfs has the correct propagation flag
+	// so if we unmount it later, it gets unmounted from other mount peer
+	// groups too. We do that regardless of the type of the container's
+	// rootfs (e.g. block-based, overlay) abd this is ok, because we later
+	// cut off all propagation from reexec.
+	// TODO: Move this to the shim, when we finally make it.
+	err = unix.Mount("", rootfsDir, "", unix.MS_SHARED|unix.MS_REC, "")
+	if err != nil && !errors.Is(err, unix.EINVAL) {
+		// An EINVAL error is fine, because it means that the
+		// rootfs is not really a mountpoint. This could be the case when
+		// using urunc directly from its cli and the rootfs is a normal
+		// directory
+		uniklog.Errorf("could not set propagation flag as shared for container's rootfs: %v", err)
+		return err
+	}
+
 	u.State.Status = specs.StateCreating
 	// FIXME: should we really create this base dir
-	err := os.MkdirAll(u.BaseDir, 0o755)
+	err = os.MkdirAll(u.BaseDir, 0o755)
 	if err != nil {
 		return err
 	}

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urunc-dev/urunc/internal/constants"
-	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
 const (
@@ -204,19 +203,8 @@ func convertUint32ToIntSlice(valSlice []uint32, size int) []int {
 // 	return data.Bytes(), nil
 // }
 
-func spawnVirtiofsd(vfsdConf types.ExtraBinConfig, sharedPath string) error {
-	args := []string{
-		"--socket-path=/tmp/vhostqemu",
-		"--shared-dir",
-		sharedPath,
-	}
-
-	if vfsdConf.Options != "" {
-		args = append(args, strings.Fields(vfsdConf.Options)...)
-	}
-
-	// #nosec G204 -- virtiofsd path and options come from the urunc configuration, which is considered trusted
-	cmd := exec.Command(vfsdConf.Path, args...)
+func spawnProcess(binaryPath string, args []string) error {
+	cmd := exec.Command(binaryPath, args...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Description

This PR takes care of various bugs we had with the handling of the rootfs, but all related to the related issue below.  The main problem was that when the `reexec` process was unmounting the block-based snapshot which was mounted as the container;s rootfs in the host, the unmounting was not propagating to the other mount namespaces (especially the initial one where the mounting of the snapshot was taking place).

The thing is that usually the container;s rootfs in the host is mounted with `MS_SHARED` propagation flag. Therefore all mount / unmount events taking place in subsequent mount namespaces (or peer mount groups) should also propagate. In simple words the unmount in `reexec` **should** propagate, except if something was cutting of the propagation.

Well, indeed something was cutting off the propagation (See https://github.com/urunc-dev/urunc/blob/main/pkg/unikontainers/unikontainers.go#L341). As part of preparing the rootfs for the execution environment of the sandbox monitor, we had to set the propagation flags according to the spec we received for the new mount namespace and make sure that the parent of the monitor's  rootfs in the host will be `MS_PRIVATE`. This is necessary for pivot to work.

All the above are necessary steps, but they cut off the mount propagation of mounts and when we perform the unmount later in https://github.com/urunc-dev/urunc/blob/main/pkg/unikontainers/unikontainers.go#L362 the unmount will never propagate. Subsequently the solution is simple: make sure the rootfs of the monitor process in the host does have `MS_SHARED` as propagation flag and unmount before cutting off the mount propagation.

Furthermore, to avoid any further surprises with block based mounts and rootfs, a simple check is added in `getMountInfo` to always exclude mount sources which appear more than once in `/proc/self/mountinfo`.

Due to the high cognitive complexity of Exec a quick fix would add extra complexity as shown in the 3rd commit. Since we are already planning to perform a major refactor for Exec and unikontainers, I brought parts of this refactor in this PR, in order to help with the further refactoring later.

At last, there was a bug in checking for a specific namespace since `findNS` was also checking for the path of the namespace in `/proc` and hence failing for new namespaces that the runtime needs to create. As a result, when we had to create a mount namespace we were not pivoting but chroot.


### Related issues

- Fixes https://github.com/urunc-dev/urunc/issues/562

### How was this tested?

With the end-to-end tests and to make sure the unmounting propagates, after running a `urunc` container which can accept a block-based device as the sandbox's rootfs the `mount` command should not show this block image mounted.

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
