### PR TITLE
CHORE: remove cancelled() checks from vm_test workflow

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -83,3 +83,6 @@ users:
   jim-junior:
     name: Beingana Jim Junior
     email: jimjunior854@gmail.com
+  kaizakin:
+    name: Karthik Balasubramanian
+    email: karthikbalasubramanian08@gmail.com

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -288,7 +288,6 @@ jobs:
 
     - name: Prepare urunc folder
       id: prepare
-      if: ${{ !cancelled() }}
       run: |
         export GOROOT=$(go env GOROOT)
         export PATH="$GOROOT/bin:$PATH"
@@ -298,7 +297,6 @@ jobs:
 
     - name: Run ${{ matrix.test }}
       id: test
-      if: ${{ !cancelled() }}
       run: |
         # Set up Go environment properly
         export GOROOT=$(go env GOROOT)


### PR DESCRIPTION
## Description

 `if: ${{ !cancelled() }}` condition in `vm_test.yml` enabled the tests to run even if any of the previous steps failed. 


### Related issues


- Fixes #580 

### How was this tested?

tested this by intentionally changing the firecraker release url and triggered a workflow in my fork. 

once the firecracker step failed further jobs were skipped.

<img width="1527" height="743" alt="image" src="https://github.com/user-attachments/assets/020d6a33-aedb-420a-b67a-16ec9a5ce71f" />


### LLM usage

N/A

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
