### PR TITLE
fix: prevent QEMU command injection via args.Command

### DIFF
--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -57,87 +57,96 @@ func (q *Qemu) Path() string {
 
 func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
 	qemuMem := BytesToStringMB(args.MemSizeB)
-	cmdString := q.binaryPath + " -m " + qemuMem + "M"
-	cmdString += " -L /usr/share/qemu"                                  // Set the path for qemu bios/data
-	cmdString += " -cpu host"                                           // Choose CPU
-	cmdString += " -enable-kvm"                                         // Enable KVM to use CPU virt extensions
-	cmdString += " -display none -vga none -serial stdio -monitor null" // Disable graphic output
+
+	exArgs := []string{q.binaryPath}
+
+	exArgs = append(exArgs, "-m", qemuMem+"M")
+	exArgs = append(exArgs, "-L", "/usr/share/qemu")
+	exArgs = append(exArgs, "-cpu", "host")
+	exArgs = append(exArgs, "-enable-kvm")
+	exArgs = append(exArgs, "-display", "none", "-vga", "none", "-serial", "stdio", "-monitor", "null")
 
 	if args.VCPUs > 0 {
-		cmdString += fmt.Sprintf(" -smp %d", args.VCPUs)
+		exArgs = append(exArgs, "-smp", fmt.Sprintf("%d", args.VCPUs))
 	}
 
 	if args.Seccomp {
-		// Enable Seccomp in QEMU
-		cmdString += " --sandbox on"
-		// Allow or Deny Obsolete system calls
-		cmdString += ",obsolete=deny"
-		// Allow or Deny set*uid|gid system calls
-		cmdString += ",elevateprivileges=deny"
-		// Allow or Deny *fork and execve
-		cmdString += ",spawn=deny"
-		// Allow or Deny process affinity and schedular priority
-		cmdString += ",resourcecontrol=deny"
+		exArgs = append(exArgs, "--sandbox", "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny")
 	}
 
-	// TODO: Check if this check causes any performance drop
-	// or explore alternative implementations
 	if runtime.GOARCH == "arm64" {
-		machineType := " -M virt"
-		cmdString += machineType
+		exArgs = append(exArgs, "-M", "virt")
 	}
 
-	cmdString += " -kernel " + args.UnikernelPath
+	exArgs = append(exArgs, "-kernel", args.UnikernelPath)
+
 	if args.Net.TapDev != "" {
 		netcli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
 		if netcli == "" {
-			netcli += " -netdev tap,id=net0,script=no,downscript=no,ifname="
-			netcli += args.Net.TapDev
-			if q.vhost {
-				netcli += ",vhost=on"
+			netcliArgs := []string{
+				"-netdev", fmt.Sprintf("tap,id=net0,script=no,downscript=no,ifname=%s", args.Net.TapDev),
 			}
-			netcli += fmt.Sprintf(" %s,host_mtu=%d,mac=%s", getVirtioNetArg(), args.Net.MTU, args.Net.MAC)
+			if q.vhost {
+				netcliArgs[0] += ",vhost=on"
+			}
+			netcliArgs = append(netcliArgs, fmt.Sprintf("%s,host_mtu=%d,mac=%s", getVirtioNetArg(), args.Net.MTU, args.Net.MAC))
+			exArgs = append(exArgs, netcliArgs...)
+		} else {
+			exArgs = append(exArgs, strings.Fields(netcli)...)
 		}
-		cmdString += netcli
 	} else {
-		cmdString += " -nic none"
+		exArgs = append(exArgs, "-nic", "none")
 	}
+
 	blockArgs := ukernel.MonitorBlockCli()
 	for _, blockArg := range blockArgs {
 		blockCli := blockArg.ExactArgs
 		if blockCli == "" && blockArg.ID != "" && blockArg.Path != "" {
-			blockCli1 := fmt.Sprintf(" -device virtio-blk-pci,serial=%s,drive=%s,scsi=off", blockArg.ID, blockArg.ID)
-			blockCli2 := fmt.Sprintf(" -drive format=raw,if=none,id=%s,file=%s", blockArg.ID, blockArg.Path)
-			blockCli = blockCli1 + blockCli2
+			exArgs = append(exArgs,
+				"-device", fmt.Sprintf("virtio-blk-pci,serial=%s,drive=%s,scsi=off", blockArg.ID, blockArg.ID),
+				"-drive", fmt.Sprintf("format=raw,if=none,id=%s,file=%s", blockArg.ID, blockArg.Path),
+			)
+		} else if blockCli != "" {
+			exArgs = append(exArgs, strings.Fields(blockCli)...)
 		}
-		cmdString += blockCli
 	}
+
 	if args.InitrdPath != "" {
-		cmdString += " -initrd " + args.InitrdPath
+		exArgs = append(exArgs, "-initrd", args.InitrdPath)
 	}
+
 	switch args.Sharedfs.Type {
 	case "9pfs":
-		cmdString += " -fsdev local,id=rootfs9p,security_model=none,path=" + args.Sharedfs.Path
-		cmdString += " -device virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0"
+		exArgs = append(exArgs,
+			"-fsdev", fmt.Sprintf("local,id=rootfs9p,security_model=none,path=%s", args.Sharedfs.Path),
+			"-device", "virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0",
+		)
 	case "virtiofs":
-		cmdString += " -object memory-backend-file,id=mem,size=" + qemuMem + "M,mem-path=/tmp,share=on"
-		cmdString += " -numa node,memdev=mem"
-		cmdString += " -chardev socket,id=char0,path=/tmp/vhostqemu"
-		cmdString += " -device vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=fs0"
+		exArgs = append(exArgs,
+			"-object", fmt.Sprintf("memory-backend-file,id=mem,size=%sM,mem-path=/tmp,share=on", qemuMem),
+			"-numa", "node,memdev=mem",
+			"-chardev", "socket,id=char0,path=/tmp/vhostqemu",
+			"-device", "vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=fs0",
+		)
 	default:
 		// Nothing to add
 	}
+
 	extraMonArgs := ukernel.MonitorCli()
 	if extraMonArgs.ExtraInitrd != "" {
-		cmdString += " -initrd " + extraMonArgs.ExtraInitrd
+		exArgs = append(exArgs, "-initrd", extraMonArgs.ExtraInitrd)
 	}
-	cmdString += extraMonArgs.OtherArgs
+
+	if extraMonArgs.OtherArgs != "" {
+		exArgs = append(exArgs, strings.Fields(extraMonArgs.OtherArgs)...)
+	}
 
 	if args.VAccelType == "vsock" {
-		cmdString += " -device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=" + fmt.Sprintf("%d", args.VSockDevID)
+		exArgs = append(exArgs,
+			"-device", fmt.Sprintf("vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=%d", args.VSockDevID),
+		)
 	}
 
-	exArgs := strings.Split(cmdString, " ")
 	exArgs = append(exArgs, "-append", args.Command)
 	return exArgs, nil
 }


### PR DESCRIPTION
---                                                                                                                                                                 
### Description
                                                                                                                                                                      
This fix addresses a command injection vulnerability in the QEMU hypervisor implementation. The previous BuildExecCmd() function built the QEMU command as a string,then split it on spaces with strings.Split(cmdString, " "). When args.Command (derived from OCI annotations) contained whitespace-separated values, they were  incorrectly parsed as separate QEMU command-line flags instead of a single kernel command-line string.
                                                                                                                                                                      
For example, a malicious container image could set an OCI annotation like org.unikernel.cmdline: quiet -drive file=/dev/sda, which would inject the -drive flag into the QEMU command line, enabling arbitrary disk access.
                                                                                                                                                                      
Fix: Refactor BuildExecCmd() to build arguments as a []string from the start using append() calls, ensuring args.Command is passed as a single argument after  -append. This follows the same pattern used by Cloud Hypervisor in the codebase.
                                                                                                                                                                      
## Related issues                                                                                                                                                      
   
- Fixes #666                                                                                                                                                          
                                                                                                                                                                      
## How was this tested?                                                                                                                                                
                                                                                                                                                                      
  - Code compiles successfully: GOOS=linux go build ./pkg/unikontainers/hypervisors/                                                                                  
  - Go vet passes: GOOS=linux go vet ./pkg/unikontainers/hypervisors/                                                                                                 
  - Existing unit tests pass (tested via make unittest on Linux)                                                                                                      
                                                                                                                                                                      
## LLM usage                                                                                                                                                           
                                                                                                                                                                      
Claude Opus 4.7 was consulted for code review. All code has been reviewed and tested locally.                                                 
                                                                                                                                                                      
## Checklist                                                                                                                                                           
                                                                                                                                                                      
 - [x] I have read the contribution guide (https://urunc.io/developer-guide/contribute/).                                                                                
 - [x] The linter passes locally (make lint).
 - [ ] The e2e tests of at least one tool pass locally (make test_ctr, make test_nerdctl, make test_docker, make test_crictl).                                           
 - [x] I have read the llm policy (https://urunc.io/developer-guide/llm-policy/).                                                                     
                                                                                                                                                                      
  ---    