### PR TITLE
Add Running-urunc-with-kind to tutorials index [Docs]

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -101,3 +101,6 @@ users:
   mdryaan:
     name: Md Raiyan
     email: alikhurshid842001@gmail.com
+  abhaygoudannavar:
+    name: AbhayGoudannavar
+    email: abhaysgoudnvr@gmail.com

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -7,3 +7,4 @@ In this section we include some end-to-end tutorials on deploying
 - [Non root monitor execution](../tutorials/Non-root-monitor-execution)
 - [Running existing containers over Linux](../tutorials/existing-container-linux)
 - [Running vAccel-enabled Containers with `urunc`](../tutorials/Running-vaccel-with-urunc.md)
+- [Running `urunc` with kind](../tutorials/Running-urunc-with-kind)


### PR DESCRIPTION

## Description
The `Running-urunc-with-kind.md` tutorial exists in `docs/tutorials/` but is not listed in `docs/tutorials/index.md`, making it undiscoverable from the documentation site navigation. This PR adds the missing entry to the tutorials index.
### Related issues
- Fixes #663
### How was this tested?
Verified that the link path `../tutorials/Running-urunc-with-kind` correctly resolves to the existing `Running-urunc-with-kind.md` file, consistent with the link format used by other entries in the index (e.g., `How-to-urunc-on-k8s`, `eks-tutorial`).
### LLM usage
N/A
### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
9:33 PM
