### PR TITLE
fix: file descriptor leak in joinSandboxNetNs by ensuring fd is closed

### DIFF
--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -682,6 +682,7 @@ func (u Unikontainer) joinSandboxNetNs() error {
 	if err != nil {
 		return fmt.Errorf("error opening namespace path: %w", err)
 	}
+	defer unix.Close(fd)
 	err = unix.Setns(int(fd), unix.CLONE_NEWNET)
 	if err != nil {
 		return fmt.Errorf("error joining namespace: %w", err)


### PR DESCRIPTION
Fixes #609 

## SUMMARY

This PR fixes a file descriptor leak in `joinSandboxNetNs()` within `pkg/unikontainers/unikontainers.go`. The function opened a network namespace file descriptor but never closed it, causing descriptors to accumulate over time in long-running processes.

The change ensures the file descriptor is properly closed on both success and error paths, preventing resource exhaustion without altering runtime behavior.

---

## FIX

```go
// BEFORE
fd, err := unix.Open(netNsPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
if err != nil {
    return fmt.Errorf("error opening namespace path: %w", err)
}
err = unix.Setns(int(fd), unix.CLONE_NEWNET)
if err != nil {
    return fmt.Errorf("error joining namespace: %w", err)
}
return nil

// AFTER
fd, err := unix.Open(netNsPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
if err != nil {
    return fmt.Errorf("error opening namespace path: %w", err)
}
defer unix.Close(fd)

err = unix.Setns(int(fd), unix.CLONE_NEWNET)
if err != nil {
    return fmt.Errorf("error joining namespace: %w", err)
}
return nil
```

