### PR TITLE
feat: Allow nightly tests to pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ GO_FLAGS       := GOOS=linux
 CGO            := CGO_ENABLED=1
 NOCGO          := CGO_ENABLED=0
 TEST_FLAGS     := "-count=1"
-TEST_OPTS      += -timeout 15m
+TEST_OPTS      += -timeout 20m
 BUILD_TAGS     ?= netgo osusergo
 
 # Linking variables


### PR DESCRIPTION
## Description

Until we fix our upload (or move to docker for storing our test images), let's increase the timeout to 20' so that nightly tests pass. It seems that pulling the images for nerdctl takes ~14' and the timeout was 15'.

### Related issues

Nightly tests fail almost every time.

### How was this tested?

Temp. Increase the timeout

### LLM usage

No LLM used
### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
