### PR TITLE
fix(cmd): add ps command for containerd recovery

### DIFF
--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -113,6 +113,7 @@ func main() {
 			deleteCommand,
 			killCommand,
 			runCommand,
+			psCommand,
 			// specCommand,
 			startCommand,
 			// stateCommand,

--- a/cmd/urunc/ps.go
+++ b/cmd/urunc/ps.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+var psCommand = &cli.Command{
+	Name:      "ps",
+	Usage:     "displays the host-visible monitor processes associated with a container",
+	ArgsUsage: `<container-id>`,
+	Description: `The ps command displays the host-visible process IDs associated
+with a urunc container. This currently returns the host-visible monitor PID
+stored in urunc state.json.
+
+This command intentionally implements the runc-compatible interface required by
+containerd-shim-runc-v2/go-runc:
+
+    urunc ps --format json <container-id>
+
+The JSON format must be a JSON array of integers, for example:
+
+    [12345]
+`,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "format",
+			Aliases: []string{"f"},
+			Value:   "table",
+			Usage:   "select output format: table or json",
+		},
+	},
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		logrus.WithField("command", "PS").WithField("args", os.Args).Debug("urunc INVOKED")
+
+		if err := checkArgs(cmd, 1, minArgs); err != nil {
+			return err
+		}
+
+		unikontainer, err := getUnikontainer(cmd)
+		if err != nil {
+			return err
+		}
+
+		// The host-visible process for the current implementation is the
+		// monitor process saved in state.json as State.Pid.
+		//
+		// Keep the return value as []int to match runc's ps implementation
+		// and containerd/go-runc's expectation for `ps --format json`.
+		pids := []int{unikontainer.State.Pid}
+
+		switch cmd.String("format") {
+		case "json":
+			return json.NewEncoder(os.Stdout).Encode(pids)
+
+		case "table":
+			fmt.Fprintln(os.Stdout, "PID")
+			for _, pid := range pids {
+				fmt.Fprintln(os.Stdout, pid)
+			}
+			return nil
+
+		default:
+			return fmt.Errorf("invalid format option: %s", cmd.String("format"))
+		}
+	},
+}


### PR DESCRIPTION


## Description

Add a runc-compatible `ps --format json` command to urunc.

containerd-shim-urunc-v2 reuses the runc shim manager and task service. During containerd restart, the recovery path calls Pids(), which eventually invokes the runtime binary as:

    urunc ps --format json <container-id>

Without this command, containerd cannot obtain the host-visible PID associated with the urunc task and may treat the shim as leaked.

Return the VMM / sandbox monitor PID stored in state.json as a []int, matching the JSON format expected by containerd/go-runc and runc's ps implementation. Keep the result as a slice so it can be extended later if urunc supports multiple VMM or unikernel processes for one container.

### Related issues



- Fixes #599 

### How was this tested?

**Before the fix**

The urunc container was running before restarting containerd:
```
root@sev:~/zxd/urunc-per-container# nerdctl ps -a
CONTAINER ID    IMAGE                                                         COMMAND                   CREATED          STATUS    PORTS    NAMES
ae3a6ebb87fe    harbor.nbfc.io/nubificus/urunc/nginx-qemu-linux-raw:latest    "/urunit /usr/sbin/n…"    5 seconds ago    Up                 urunc-view-check-1
```
After restarting containerd:
```
root@sev:~/zxd/urunc-per-container# systemctl restart containerd
```
the same container became Created:
```
root@sev:~/zxd/urunc-per-container# nerdctl ps -a
CONTAINER ID    IMAGE                                                         COMMAND                   CREATED           STATUS     PORTS    NAMES
ae3a6ebb87fe    harbor.nbfc.io/nubificus/urunc/nginx-qemu-linux-raw:latest    "/urunit /usr/sbin/n…"    14 seconds ago    Created             urunc-view-check-1
```
The state stayed Created on the next check:
```
root@sev:~/zxd/urunc-per-container# nerdctl ps -a
CONTAINER ID    IMAGE                                                         COMMAND                   CREATED           STATUS     PORTS    NAMES
ae3a6ebb87fe    harbor.nbfc.io/nubificus/urunc/nginx-qemu-linux-raw:latest    "/urunit /usr/sbin/n…"    26 seconds ago    Created             urunc-view-check-1
```
The urunc shim process was still alive:
```
root@sev:~/zxd/urunc-per-container# ps aux | grep shim
root      512463  0.0  0.0 1233708 4704 ?        Sl   04:39   0:00 /usr/local/bin/containerd-shim-urunc-v2 -namespace default -id ae3a6ebb87fea672711de7b7ab75315eb7e39605330b71236d607657b1707c9a -address /run/containerd/containerd.sock -debug
root      513223  0.0  0.0   6548  1544 pts/1    S+   04:40   0:00 grep --color=auto shim
```
After stopping and removing the container:
```
root@sev:~/zxd/urunc-per-container# nerdctl stop ae3
ae3
root@sev:~/zxd/urunc-per-container# nerdctl rm ae3
ae3
```
the shim was still left behind:
```
root@sev:~/zxd/urunc-per-container# ps aux | grep shim
root      512463  0.0  0.0 1233708 4704 ?        Sl   04:39   0:00 /usr/local/bin/containerd-shim-urunc-v2 -namespace default -id ae3a6ebb87fea672711de7b7ab75315eb7e39605330b71236d607657b1707c9a -address /run/containerd/containerd.sock -debug
root      513492  0.0  0.0   6548  1548 pts/1    S+   04:40   0:00 grep --color=auto shim
```
At that point, the container metadata had already disappeared:
```
root@sev:~/zxd/urunc-per-container# nerdctl ps -a
CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
```
This shows the failure mode before the fix: containerd restart caused the urunc container to fall from Up to Created, and cleanup left a live containerd-shim-urunc-v2 process behind.

**After the fix**

After replacing the binaries with the fixed version, a new urunc container was started:
```
root@sev:~/zxd/urunc-per-container#nerdctl -n default  --snapshotter devmapper run -d --name urunc-view-check-1   --runtime io.containerd.urunc.v2   harbor.nbfc.io/nubificus/urunc/nginx-qemu-linux-raw:latest
4426490c6afd310ebe8653126f0479efe25ed60c32b48e585d9f95e9b028fd17
```

The container was Up before restarting containerd:
```
root@sev:~/zxd/urunc-per-container# nerdctl ps -a
CONTAINER ID    IMAGE                                                         COMMAND                   CREATED          STATUS    PORTS    NAMES
4426490c6afd    harbor.nbfc.io/nubificus/urunc/nginx-qemu-linux-raw:latest    "/urunit /usr/sbin/n…"    5 seconds ago    Up                 urunc-view-check-1
```
After restarting containerd:
```
root@sev:~/zxd/urunc-per-container# systemctl restart containerd
```
the container remained Up:
```
root@sev:~/zxd/urunc-per-container# nerdctl ps -a
CONTAINER ID    IMAGE                                                         COMMAND                   CREATED           STATUS    PORTS    NAMES
4426490c6afd    harbor.nbfc.io/nubificus/urunc/nginx-qemu-linux-raw:latest    "/urunit /usr/sbin/n…"    17 seconds ago    Up                 urunc-view-check-1
```
The container was then stopped and removed normally:
```
root@sev:~/zxd/urunc-per-container# nerdctl stop 4426
4426
root@sev:~/zxd/urunc-per-container# nerdctl rm 4426
4426
```
After removal, no urunc shim was left behind; only the grep process appeared:
```
root@sev:~/zxd/urunc-per-container# ps aux | grep shim
root      515037  0.0  0.0   6548  1544 pts/1    S+   04:42   0:00 grep --color=auto shim
```
### LLM usage

ChatGPT

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
