### PR TITLE
fix: close namespace fd after Setns in joinSandboxNetNs

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -95,3 +95,7 @@ users:
   rishi-jat:
     name: Rishi Jat
     email: rishijat098@gmail.com
+  atishay-jain:
+    name: Atishay Jain
+    email: atishayjain27@gmail.com
+  github: Atishyy27

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -799,6 +799,7 @@ func (u Unikontainer) joinSandboxNetNs() error {
 	if err != nil {
 		return fmt.Errorf("error opening namespace path: %w", err)
 	}
+	defer unix.Close(fd)
 	err = unix.Setns(int(fd), unix.CLONE_NEWNET)
 	if err != nil {
 		return fmt.Errorf("error joining namespace: %w", err)


### PR DESCRIPTION
## Description

Fixes file descriptor leak in `joinSandboxNetNs()` by adding `defer unix.Close(fd)` immediately after opening the namespace file descriptor.

### Problem
The function opens a file descriptor to the network namespace but never closes it. Since `Kill()` returns normally (no exec happens), the `O_CLOEXEC` flag doesn't help. The fd stays open through the rest of `delete --force` (`Delete()` + `ExecuteHooks("Poststop")`), keeping the namespace reference alive after the VMM is already dead.

### Solution
Add `defer unix.Close(fd)` right after the `unix.Open()` call and error check. This follows the same pattern used in:
- [`vishvananda/netns`](https://github.com/vishvananda/netns)
- [`runc`](https://github.com/opencontainers/runc)

Closing the fd after `Setns` is safe and won't pull the thread out of the namespace.

### Related issues

- Fixes #673

### How was this tested?

Development environment is Windows, so local build/test was not possible (urunc requires Linux syscalls). The fix follows established patterns from `vishvananda/netns` and `runc`. CI tests will validate on Linux.

### LLM usage

Claude 3.7 Sonnet (via claude.ai) was used to:
- Analyze the issue and identify the fix
- Guide through the contribution process
- Help format the commit message and PR description

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`). *(Unable to test on Windows)*
- [ ] The e2e tests of at least one tool pass locally. *(Unable to test on Windows)*
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).