### PR TITLE
fix: use atomic writes for state.json to prevent corruption

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -92,3 +92,6 @@ users:
   neo-0007:
     name: Hrishikesh Gohain
     email: hrishikeshgohain123@gmail.com
+  MayankSharmaCSE:
+    name: Mayank Sharma
+    email: mayanksharmacse1@gmail.com

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -816,7 +816,7 @@ func (u *Unikontainer) saveContainerState() error {
 	}
 
 	stateName := filepath.Join(u.BaseDir, stateFilename)
-	return atomicWriteFile(stateName, data, 0o644) //nolint: gosec
+	return atomicWriteFile(stateName, data, 0o644)
 }
 
 // getHooksByName returns the hooks for a given lifecycle stage

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -816,7 +816,7 @@ func (u *Unikontainer) saveContainerState() error {
 	}
 
 	stateName := filepath.Join(u.BaseDir, stateFilename)
-	return os.WriteFile(stateName, data, 0o644) //nolint: gosec
+	return atomicWriteFile(stateName, data, 0o644) //nolint: gosec
 }
 
 // getHooksByName returns the hooks for a given lifecycle stage

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -113,7 +113,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	tmpName := filepath.Join(dir, "."+filepath.Base(path)+".tmp")
 
-	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, perm)
+	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
@@ -135,7 +135,11 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to close temp file: %w", closeErr)
 	}
 
-	return os.Rename(tmpName, path)
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to rename temp file to %s: %w", path, err)
+	}
+	return nil
 }
 
 // writePidFile writes the content of pid to the file defined by path

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -105,22 +105,42 @@ func loadSpec(bundleDir string) (*specs.Spec, error) {
 	return &spec, nil
 }
 
+// atomicWriteFile writes data to a file atomically by first writing to a
+// temporary file in the same directory, syncing it, and then renaming it
+// to the target path. This prevents partial/corrupt files if the process
+// is killed mid-write.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmpName := filepath.Join(dir, "."+filepath.Base(path)+".tmp")
+
+	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, perm)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	_, writeErr := f.Write(data)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+
+	if writeErr != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to write temp file: %w", writeErr)
+	}
+	if syncErr != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to sync temp file: %w", syncErr)
+	}
+	if closeErr != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to close temp file: %w", closeErr)
+	}
+
+	return os.Rename(tmpName, path)
+}
+
 // writePidFile writes the content of pid to the file defined by path
 func writePidFile(path string, pid int) error {
-	var (
-		tmpDir  = filepath.Dir(path)
-		tmpName = filepath.Join(tmpDir, "."+filepath.Base(path))
-	)
-	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_SYNC, 0o666)
-	if err != nil {
-		return err
-	}
-	_, err = f.WriteString(strconv.Itoa(pid))
-	f.Close()
-	if err != nil {
-		return err
-	}
-	return os.Rename(tmpName, path)
+	return atomicWriteFile(path, []byte(strconv.Itoa(pid)), 0o666)
 }
 
 // handleQueueProxy adds a hardcoded IP to the process's environment.

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -25,6 +25,60 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAtomicWriteFile(t *testing.T) {
+	t.Run("writes file atomically", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		target := filepath.Join(tmpDir, "state.json")
+		data := []byte(`{"status":"running"}`)
+
+		err := atomicWriteFile(target, data, 0o644)
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(target)
+		assert.NoError(t, err)
+		assert.Equal(t, data, content)
+	})
+
+	t.Run("overwrites existing file", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		target := filepath.Join(tmpDir, "state.json")
+
+		err := os.WriteFile(target, []byte("old"), 0o600)
+		assert.NoError(t, err)
+
+		newData := []byte("new content")
+		err = atomicWriteFile(target, newData, 0o644)
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(target)
+		assert.NoError(t, err)
+		assert.Equal(t, newData, content)
+	})
+
+	t.Run("no temp file left on success", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		target := filepath.Join(tmpDir, "state.json")
+
+		err := atomicWriteFile(target, []byte("data"), 0o644)
+		assert.NoError(t, err)
+
+		tmpFile := filepath.Join(tmpDir, ".state.json.tmp")
+		_, err = os.Stat(tmpFile)
+		assert.True(t, os.IsNotExist(err), "Temp file should not exist after successful write")
+	})
+
+	t.Run("fails on invalid directory", func(t *testing.T) {
+		t.Parallel()
+		target := filepath.Join("/nonexistent/dir", "state.json")
+
+		err := atomicWriteFile(target, []byte("data"), 0o644)
+		assert.Error(t, err)
+	})
+}
+
 func TestWritePidFile(t *testing.T) {
 	tmpDir := t.TempDir() // Create a temporary directory for the test
 	pidFilePath := filepath.Join(tmpDir, "test.pid")

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -77,6 +77,25 @@ func TestAtomicWriteFile(t *testing.T) {
 		err := atomicWriteFile(target, []byte("data"), 0o644)
 		assert.Error(t, err)
 	})
+
+	t.Run("rename failure cleans up temp file", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+
+		// Create a directory at the target path so rename fails.
+		target := filepath.Join(tmpDir, "state.json")
+		err := os.Mkdir(target, 0o755)
+		assert.NoError(t, err)
+
+		err = atomicWriteFile(target, []byte("data"), 0o644)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to rename temp file")
+
+		// Verify the temp file was cleaned up.
+		tmpFile := filepath.Join(tmpDir, ".state.json.tmp")
+		_, err = os.Stat(tmpFile)
+		assert.True(t, os.IsNotExist(err), "Temp file should be cleaned up after rename failure")
+	})
 }
 
 func TestWritePidFile(t *testing.T) {


### PR DESCRIPTION
## Description                                                                                                                                                                                                      
                                                                                                                                                                                                                      
  <!-- Describe the changes and why they are needed. -->                                                                                                                                                              
                                                                                                                                                                                                                      
  This PR fixes the non-atomic state.json writes in `saveContainerState()` that could lead to file corruption if the urunc process is killed mid-write.                                                               
                                                                                                                                                                                                                      
  ### Problem     
  - `saveContainerState()` in `pkg/unikontainers/unikontainers.go` was using `os.WriteFile()` directly                                                                                                                
  - If the process was killed during write, state.json would be partially/corruptly written           
  - Subsequent lifecycle operations (`urunc start`, `kill`, `delete`) would fail with JSON parse errors                                                                                                               
  - VMM processes would become orphaned and unmanageable                                                                                                                                                              
                                                                                                                                                                                                                      
  ### Solution                                                                                                                                                                                                        
  - Added `atomicWriteFile()` helper in `pkg/unikontainers/utils.go` that:                                                                                                                                            
    - Writes to a temporary file in the same directory                                                                                                                                                                
    - Syncs the file to ensure durability                                                                                                                                                                             
    - Atomically renames the temp file to the target path                                                                                                                                                             
  - Refactored `saveContainerState()` to use the new helper                                                                                                                                                           
  - Refactored `writePidFile()` to use the same helper for consistency                                                                                                                                                
  - Added unit tests for `atomicWriteFile()`                                                                                                                                                                          
                                                                                                                                                                                                                      
  ### Files changed                                                                                                                                                                                                   
  - `pkg/unikontainers/utils.go` - Added `atomicWriteFile()`, refactored `writePidFile()`                                                                                                                             
  - `pkg/unikontainers/unikontainers.go` - Changed `saveContainerState()` to use atomic writes                                                                                                                        
  - `pkg/unikontainers/utils_test.go` - Added `TestAtomicWriteFile` with 4 test cases                                                                                                                                 
                                                                                                                                                                                                                      
  ### Related issues                                                                                                                                                                                                  
                                                                                                                                                                                                                      
  <!-- Include links to relevant issues or other pages. -->                                                                                                                                                           
                                                                                                                                                                                                                      
  - Fixes #598      
                                                                                                                                                                                                                      
  ### How was this tested?
                                                                                                                                                                                                                      
  <!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->
                                                                                                                                                                                                                      
  - Added unit tests for `atomicWriteFile()` covering:
    - Basic atomic write                                                                                                                                                                                              
    - Overwriting existing file
    - Temp file cleanup on success                                                                                                                                                                                    
    - Error handling for invalid directory                                                                                                                                                                            
  - Verified `writePidFile` still works correctly (existing test passes)                                                                                                                                              
  - Verified `go vet` passes for Linux target                                                                                                                                                                         
  - Verified `golangci-lint` passes with no new warnings                                                                                                                                                              
                                                                                                                                                                                                                      
  ### LLM usage                                                                                                                                                                                                       
                                                                                                                                                                                                                      
  <!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->                                                                                                                       
                                                                                                                                                                                                                      
  Claude Opus 4.7 (Anthropic) assisted with analysis, implementation, and code review.
                                                                                                                                                                                                                      
  ### Checklist   
                                                                                                                                                                                                                      
  - [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
  - [x] The linter passes locally (`make lint`).                                                                                                                                                                      
  - [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
  - [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).                                                                                                                
                                                                                                                                                                                                                      
  ---                                                                         