### PR TITLE
fix: validate Linux spec early to prevent nil dereference panics

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -92,3 +92,6 @@ users:
   neo-0007:
     name: Hrishikesh Gohain
     email: hrishikeshgohain123@gmail.com
+  rishi-jat:
+    name: Rishi Jat
+    email: rishijat098@gmail.com

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -70,6 +70,10 @@ func New(bundlePath string, containerID string, rootDir string, cfg *UruncConfig
 		return nil, err
 	}
 
+	if spec == nil || spec.Linux == nil {
+		return nil, fmt.Errorf("invalid OCI spec: linux section is required")
+	}
+
 	containerName := spec.Annotations["io.kubernetes.cri.container-name"]
 	if containerName == "queue-proxy" {
 		uniklog.Warn("This is a queue-proxy container. Adding IP env.")
@@ -124,6 +128,9 @@ func Get(containerID string, rootDir string) (*Unikontainer, error) {
 	spec, err := loadSpec(state.Bundle)
 	if err != nil {
 		return nil, err
+	}
+	if spec == nil || spec.Linux == nil {
+		return nil, fmt.Errorf("invalid OCI spec: linux section is required")
 	}
 	u.BaseDir = containerDir
 	u.RootDir = rootDir
@@ -357,7 +364,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// ExecArgs
 	// If memory limit is set in spec, use it instead of the config default value
-	if u.Spec.Linux.Resources.Memory != nil {
+	if u.Spec.Linux.Resources != nil && u.Spec.Linux.Resources.Memory != nil {
 		if u.Spec.Linux.Resources.Memory.Limit != nil {
 			if *u.Spec.Linux.Resources.Memory.Limit > 0 {
 				vmmArgs.MemSizeB = uint64(*u.Spec.Linux.Resources.Memory.Limit) // nolint:gosec


### PR DESCRIPTION
## Description
Validate the OCI Linux spec early during container initialization and retrieval to prevent nil dereference panics caused by unsafe access to Spec.Linux.

This change establishes the Linux spec invariant once in:

* New()
* Get()

and returns an explicit error when the Linux section is missing.

Additionally, Exec() now guards access to Spec.Linux.Resources.Memory since Resources remains optional even when the Linux spec is present.

### Related issues

- Fixes #409

### How was this tested?

```
gofmt -w pkg/unikontainers/unikontainers.go
go test $(go list ./... | grep -v /tests/e2e)
```

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
