### PR TITLE
Fix/594 signal handling

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -56,7 +56,7 @@ users:
   hemang1404:
     name: Hemang Sharrma
     email: hemangsharrma@gmail.com
-  ilp-sys:
+  jiwahn:
     name: Jiwoo Ahn
     email: ikwydls1314@gmail.com
   goyalpalak18:

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -298,6 +298,7 @@ sgid
 sharedfs
 sigaction
 sigreturn
+sigstr
 sirupsen
 socker
 stretchr

--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -16,11 +16,16 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
+
+	"golang.org/x/sys/unix"
 )
 
 var killCommand = &cli.Command{
@@ -36,13 +41,6 @@ For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
 
 	# urunc kill ubuntu01 KILL`,
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:    "all",
-			Aliases: []string{"a"},
-			Usage:   "send the specified signal to all processes inside the container",
-		},
-	},
 	Action: func(_ context.Context, cmd *cli.Command) error {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
@@ -59,6 +57,34 @@ signal to the init process of the "ubuntu01" container:
 		if err != nil {
 			return err
 		}
-		return unikontainer.Kill()
+
+		sigstr := cmd.Args().Get(1)
+		if sigstr == "" {
+			sigstr = "SIGTERM"
+		}
+
+		signal, err := parseSignal(sigstr)
+		if err != nil {
+			return err
+		}
+
+		return unikontainer.Signal(signal)
 	},
+}
+
+// Taken from https://github.com/opencontainers/runc/blob/af6b9e7fa96026c4fdac93e6e4fddf69ae348532/kill.go
+func parseSignal(rawSignal string) (unix.Signal, error) {
+	s, err := strconv.Atoi(rawSignal)
+	if err == nil {
+		return unix.Signal(s), nil
+	}
+	sig := strings.ToUpper(rawSignal)
+	if !strings.HasPrefix(sig, "SIG") {
+		sig = "SIG" + sig
+	}
+	signal := unix.SignalNum(sig)
+	if signal == 0 {
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+	}
+	return signal, nil
 }

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -29,6 +30,10 @@ const (
 type CloudHypervisor struct {
 	binaryPath string
 	binary     string
+}
+
+func (ch *CloudHypervisor) Signal(pid int, signal unix.Signal) error {
+	return unix.Kill(pid, signal)
 }
 
 func (ch *CloudHypervisor) Stop(pid int) error {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -73,6 +74,10 @@ type FirecrackerConfig struct {
 	Drives  []FirecrackerDrive    `json:"drives"`
 	NetIfs  []FirecrackerNet      `json:"network-interfaces,omitempty"`
 	VSock   FirecrackerVSockDev   `json:"vsock,omitempty"`
+}
+
+func (fc *Firecracker) Signal(pid int, signal unix.Signal) error {
+	return unix.Kill(pid, signal)
 }
 
 func (fc *Firecracker) Stop(pid int) error {

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -19,6 +19,7 @@ import (
 
 	hedge "github.com/nubificus/hedge_cli/hedge_api"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -30,6 +31,10 @@ const (
 type Hedge struct{}
 
 func (h *Hedge) Ok() error {
+	return fmt.Errorf("hedge not implemented yet")
+}
+
+func (h *Hedge) Signal(_ int, _ unix.Signal) error {
 	return fmt.Errorf("hedge not implemented yet")
 }
 

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -21,6 +21,7 @@ import (
 
 	seccomp "github.com/elastic/go-seccomp-bpf"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -117,6 +118,10 @@ func applySeccompFilter() error {
 	vmmLog.WithField("allowed syscalls", syscalls).Debug("Whitelisted system calls")
 
 	return nil
+}
+
+func (h *HVT) Signal(pid int, signal unix.Signal) error {
+	return unix.Kill(pid, signal)
 }
 
 // Stop kills the hvt process

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -31,6 +32,10 @@ type Qemu struct {
 	binaryPath string
 	binary     string
 	vhost      bool
+}
+
+func (q *Qemu) Signal(pid int, signal unix.Signal) error {
+	return unix.Kill(pid, signal)
 }
 
 func (q *Qemu) Stop(pid int) error {

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -29,6 +30,10 @@ const (
 type SPT struct {
 	binaryPath string
 	binary     string
+}
+
+func (s *SPT) Signal(pid int, signal unix.Signal) error {
+	return unix.Kill(pid, signal)
 }
 
 // Stop kills the spt process

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
-	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -69,9 +68,9 @@ func BytesToStringMB(argMem uint64) string {
 
 func killProcess(pid int) error {
 	const timeout = 2 * time.Second
-	err := syscall.Kill(pid, unix.SIGKILL)
+	err := unix.Kill(pid, unix.SIGKILL)
 	if err != nil {
-		if errors.Is(err, syscall.ESRCH) {
+		if errors.Is(err, unix.ESRCH) {
 			// Process already dead, nothing to do
 			return nil
 		}
@@ -79,8 +78,8 @@ func killProcess(pid int) error {
 	}
 	deadline := time.Now().Add(timeout)
 	for {
-		if err := syscall.Kill(pid, 0); err != nil {
-			if errors.Is(err, syscall.ESRCH) {
+		if err := unix.Kill(pid, 0); err != nil {
+			if errors.Is(err, unix.ESRCH) {
 				// process is dead
 				break
 			}

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -15,6 +15,8 @@
 //revive:disable:var-naming
 package types
 
+import "golang.org/x/sys/unix"
+
 type Unikernel interface {
 	Init(UnikernelParams) error
 	CommandString() (string, error)
@@ -35,6 +37,7 @@ type VMM interface {
 	// filters here. Most monitors can return nil (no-op).
 	PreExec(args ExecArgs) error
 	Stop(int) error
+	Signal(int, unix.Signal) error
 	Path() string
 	UsesKVM() bool
 	SupportsSharedfs(string) bool

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -656,6 +656,17 @@ func setupUser(user specs.User) error {
 	return nil
 }
 
+// Signal sends a specified signal to container's init.
+func (u *Unikontainer) Signal(signal unix.Signal) error {
+	vmmType := u.State.Annotations[annotHypervisor]
+	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
+	if err != nil {
+		return err
+	}
+
+	return vmm.Signal(u.State.Pid, signal)
+}
+
 // Kill stops the VMM process, first by asking the VMM struct to stop
 // and consequently by killing the process described in u.State.Pid
 func (u *Unikontainer) Kill() error {


### PR DESCRIPTION
## Description

<!-- Describe the changes and why they are needed. -->
- Update the kill command to actually use the argument and forward signals to init.
- Currently urunc kill command always send SIGKILL, resulting non-terminating signals(ex, SIGWINCH) could hard kill the containers. 
- Hide the ignored `--all` option to keep compatibility.
-  Not sure yet whether `SIGTERM` should follow the same path as `SIGKILL`.

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #594 

### How was this tested?
1. `sudo docker run --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest`
2. `sudo docker kill --signal <signo> <container_id>`
3. See if the container still alives 

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->
GPT-5.5

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
