### PR TITLE
docs: update unikernel support list to include all supported frameworks

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -101,3 +101,6 @@ users:
   mdryaan:
     name: Md Raiyan
     email: alikhurshid842001@gmail.com
+  Anshumancanrock:
+    name: anshumancanrock
+    email: anshu.1239.as@gmail.com

--- a/docs/unikernel-support.md
+++ b/docs/unikernel-support.md
@@ -9,9 +9,13 @@ One of the main goals of `urunc` is to bridge the gap between unikernels and
 the cloud-native ecosystem. For that reason, `urunc` aims to support all the
 available unikernel frameworks and similar technologies.
 
-For the time being, `urunc` provides support for
-[Unikraft](https://unikraft.org/) and
-[Rumprun](https://github.com/cloudkernels/rumprun) unikernels.
+Currently, `urunc` provides support for
+[Unikraft](https://unikraft.org/),
+[MirageOS](https://github.com/mirage/mirage),
+[Rumprun](https://github.com/cloudkernels/rumprun),
+[Mewz](https://github.com/Mewz-project/Mewz),
+[Linux](https://github.com/torvalds/linux) and
+[Hermit](https://hermit-os.org/).
 
 ## Unikraft
 


### PR DESCRIPTION
## Description

The unikernel support page intro was outdated as it stated that urunc only supports Unikraft and Rumprun. However, the page itself already documents six supported frameworks. This PR updates the intro paragraph to accurately reflect all of them.

Also changed the wording from "For the time being" to "Currently" since the original phrasing implied the list was tentative.

### Related issues

- Fixes #627

### How was this tested?

Verified that the updated list matches the sections documented in `unikernel-support.md`, the support table in `README.md` , and the table in `docs/index.md`.

### LLM usage

(N/A)

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
