### PR TITLE
 fix(unikernels): skip network args in mewz commandstring when no network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ test: unittest e2etest
 
 ## unittest Run all unit tests
 .PHONY: unittest
-unittest: test_unikontainers test_metrics test_network test_hypervisors
+unittest: test_unikontainers test_metrics test_network test_hypervisors test_unikernels
 
 ## e2etest Run all end-to-end tests
 .PHONY: e2etest
@@ -261,6 +261,12 @@ test_network:
 test_hypervisors:
 	@echo "Unit testing in hypervisors"
 	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/unikontainers/hypervisors -v
+	@echo " "
+
+## test_unikernels Run unit tests for unikernels package
+test_unikernels:
+	@echo "Unit testing in unikernels"
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/unikontainers/unikernels -v
 	@echo " "
 
 ## test_nerdctl Run all end-to-end tests with nerdctl

--- a/pkg/unikontainers/unikernels/mewz.go
+++ b/pkg/unikontainers/unikernels/mewz.go
@@ -36,8 +36,10 @@ type MewzNet struct {
 }
 
 func (m *Mewz) CommandString() (string, error) {
-	return fmt.Sprintf("ip=%s/%d gateway=%s ", m.Net.Address, m.Net.Mask,
-		m.Net.Gateway), nil
+	if m.Net.Address != "" {
+		return fmt.Sprintf("ip=%s/%d gateway=%s", m.Net.Address, m.Net.Mask, m.Net.Gateway), nil
+	}
+	return "", nil
 }
 
 func (m *Mewz) SupportsBlock() bool {

--- a/pkg/unikontainers/unikernels/mewz_test.go
+++ b/pkg/unikontainers/unikernels/mewz_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMewzCommandString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		mewz     *Mewz
+		expected string
+	}{
+		{
+			name:     "no network configured",
+			mewz:     &Mewz{},
+			expected: "",
+		},
+		{
+			name: "with network configured",
+			mewz: &Mewz{
+				Net: MewzNet{
+					Address: "10.0.0.2",
+					Mask:    24,
+					Gateway: "10.0.0.1",
+				},
+			},
+			expected: "ip=10.0.0.2/24 gateway=10.0.0.1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := tc.mewz.CommandString()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`Mewz.CommandString()` unconditionally formatted `ip=%s/%d gateway=%s` even when no network was configured, producing `"ip=/0 gateway= "` as kernel boot parameters. Mewz does not handle this and panics at startup.

Guard the network args behind an `m.Net.Address != ""` check, matching the pattern already used by `Hermit.CommandString()`. Add unit tests covering both the no-network and with-network cases.

### Related issues

- Fixes #672

### How was this tested?

Added two unit tests in `pkg/unikontainers/unikernels/mewz_test.go`:

- `TestMewzCommandStringNoNetwork`: asserts `CommandString()` returns `""` when no network is configured.
- `TestMewzCommandStringWithNetwork`: asserts `CommandString()` returns  `"ip=10.0.0.2/24 gateway=10.0.0.1"` when network is configured.

**Before fix** (bug reproduced):
<img width="1465" height="562" alt="Screenshot 2026-05-14 064959" src="https://github.com/user-attachments/assets/f0283406-6304-4a7d-8182-a2ca5c240daf" />

**After fix**:
<img width="1451" height="214" alt="Screenshot 2026-05-14 065053" src="https://github.com/user-attachments/assets/9040460f-9324-424c-9945-a03a9382fd8a" />


### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).