### PR TITLE
Support per-container TAP devices for urunc guests

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -17,6 +17,7 @@ package network
 import (
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"net"
 	"regexp"
 	"strings"
@@ -28,17 +29,23 @@ import (
 )
 
 const (
-	DefaultTap = "tapX_urunc"
+	DefaultTap        = "tapX_urunc"
+	defaultTapPattern = `^tap\d+_urunc$`
 )
 
 var netlog = logrus.WithField("subsystem", "network")
+
+var (
+	defaultTapRe = regexp.MustCompile(defaultTapPattern)
+	hashedTapRe  = regexp.MustCompile(`^tap[0-9a-f]{8}_ur$`)
+)
 
 type UnikernelNetworkInfo struct {
 	TapDevice string
 	EthDevice Interface
 }
 type Manager interface {
-	NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error)
+	NetworkSetup(containerID string, uid uint32, gid uint32) (*UnikernelNetworkInfo, error)
 }
 
 type Interface struct {
@@ -62,6 +69,19 @@ func NewNetworkManager(networkType string) (Manager, error) {
 	}
 }
 
+func TapNameForID(containerID string) string {
+	if containerID == "" {
+		return strings.ReplaceAll(DefaultTap, "X", "0")
+	}
+
+	sum := crc32.ChecksumIEEE([]byte(containerID))
+	return fmt.Sprintf("tap%08x_ur", sum)
+}
+
+func isUruncTapName(name string) bool {
+	return defaultTapRe.MatchString(name) || hashedTapRe.MatchString(name)
+}
+
 func getTapIndex() (int, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -69,7 +89,7 @@ func getTapIndex() (int, error) {
 	}
 	tapCount := 0
 	for _, iface := range ifaces {
-		if strings.Contains(iface.Name, "tap") {
+		if isUruncTapName(iface.Name) {
 			tapCount++
 		}
 	}
@@ -184,6 +204,20 @@ func addIngressQdisc(link netlink.Link) error {
 	return netlink.QdiscAdd((ingress))
 }
 
+func ensureIngressQdisc(link netlink.Link) error {
+	qdiscs, err := netlink.QdiscList(link)
+	if err != nil {
+		return err
+	}
+	for _, qdisc := range qdiscs {
+		attrs := qdisc.Attrs()
+		if attrs.Parent == netlink.HANDLE_INGRESS && attrs.LinkIndex == link.Attrs().Index {
+			return nil
+		}
+	}
+	return addIngressQdisc(link)
+}
+
 func addRedirectFilter(source netlink.Link, target netlink.Link) error {
 	return netlink.FilterAdd(&netlink.U32{
 		FilterAttrs: netlink.FilterAttrs{
@@ -230,11 +264,11 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 	if addTCRules {
 		netlog.Debug("adding tc ingress qdisc + redirect filters")
 
-		if err = addIngressQdisc(newTapDevice); err != nil {
+		if err = ensureIngressQdisc(newTapDevice); err != nil {
 			return nil, fmt.Errorf("addIngressQdisc(tap=%s) failed: %w",
 				newTapDevice.Attrs().Name, err)
 		}
-		if err = addIngressQdisc(redirectLink); err != nil {
+		if err = ensureIngressQdisc(redirectLink); err != nil {
 			return nil, fmt.Errorf("addIngressQdisc(redirect=%s) failed: %w",
 				redirectLink.Attrs().Name, err)
 		}
@@ -280,37 +314,90 @@ func CleanupAllUruncTaps() error {
 	}
 
 	var retErr error
-	tapRe := regexp.MustCompile(`^tap\d+_urunc$`)
+	redirectLink, err := discoverContainerIface()
+	if err != nil {
+		netlog.Debugf("could not find redirect interface during cleanup: %v", err)
+	}
 	for _, link := range links {
 		attrs := link.Attrs()
 		if attrs == nil {
 			continue
 		}
 		name := attrs.Name
-		if !tapRe.MatchString(name) {
+		if !isUruncTapName(name) {
 			continue
 		}
 
-		netlog.Debugf("cleaning up tap device %s", name)
-		var devErr error
-		if err := deleteAllTCFilters(link); err != nil {
-			netlog.Errorf("failed to delete TC filters for %s: %v", name, err)
-			devErr = errors.Join(devErr, err)
-		}
-		if err := deleteAllQDiscs(link); err != nil {
-			netlog.Errorf("failed to delete qdiscs for %s: %v", name, err)
-			devErr = errors.Join(devErr, err)
-		}
-		if err := deleteTapDevice(link); err != nil {
-			netlog.Errorf("failed to delete tap %s: %v", name, err)
-			devErr = errors.Join(devErr, err)
-		}
-		if devErr == nil {
-			netlog.Debugf("deleted tap device %s", name)
-		}
-		retErr = errors.Join(retErr, devErr)
+		retErr = errors.Join(retErr, cleanupUruncTap(link, redirectLink))
 	}
 
+	if retErr == nil {
+		retErr = errors.Join(retErr, cleanupRedirectQdiscIfUnused(redirectLink))
+	}
+	return retErr
+}
+
+func CleanupUruncTap(tapName string) error {
+	if tapName == "" {
+		return nil
+	}
+	if !isUruncTapName(tapName) {
+		return fmt.Errorf("refusing to clean non-urunc tap device %s", tapName)
+	}
+
+	handle, err := netlink.NewHandle()
+	if err != nil {
+		return fmt.Errorf("failed to get netlink handle: %w", err)
+	}
+	defer handle.Close()
+
+	link, err := handle.LinkByName(tapName)
+	if err != nil {
+		var notFound netlink.LinkNotFoundError
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to find tap %s: %w", tapName, err)
+	}
+
+	redirectLink, err := discoverContainerIface()
+	if err != nil {
+		netlog.Debugf("could not find redirect interface during cleanup: %v", err)
+	}
+
+	err = cleanupUruncTap(link, redirectLink)
+	if err != nil {
+		return err
+	}
+	return cleanupRedirectQdiscIfUnused(redirectLink)
+}
+
+func cleanupUruncTap(tapLink netlink.Link, redirectLink netlink.Link) error {
+	name := tapLink.Attrs().Name
+	netlog.Debugf("cleaning up tap device %s", name)
+
+	var retErr error
+	if err := deleteTapFilters(tapLink); err != nil {
+		netlog.Errorf("failed to delete TC filters for %s: %v", name, err)
+		retErr = errors.Join(retErr, err)
+	}
+	if redirectLink != nil {
+		if err := deleteRedirectFiltersForTap(redirectLink, tapLink.Attrs().Index); err != nil {
+			netlog.Errorf("failed to delete redirect filters for %s: %v", name, err)
+			retErr = errors.Join(retErr, err)
+		}
+	}
+	if err := deleteIngressQdisc(tapLink); err != nil {
+		netlog.Errorf("failed to delete qdisc for %s: %v", name, err)
+		retErr = errors.Join(retErr, err)
+	}
+	if err := deleteTapDevice(tapLink); err != nil {
+		netlog.Errorf("failed to delete tap %s: %v", name, err)
+		retErr = errors.Join(retErr, err)
+	}
+	if retErr == nil {
+		netlog.Debugf("deleted tap device %s", name)
+	}
 	return retErr
 }
 
@@ -387,46 +474,70 @@ func discoverContainerIface() (netlink.Link, error) {
 	return nil, errors.New("no suitable network interface found in namespace")
 }
 
-func deleteAllQDiscs(device netlink.Link) error {
-	err := deleteIngressQdisc(device)
-	if err != nil {
-		return err
+func cleanupRedirectQdiscIfUnused(redirectLink netlink.Link) error {
+	if redirectLink == nil {
+		return nil
 	}
-	device, err = discoverContainerIface()
-	if err != nil {
-		return err
+
+	if hasUruncTap() {
+		return nil
 	}
-	err = deleteIngressQdisc(device)
-	if err != nil {
-		return err
-	}
-	return nil
+	return deleteIngressQdisc(redirectLink)
 }
 
-func deleteAllTCFilters(device netlink.Link) error {
-	var allFilters []netlink.Filter
-	parent := uint32(netlink.HANDLE_ROOT)
-	tapFilters, err := netlink.FilterList(device, parent)
+func hasUruncTap() bool {
+	ifaces, err := net.Interfaces()
 	if err != nil {
-		return err
+		netlog.Debugf("failed to list interfaces while checking urunc taps: %v", err)
+		return true
 	}
-	allFilters = append(allFilters, tapFilters...)
-	device, err = discoverContainerIface()
-	if err != nil {
-		return err
-	}
-	ethFilters, err := netlink.FilterList(device, parent)
-	if err != nil {
-		return err
-	}
-	allFilters = append(allFilters, ethFilters...)
-	for _, filter := range allFilters {
-		err = netlink.FilterDel(filter)
-		if err != nil {
-			return err
+	for _, iface := range ifaces {
+		if isUruncTapName(iface.Name) {
+			return true
 		}
 	}
-	return nil
+	return false
+}
+
+func deleteTapFilters(device netlink.Link) error {
+	filters, err := netlink.FilterList(device, uint32(netlink.HANDLE_ROOT))
+	if err != nil {
+		return err
+	}
+	var retErr error
+	for _, filter := range filters {
+		retErr = errors.Join(retErr, netlink.FilterDel(filter))
+	}
+	return retErr
+}
+
+func filterRedirectsTo(filter netlink.Filter, ifindex int) bool {
+	u32, ok := filter.(*netlink.U32)
+	if !ok {
+		return false
+	}
+	for _, action := range u32.Actions {
+		mirred, ok := action.(*netlink.MirredAction)
+		if ok && mirred.Ifindex == ifindex {
+			return true
+		}
+	}
+	return false
+}
+
+func deleteRedirectFiltersForTap(device netlink.Link, tapIndex int) error {
+	filters, err := netlink.FilterList(device, uint32(netlink.HANDLE_ROOT))
+	if err != nil {
+		return err
+	}
+	var retErr error
+	for _, filter := range filters {
+		if !filterRedirectsTo(filter, tapIndex) {
+			continue
+		}
+		retErr = errors.Join(retErr, netlink.FilterDel(filter))
+	}
+	return retErr
 }
 
 func deleteTapDevice(device netlink.Link) error {

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -16,30 +16,19 @@ package network
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 )
 
 type DynamicNetwork struct {
 }
 
-// NetworkSetup checks if any tap device is available in the current netns. If it is, it assumes a running unikernel
-// is present in the current netns and returns an error, because network functionality for more than one unikernels
-// is not yet implemented.
-// If no TAP devices are available in the current netns, it creates a new tap device and
-// sets TC rules between the veth interface and the tap device inside the namespace.
-//
-// FIXME: CUrrently only one tap device per netns can provide functional networking. We need to find a proper way to handle networking
-// for multiple unikernels in the same pod/network namespace.
-// See: https://github.com/urunc-dev/urunc/issues/13
-func (n DynamicNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
+// NetworkSetup creates a TAP device owned by this container and wires it to
+// the container namespace interface.
+func (n DynamicNetwork) NetworkSetup(containerID string, uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
 	tapIndex, err := getTapIndex()
 	if err != nil {
 		return nil, fmt.Errorf("getTapIndex failed: %w", err)
 	}
-	if tapIndex > 0 {
-		return nil, fmt.Errorf("unsupported operation: can't spawn multiple unikernels in the same network namespace")
-	}
+	netlog.Debugf("found %d existing urunc tap device(s)", tapIndex)
 
 	redirectLink, err := discoverContainerIface()
 	if err != nil {
@@ -47,7 +36,7 @@ func (n DynamicNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkI
 	}
 	netlog.Debugf("found interface %s (index=%d)", redirectLink.Attrs().Name, redirectLink.Attrs().Index)
 
-	newTapName := strings.ReplaceAll(DefaultTap, "X", strconv.Itoa(tapIndex))
+	newTapName := TapNameForID(containerID)
 	netlog.Debugf("creating tap device %s", newTapName)
 
 	newTapDevice, err := networkSetup(newTapName, "", redirectLink, true, uid, gid)

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -88,7 +88,7 @@ func setNATRule(iface string, sourceIP string) error {
 	return nil
 }
 
-func (n StaticNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
+func (n StaticNetwork) NetworkSetup(_ string, uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
 	newTapName := strings.ReplaceAll(DefaultTap, "X", "0")
 	addTCRules := false
 	redirectLink, err := discoverContainerIface()

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
 )
 
 func TestNewNetworkManager(t *testing.T) {
@@ -55,4 +56,55 @@ func TestNewNetworkManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTapNameForID(t *testing.T) {
+	t.Parallel()
+
+	first := TapNameForID("container-a")
+	second := TapNameForID("container-b")
+
+	assert.NotEqual(t, first, second)
+	assert.True(t, isUruncTapName(first))
+	assert.True(t, isUruncTapName(second))
+	assert.LessOrEqual(t, len(first), 15)
+	assert.Equal(t, first, TapNameForID("container-a"))
+	assert.Equal(t, "tap0_urunc", TapNameForID(""))
+}
+
+func TestIsUruncTapName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "tap0_urunc", want: true},
+		{name: "tap15_urunc", want: true},
+		{name: "tapabcd1234_ur", want: true},
+		{name: "tap0", want: false},
+		{name: "tap0_other", want: false},
+		{name: "eth0", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isUruncTapName(tt.name))
+		})
+	}
+}
+
+func TestFilterRedirectsTo(t *testing.T) {
+	t.Parallel()
+
+	filter := &netlink.U32{
+		Actions: []netlink.Action{
+			&netlink.MirredAction{Ifindex: 7},
+		},
+	}
+
+	assert.True(t, filterRedirectsTo(filter, 7))
+	assert.False(t, filterRedirectsTo(filter, 8))
+	assert.False(t, filterRedirectsTo(&netlink.BpfFilter{}, 7))
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -178,7 +178,7 @@ func (u *Unikontainer) SetupNet() (types.NetDevParams, error) {
 		return netArgs, fmt.Errorf("failed to create network manager for %s type: %v", networkType, err)
 	}
 
-	networkInfo, err := netManager.NetworkSetup(u.Spec.Process.User.UID, u.Spec.Process.User.GID)
+	networkInfo, err := netManager.NetworkSetup(u.State.ID, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
 	if err != nil {
 		// TODO: Handle this case better. We do not need to show an error
 		// since there was no network in the container. Therefore, we
@@ -586,7 +586,11 @@ func (u *Unikontainer) Kill() error {
 		return err
 	}
 
-	err = network.CleanupAllUruncTaps()
+	tapName := network.TapNameForID(u.State.ID)
+	if u.getNetworkType() == "static" {
+		tapName = network.TapNameForID("")
+	}
+	err = network.CleanupUruncTap(tapName)
 	if err != nil {
 		uniklog.Errorf("failed to cleanup tap devices: %v", err)
 	}


### PR DESCRIPTION
## Description

This adds the first piece needed for running more than one urunc guest in the same network namespace.

The dynamic network setup no longer rejects a namespace just because another urunc TAP already exists. Instead, it derives a stable TAP name from the container id, so each urunc container gets its own TAP device.

The cleanup path also stops deleting every urunc TAP in the namespace. `Kill()` now targets the TAP that belongs to the container being stopped, and the redirect filter cleanup only removes filters that point to that TAP.

This keeps the change scoped to TAP allocation and cleanup. It does not try to solve every pod networking case in one PR.

### Related issues

- Fixes #589

### How was this tested?

- `GOOS=linux go test -exec=/usr/bin/true ./pkg/...`
- `ARCH=arm64 CNTR_OPTS='run --rm' make lint`

Native `go test` on this macOS host cannot run the Linux-only netlink/TUN package directly, so I used Linux-targeted compile validation and the project lint container.

### LLM usage

Assisted by GPT-5.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
