### PR TITLE
test: add unit tests for remove

### DIFF
--- a/pkg/unikontainers/remove_test.go
+++ b/pkg/unikontainers/remove_test.go
@@ -1,0 +1,28 @@
+package unikontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests for remove() - removes element from a string slice by index
+func TestRemove(t *testing.T) {
+	t.Run("remove first element", func(t *testing.T) {
+		s := []string{"a", "b", "c"}
+		result := remove(s, 0)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("remove middle element", func(t *testing.T) {
+		s := []string{"a", "b", "c"}
+		result := remove(s, 1)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("remove only element", func(t *testing.T) {
+		s := []string{"a"}
+		result := remove(s, 0)
+		assert.Len(t, result, 0)
+	})
+}


### PR DESCRIPTION
## Description
Adds unit tests for the `remove()` helper function in `pkg/unikontainers/utils.go`.
This function had no test coverage. The tests cover:
- removing the first element
- removing a middle element
- removing the only element

### Related issues
- Fixes #96

### How was this tested?
Ran unit tests locally:
`go test ./pkg/unikontainers/... -v -run TestRemove`
All 3 test cases passed. Linter also passes locally (`make lint`).

### LLM usage
Claude Sonnet 4.6 was used to assist in understanding the codebase and test structure. All code was reviewed and understood before submission.

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally.
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).