### PR TITLE
 fix(hypervisors): prevent double --initramfs flag in Cloud Hypervisor command

### DIFF
--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -120,15 +120,15 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 		}
 	}
 
-	// Initrd configuration
-	if args.InitrdPath != "" {
-		exArgs = append(exArgs, "--initramfs", args.InitrdPath)
-	}
-
-	// Check for extra initrd from unikernel monitor args
 	extraMonArgs := ukernel.MonitorCli()
-	if extraMonArgs.ExtraInitrd != "" {
-		exArgs = append(exArgs, "--initramfs", extraMonArgs.ExtraInitrd)
+
+	// Initrd configuration — prefer args.InitrdPath, fall back to unikernel extra initrd
+	initrdPath := args.InitrdPath
+	if initrdPath == "" {
+		initrdPath = extraMonArgs.ExtraInitrd
+	}
+	if initrdPath != "" {
+		exArgs = append(exArgs, "--initramfs", initrdPath)
 	}
 
 	switch args.Sharedfs.Type {

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor_test.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+type mockUnikernel struct {
+	extraInitrd string
+}
+
+func (m *mockUnikernel) Init(_ types.UnikernelParams) error        { return nil }
+func (m *mockUnikernel) CommandString() (string, error)            { return "", nil }
+func (m *mockUnikernel) SupportsBlock() bool                       { return false }
+func (m *mockUnikernel) SupportsFS(_ string) bool                  { return false }
+func (m *mockUnikernel) MonitorNetCli(_, _ string) string          { return "" }
+func (m *mockUnikernel) MonitorBlockCli() []types.MonitorBlockArgs { return nil }
+func (m *mockUnikernel) MonitorCli() types.MonitorCliArgs {
+	return types.MonitorCliArgs{ExtraInitrd: m.extraInitrd}
+}
+
+func TestCloudHypervisorSingleInitrd(t *testing.T) {
+	t.Parallel()
+	ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: "/usr/bin/cloud-hypervisor"}
+	args := types.ExecArgs{
+		UnikernelPath: "/unikernel",
+		InitrdPath:    "/primary/initrd",
+		MemSizeB:      256 * 1024 * 1024,
+		Command:       "console=ttyS0",
+	}
+	ukernel := &mockUnikernel{extraInitrd: "/extra/initrd"}
+
+	result, err := ch.BuildExecCmd(args, ukernel)
+	assert.NoError(t, err)
+
+	count := 0
+	for _, arg := range result {
+		if arg == "--initramfs" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "expected exactly one --initramfs flag")
+}


### PR DESCRIPTION

 ## Description
  `BuildExecCmd` in `cloud_hypervisor.go` appended `--initramfs` unconditionally for both `args.InitrdPath` and `extraMonArgs.ExtraInitrd`. When both were set, the Cloud Hypervisor command line contained two `--initramfs` flags and Cloud  Hypervisor rejected it. Apply the same priority-fallback logic already used by  the Firecracker implementation: resolve to `args.InitrdPath` if set, otherwise  fall back to `extraMonArgs.ExtraInitrd`, and append at most one `--initramfs`.

  ### Related issues
  - Fixes #679 

  ### How was this tested?
  Added `TestCloudHypervisorSingleInitrd` to  `pkg/unikontainers/hypervisors/cloud_hypervisor_test.go`. The test calls  `BuildExecCmd` with both `args.InitrdPath` and a mock unikernel returning a  non-empty `ExtraInitrd`, then counts `--initramfs` occurrences in the result.

 ### Before fix:
<img width="1463" height="392" alt="Screenshot 2026-05-14 091623" src="https://github.com/user-attachments/assets/52d87b15-42e6-480c-80b4-7370525f69e1" />

###  After fix:
<img width="1767" height="204" alt="Screenshot 2026-05-14 091934" src="https://github.com/user-attachments/assets/23f1844e-9949-41b2-9062-c38d94ebd875" />

  Run with:
  go test ./pkg/unikontainers/hypervisors/ -v -run TestCloudHypervisorSingleInitrd

  `golangci-lint run` passes with 0 issues. `make` builds successfully.

  ### LLM usage
  N/A

  ### Checklist
  - [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
  - [x] The linter passes locally (`make lint`).
  - [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
  - [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
