### PR TITLE
feat: add quiet image pulls by default

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -123,7 +123,11 @@ func commonCmdExec(command string) (output string, err error) {
 }
 
 func commonPull(tool string, image string) error {
-	pullCmd := tool + " image pull " + image
+	pullCmd := tool + " image pull "
+	if !verbosePull() {
+		pullCmd += "-q "
+	}
+	pullCmd += image
 
 	output, err := commonCmdExec(pullCmd)
 	if err != nil {

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -81,8 +81,11 @@ func pullImageWithRetry(testFunc string, image string) error {
 func pullImageForTest(testFunc string, image string) error {
 	switch testFunc {
 	case testCrictl:
-		cmd := crictlName + " pull " + image
-		output, err := commonCmdExec(cmd)
+		cmd := crictlName + " pull "
+		if !verbosePull() {
+			cmd += "-q "
+		}
+		cmd += image
 		if err != nil {
 			return fmt.Errorf("%s -- %v", output, err)
 		}
@@ -256,4 +259,10 @@ func findLineInFile(filePath string, pattern string) (string, error) {
 	}
 
 	return "", fmt.Errorf("Pattern %s was not found in any line of %s", pattern, filePath)
+}
+
+// Set URUNC_VERBOSE_PULL=true locally to see pull progress output
+func verbosePull() bool {
+	v := os.Getenv("URUNC_VERBOSE_PULL")
+	return v == "1" || v == "true"
 }


### PR DESCRIPTION
## Description
This PR suppresses noisy image pull progress output during end-to-end tests by enabling quiet image pulls by default for supported tools (e.g. docker and nerdctl).

An optional `URUNC_VERBOSE_PULL` environment variable was added to allow verbose image pull logs when debugging is needed.
<!-- Describe the changes and why they are needed. -->

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #654 

### How was this tested?

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
