### PR TITLE
fix(unikontainers): preserve slice order when removing element

### DIFF
--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -164,8 +164,7 @@ func handleQueueProxy(spec specs.Spec, configFile string) error {
 }
 
 func remove(s []string, i int) []string {
-	s[i] = s[len(s)-1]
-	return s[:len(s)-1]
+	return append(s[:i], s[i+1:]...)
 }
 
 func checkValidNsPath(path string) error {

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -234,6 +234,12 @@ func TestMoveFile(t *testing.T) {
 	})
 }
 
+func TestRemovePreservesOrder(t *testing.T) {
+	t.Parallel()
+	result := remove([]string{"a", "b", "c", "d"}, 0)
+	assert.Equal(t, []string{"b", "c", "d"}, result)
+}
+
 func TestLoadSpec(t *testing.T) {
 	t.Run("load spec success", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Description
  `remove()` in `pkg/unikontainers/utils.go` removed an element by swapping it with the last element before truncating. This destroyed the ordering of all  remaining elements. Both call sites are affected: `handleQueueProxy` (removes `SERVING_READINESS_PROBE` from `spec.Process.Env`) and the vAccel env cleanup  in `unikontainers.go` (removes `VACCEL_RPC_ADDRESS`). Replace the  swap-and-truncate with `append(s[:i], s[i+1:]...)` to preserve order.

  ### Related issues
  - Fixes #677 

  ### How was this tested?
  Added `TestRemovePreservesOrder` to `pkg/unikontainers/utils_test.go`. The test
  calls `remove([]string{"a", "b", "c", "d"}, 0)` and asserts the result is
  `["b", "c", "d"]`.

 ### Before fix:
<img width="1407" height="644" alt="Screenshot 2026-05-14 083407" src="https://github.com/user-attachments/assets/9e44a024-1b62-434f-bfd3-7f1f9933b797" />

  ### After fix:

<img width="1426" height="192" alt="Screenshot 2026-05-14 083605" src="https://github.com/user-attachments/assets/8feb929c-212e-4fc7-9455-e07651b53e67" />

  Run with:
  go test ./pkg/unikontainers/ -v -run TestRemovePreservesOrder

  `golangci-lint run` passes with 0 issues. `make` builds successfully.

  ### LLM usage
  N/A

  ### Checklist
  - [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
  - [x] The linter passes locally (`make lint`).
  - [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
  - [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
