### PR TITLE
fix: propagate error on target.Close() in copyFile

### DIFF
--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -62,14 +62,16 @@ func copyFile(sourceFile string, targetPath string) error {
 	if err != nil {
 		return err
 	}
-	defer target.Close()
 
 	_, err = io.Copy(target, source)
+	
+	closeErr := target.Close()
+	
 	if err != nil {
 		return err
 	}
-
-	return nil
+	
+	return closeErr
 }
 
 // move sourceFile to targetDir


### PR DESCRIPTION
Fixes #566

Properly propagates the error when closing the target file during copyFile to avoid corrupted rootfs if the file fails to close/flush.