### PR TITLE
docs: add code copy button for code blocks with no output

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -86,3 +86,6 @@ users:
   kaizakin:
     name: Karthik Balasubramanian
     email: karthikbalasubramanian08@gmail.com
+  MUFFANUJ:
+    name: Anuj Kumar Singh
+    email: anujsinghhero292@gmail.com

--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -89,3 +89,6 @@ users:
   MUFFANUJ:
     name: Anuj Kumar Singh
     email: anujsinghhero292@gmail.com
+  neo-0007:
+    name: Hrishikesh Gohain
+    email: hrishikeshgohain123@gmail.com

--- a/docs/assets/stylesheets/theme.css
+++ b/docs/assets/stylesheets/theme.css
@@ -6,14 +6,14 @@
    Light Theme: urunc
    ======================= */
 [data-md-color-scheme="urunc"] {
-  --md-primary-fg-color: #FAFAFF;
+  --md-primary-fg-color: #fafaff;
   --md-primary-fg-color--light: #001524;
   --md-primary-fg-color--dark: #001524;
   --md-primary-bg-color: #001524;
   --md-primary-bg-color--light: #001524;
   --md-primary-bg-color--dark: #001524;
 
-  --md-accent-fg-color: #FF7D00;
+  --md-accent-fg-color: #ff7d00;
   --md-accent-fg-color--transparent: hsla(32, 100%, 55%, 0.1);
 
   --md-footer-logo-dark-mode: none;
@@ -29,7 +29,7 @@
   --md-primary-fg-color--dark: #001524;
   --md-primary-bg-color: #fff3f0;
 
-  --md-accent-fg-color: #FF7D00;
+  --md-accent-fg-color: #ff7d00;
   --md-accent-fg-color--transparent: hsla(32, 100%, 55%, 0.1);
 
   --md-footer-logo-dark-mode: block;
@@ -145,7 +145,7 @@
 
 .md-typeset code,
 .md-typeset pre {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
 }
 
 /* Fix active link color in dark mode sidebar */
@@ -179,3 +179,19 @@
   display: none; /* Hide light images in dark mode */
 }
 
+.md-clipboard {
+  opacity: 1 !important;
+}
+
+.md-clipboard:hover {
+  background-color: var(--md-accent-fg-color--transparent);
+}
+
+[data-md-color-scheme="slate"] .md-clipboard:not(:hover) {
+  color: var(--md-default-fg-color--light);
+}
+
+/* Hide copy button for console blocks (commands with output) */
+.language-console .md-code__nav {
+  display: none;
+}

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -42,7 +42,7 @@ cargo install cntr
 
 2. **Get the container ID:**
 
-    ```bash
+    ```console
     $ sudo docker ps -a
     CONTAINER ID   IMAGE                                             COMMAND       CREATED         STATUS         PORTS     NAMES
     56b93fbd7332   harbor.nbfc.io/nubificus/urunc/dbg/ubuntu:dltme   "/bin/bash"   3 seconds ago   Up 3 seconds             urunc-debug
@@ -58,7 +58,7 @@ You now have an interactive shell with access to debugging tools!
 
 ### Output:
 
-```bash
+```console
 $ sudo cntr attach 56b93fbd7332
 root@host:/var/lib/cntr#
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -216,7 +216,7 @@ sudo systemctl restart containerd
 
 Verify that the devmapper snapshotter is properly configured with:
 
-```bash
+```console
 $ sudo ctr plugin ls | grep devmapper
 io.containerd.snapshotter.v1              devmapper                linux/amd64    ok
 ```
@@ -275,7 +275,7 @@ sudo systemctl restart containerd
 
 Verify that the blockfile snapshotter is properly configured with:
 
-```bash
+```console
 $ sudo ctr plugin ls | grep blockfile
    io.containerd.snapshotter.v1           blockfile               linux/amd64    ok
 ```

--- a/docs/tutorials/Running-urunc-with-kind.md
+++ b/docs/tutorials/Running-urunc-with-kind.md
@@ -276,7 +276,7 @@ Define the `urunc` RuntimeClass for Kubernetes.
    You should see Unikraft logs indicating NGINX startup without errors.
 
    Output: 
-   ```
+   ```console
    [    1.118355] Info: [libukcpio] <cpio.c @  233> Extracting /./nginx/logs/error.log (0 bytes)
    [    1.150129] Info: [libukcpio] <cpio.c @  286> Creating directory /./nginx/html
    [    1.178385] Info: [libukcpio] <cpio.c @  233> Extracting /./nginx/html/index.html (180 bytes)
@@ -305,6 +305,6 @@ Confirm that the `nginx-urunc` Pod uses the `urunc` runtime.
    kubectl describe pod <pod-name>
    ```
    Look for:
-   ```
+   ```console
    Runtime Class Name:  urunc
    ```

--- a/docs/tutorials/Running-vaccel-with-urunc.md
+++ b/docs/tutorials/Running-vaccel-with-urunc.md
@@ -28,7 +28,7 @@ classify /usr/share/vaccel/images/example.jpg 1
 ```
 
 ### Expected output
-```bash
+```console
 2025.12.11-15:02:16.45 - <info> vAccel 0.7.1-51-499fc2f7
 2025.12.11-15:02:16.50 - <info> Registered plugin rpc 0.2.1-10-3d4d748c
 Initialized session with id: 1
@@ -41,7 +41,7 @@ export VACCEL_LOG_LEVEL=4
 classify /usr/share/vaccel/images/example.jpg 1
 ```
 The expected output is:
-```bash
+```console
 2025.12.11-15:03:04.72 - <debug> Initializing vAccel
 2025.12.11-15:03:04.72 - <info> vAccel 0.7.1-51-499fc2f7
 2025.12.11-15:03:04.72 - <debug> Config:

--- a/docs/tutorials/eks-tutorial.md
+++ b/docs/tutorials/eks-tutorial.md
@@ -195,7 +195,7 @@ bash get_pub_subnets.sh
 ```
 
 Example output:
-```
+```console
 subnet-02bcaca5ac39eca7a,subnet-0d0667e2156169998
 ```
 #### Create the EKS Cluster with Calico CNI
@@ -219,7 +219,7 @@ eksctl create cluster \
 ```
 
 Example output:
-```
+```console
 2 sequential tasks: { create cluster control plane "urunc-tutorial", wait for control plane to become ready
 }
 2025-04-02 12:29:16 [ℹ]  building cluster stack "eksctl-urunc-tutorial-cluster"
@@ -245,7 +245,7 @@ kubectl delete daemonset -n kube-system aws-node
 ```
 
 Expected output:
-```
+```console
 daemonset.apps "aws-node" deleted
 ```
 
@@ -259,7 +259,7 @@ kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v[[ ver
 > the above command. If it does, try to re-issue the command.
 
 Expected output:
-```
+```console
 namespace/tigera-operator created
 customresourcedefinition.apiextensions.k8s.io/bgpconfigurations.crd.projectcalico.org created
 customresourcedefinition.apiextensions.k8s.io/bgpfilters.crd.projectcalico.org created
@@ -307,7 +307,7 @@ EOF
 
 Expected output:
 
-```
+```console
 installation.operator.tigera.io/default created
 ```
 
@@ -365,7 +365,7 @@ EOF
 ```
 
 Example output:
-```
+```console
 2025-04-02 12:39:44 [ℹ]  will use version 1.30 for new nodegroup(s) based on control plane version
 2025-04-02 12:39:46 [!]  "aws-node" was not found
 2025-04-02 12:39:48 [ℹ]  nodegroup "a1-metal-cni" will use "ami-0eb5f4a5031f47d7b" [Ubuntu2204/1.30]
@@ -454,7 +454,7 @@ done
 
 We have successfully setup the cluster. Let's see what we have using a simple `kubectl get pods -o wide -A`:
 
-```
+```console
 NAMESPACE         NAME                                       READY   STATUS    RESTARTS   AGE     IP                NODE                                               NOMINATED NODE   READINESS GATES
 calico-system     calico-kube-controllers-64cf794c44-jnggx   1/1     Running   0          3m52s   172.16.50.196     ip-192-168-32-137.eu-central-1.compute.internal    <none>           <none>
 calico-system     calico-node-xcqrj                          1/1     Running   0          3m47s   192.168.32.137    ip-192-168-32-137.eu-central-1.compute.internal    <none>           <none>
@@ -519,7 +519,7 @@ kubectl get pods -o wide
 ```
 
 Example output:
-```
+```console
 NAME                           READY   STATUS    RESTARTS   AGE     IP                NODE                                               NOMINATED NODE   READINESS GATES
 nginx-stock-7d54d66484-k9rj5   1/1     Running   0          42s     172.16.50.197     ip-192-168-32-137.eu-central-1.compute.internal    <none>           <none>
 nginx-stock-7d54d66484-nn696   1/1     Running   0          42s     172.16.139.2      ip-192-168-103-211.eu-central-1.compute.internal   <none>           <none>
@@ -532,13 +532,13 @@ kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash
 ```
 
 Expected output:
-```
+```console
 If you don't see a command prompt, try pressing enter.
 tmp-shell:~# 
 ```
 
 If we issue a simple `curl` command to one of the pods IPs, we should get a response from the NGINX server:
-```
+```console
 tmp-shell:~# curl 172.16.139.2
 <!DOCTYPE html>
 <html>
@@ -609,7 +609,7 @@ kubectl logs -f -n kube-system -l name=urunc-deploy
 ```
 
 Example output:
-```
+```console
 Installing qemu
 Installing solo5-hvt
 Installing solo5-spt
@@ -688,14 +688,14 @@ Issuing the command below:
 kubectl apply -f nginx-urunc.yaml
 ```
 will produce the following output:
-```
+```console
 deployment.apps/nginx-urunc created
 service/nginx-urunc created
 ```
 and will create a deployment of an NGINX unikernel, from the container image pushed at `harbor.nbfc.io/nubificus/urunc/nginx-hvt-rumprun-block:latest`
 
 Inspecting the pods with `kubectl get pods -o wide` reveals the status:
-```
+```console
 default           nginx-urunc-998b889c4-x798f                1/1     Running             0          2s      172.16.50.225     ip-192-168-32-137.eu-central-1.compute.internal    <none>           <none>
 ```
 
@@ -705,14 +705,14 @@ and following up on the previous test, we do:
 kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash
 ```
 To get a shell in a pod in the cluster:
-```
+```console
 If you don't see a command prompt, try pressing enter.
 tmp-shell:~# 
 ```
 
 and we `curl` the pod's IP:
 
-```
+```console
 tmp-shell:~# curl 172.16.50.225
 <html>
 <body style="font-size: 14pt;">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,11 +72,11 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 
-features:
-  - navigation.instant
-  - navigation.sections
-  - navigation.expand
-  - toc.integrate
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
 
 markdown_extensions:
   - footnotes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,8 +74,6 @@ theme:
 
   features:
     - navigation.instant
-    - navigation.sections
-    - navigation.expand
     - content.code.copy
 
 markdown_extensions:


### PR DESCRIPTION
## Description

This PR builds in top of https://github.com/urunc-dev/urunc/pull/432

@MUFFANUJ implemented the feature and logic for:

- copy button feature and styling
- use `.language-console` in custom css to disable copy button for code blocks with output ( reason in issue discussion )  

@neo-0007 Fixed the issues described in https://github.com/urunc-dev/urunc/pull/432#issuecomment-3858623486 

- rename all code blocks with output as console so that the copy button gets disabled
- fix auto expand of toc in left navigation menu

### Related issues

- Fixes #431 

### How was this tested?

This was tested by locally running the mkdocs site:

After Change: 
 
<img width="1920" height="1034" alt="copy-button" src="https://github.com/user-attachments/assets/ea8c7d39-86a2-49e3-bced-e3a3c063c77e" />

---

<img width="786" height="273" alt="image" src="https://github.com/user-attachments/assets/4e0c46bb-0b7c-4684-83b9-1f11343fe894" />

### LLM usage

(N/A)

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
