### PR TITLE
docs: update footer trademark link to LF Projects Series LLC

### DIFF
--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,9 +1,9 @@
 <div class="md-copyright">
     {% if config.copyright %}
     <div class="md-copyright__highlight">
-        {{ config.copyright }}.<br>The Linux Foundation has registered trademarks and uses
-        trademarks. For a list of trademarks of The Linux Foundation, please see our <a
-            href="https://www.linuxfoundation.org/trademark-usage" />Trademark Usage page</a>.
+        {{ config.copyright }}.<br>LF Projects, LLC has registered trademarks and uses
+        trademarks. For a list of trademarks of LF Projects, LLC, please see our <a
+            href="https://lfprojects.org/policies/" />Policies page</a>.
     </div>
     {% endif %}
     {% if not config.extra.generator == false %}


### PR DESCRIPTION
## Description
Updates the website footer trademark disclaimer link to point to the new LF Projects Series LLC policies page. 

The old link (`https://www.linuxfoundation.org/trademark-usage`) has been replaced with `https://lfprojects.org/policies/`, and the accompanying text was updated from "The Linux Foundation" to "LF Projects, LLC" to accurately reflect the new trademark entity.

### Related issues
- Fixes #671

### How was this tested?
- Verified the HTML block changes structurally.
- Note: This is a documentation-only change to the MkDocs template.

### LLM usage
N/A

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).