### PR TITLE
fix(create): report actual exit status when nsenter exits unsuccessfully

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -98,3 +98,6 @@ users:
   parthdagia05:
     name: Parth Dagia
     email: parth.24bcs10414@sst.scaler.com
+  mdryaan:
+    name: Md Raiyan
+    email: alikhurshid842001@gmail.com

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -333,7 +333,7 @@ func handleNsenterRet(initSock *os.File, reexec *exec.Cmd) (int, error) {
 	}
 	if !status.Success() {
 		_ = reexec.Wait()
-		return -1, fmt.Errorf("nsenter unsuccessful exit: %w", err)
+		return -1, fmt.Errorf("nsenter unsuccessful exit: %d", status.ExitCode())
 	}
 
 	return pid.Stage2Pid, nil


### PR DESCRIPTION
## Description

`handleNsenterRet` in `cmd/urunc/create.go` wraps `err` with `%w` inthe branch that handles an unsuccessful nsenter exit. That branch isonly reachable when `err == nil` — the `err != nil` case is handled above it. The resulting error message always reads
`"nsenter unsuccessful exit: <nil>"`, hiding the actual exit code.

Fixed by formatting the exit code from `status.ExitCode()` directly instead of wrapping `err`.

### Related issues

- Fixes #675 

### How was this tested?

Fix verified by code inspection — the branch is only reachable when `err` is nil, making the `%w` wrap provably wrong. All CI checks pass locally:

- `golangci-lint run -v --timeout=5m` — 0 issues
- `go test ./pkg/unikontainers/... ./internal/metrics/... ./pkg/network/...` — PASS
- `make` — builds successfully

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).