### PR TITLE
ci: add contributor check to validate-files-and-commits

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -95,3 +95,9 @@ users:
   rishi-jat:
     name: Rishi Jat
     email: rishijat098@gmail.com
+  Anshumancanrock:
+    name: Anshuman Singh
+    email: anshu.1239.as@gmail.com
+  parthdagia05:
+    name: Parth Dagia
+    email: parth.24bcs10414@sst.scaler.com

--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -111,3 +111,56 @@ jobs:
         with:
           config: .github/linters/licenserc.yml
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  check-contributor:
+    name: Check Contributor
+    if: github.event.pull_request != null
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+      fail-fast: false
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Check if PR author exists in contributors.yaml
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Normalize username (mirrors nubificus/git-trailers action logic)
+          AUTHOR=$(echo "$PR_AUTHOR" | sed 's/\[bot\]//g' | sed 's/app\///g')
+          echo "Checking for contributor: ${AUTHOR}"
+
+          # Primary lookup: check if username exists as a YAML key
+          if grep -q "^  ${AUTHOR}:" .github/contributors.yaml; then
+            echo "✓ Contributor '${AUTHOR}' found in contributors.yaml"
+            exit 0
+          fi
+
+          # Bot fallback: check if any entry has a matching bot name
+          if grep -q "name: ${AUTHOR}\[bot\]" .github/contributors.yaml; then
+            echo "✓ Contributor '${AUTHOR}' found in contributors.yaml (bot)"
+            exit 0
+          fi
+
+          echo "::error::PR author '${PR_AUTHOR}' is not listed in .github/contributors.yaml."
+          echo ""
+          echo "Please add the following entry to .github/contributors.yaml under the 'users' key as part of this PR:"
+          echo ""
+          echo "  ${AUTHOR}:"
+          echo "    name: Your Full Name"
+          echo "    email: your.email@example.com"
+          echo ""
+          echo "See: https://urunc.io/developer-guide/contribute/"
+          exit 1


### PR DESCRIPTION
## Description

When a PR author isn't listed in `.github/contributors.yaml`, the [`nubificus/git-trailers`](https://github.com/nubificus/git-trailers/blob/main/action.yml) action fails at merge time after the review is already done. This happens in both [`add-git-trailers.yml`](https://github.com/nubificus/urunc/blob/main/.github/workflows/add-git-trailers.yml) and [`pr-merge.yml`](https://github.com/nubificus/urunc/blob/main/.github/workflows/pr-merge.yml).

This PR adds a `check-contributor` job to `validate-files-and-commits.yml` that catches missing contributors early during CI.

The job normalizes the PR author's username using the same [`sed` logic](https://github.com/nubificus/git-trailers/blob/main/action.yml#L54-L55) as `nubificus/git-trailers` (strips `[bot]` suffix, `app/` prefix), does a primary lookup by YAML key, and falls back to a `name` field search for bot accounts. If the author isn't found, it fails with a message showing exactly what entry to add.

### Related issues

- Fixes #683

### How was this tested?

Tested the grep matching logic locally against the current `contributors.yaml`:
- Normal users (`ananos`, `johnp41`) : matched correctly
- Hyphenated names (`mgkeka-nbfc`) : matched correctly
- Case-sensitive entries (`DionisiaK4`) :  matched correctly
- Bot accounts (`dependabot[bot]`) : matched via bot fallback
- Non-existent users :  correctly rejected
- Partial username matches (`anano` vs `ananos`) :  correctly rejected
- Empty input :  correctly rejected

### LLM usage

N/a

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
