### PR TITLE
fix: use annotation for MirageOS net device name

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -107,3 +107,6 @@ users:
   Chennamma-Hotkar:
     name: Chennamma Hotkar
     email: channuhotkar@gmail.com
+  pocopepe:
+    name: Viju Sanjai
+    email: avijusanjai@gmail.com

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -45,6 +45,7 @@ const (
 	annotBlock         = "com.urunc.unikernel.block"
 	annotBlockMntPoint = "com.urunc.unikernel.blkMntPoint"
 	annotMountRootfs   = "com.urunc.unikernel.mountRootfs"
+	annotNetDev        = "com.urunc.unikernel.solo5NetDev"
 )
 
 // A UnikernelConfig struct holds the info provided by bima image on how to execute our unikernel
@@ -58,6 +59,7 @@ type UnikernelConfig struct {
 	Block            string `json:"com.urunc.unikernel.block,omitempty"`
 	BlkMntPoint      string `json:"com.urunc.unikernel.blkMntPoint,omitempty"`
 	MountRootfs      string `json:"com.urunc.unikernel.mountRootfs"`
+	NetDev           string `json:"com.urunc.unikernel.solo5NetDev,omitempty"`
 }
 
 // validate checks if the mandatory configuration fields are present.
@@ -119,6 +121,7 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 	block := spec.Annotations[annotBlock]
 	blkMntPoint := spec.Annotations[annotBlockMntPoint]
 	MountRootfs := spec.Annotations[annotMountRootfs]
+	netDev := spec.Annotations[annotNetDev]
 	uniklog.WithFields(logrus.Fields{
 		"unikernelType":    unikernelType,
 		"unikernelVersion": unikernelVersion,
@@ -129,6 +132,7 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 		"block":            block,
 		"blkMntPoint":      blkMntPoint,
 		"mountRootfs":      MountRootfs,
+		"netDev":           netDev,
 	}).WithField("source", "spec").Debug("urunc annotations")
 
 	return &UnikernelConfig{
@@ -141,6 +145,7 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 		Block:            block,
 		BlkMntPoint:      blkMntPoint,
 		MountRootfs:      MountRootfs,
+		NetDev:           netDev,
 	}
 }
 
@@ -180,6 +185,7 @@ func getConfigFromJSON(jsonFilePath string) (*UnikernelConfig, error) {
 		"block":            tryDecode(conf.Block),
 		"blkMntPoint":      tryDecode(conf.BlkMntPoint),
 		"mountRootfs":      tryDecode(conf.MountRootfs),
+		"netDev":           tryDecode(conf.NetDev),
 	}).WithField("source", uruncJSONFilename).Debug("urunc annotations")
 
 	return &conf, nil
@@ -250,6 +256,12 @@ func (c *UnikernelConfig) decode() error {
 	}
 	c.MountRootfs = string(decoded)
 
+	decoded, err = base64.StdEncoding.DecodeString(c.NetDev)
+	if err != nil {
+		return fmt.Errorf("failed to decode netDev: %v", err)
+	}
+	c.NetDev = string(decoded)
+
 	return nil
 }
 
@@ -282,6 +294,9 @@ func (c *UnikernelConfig) Map() map[string]string {
 	}
 	if c.MountRootfs != "" {
 		myMap[annotMountRootfs] = c.MountRootfs
+	}
+	if c.NetDev != "" {
+		myMap[annotNetDev] = c.NetDev
 	}
 
 	return myMap

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -38,6 +38,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 				annotBlock:         "block1",
 				annotBlockMntPoint: "point1",
 				annotMountRootfs:   "true",
+				annotNetDev:        "management",
 			},
 		}
 
@@ -50,6 +51,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 			Block:           "block1",
 			BlkMntPoint:     "point1",
 			MountRootfs:     "true",
+			NetDev:          "management",
 		}
 
 		config := getConfigFromSpec(spec)
@@ -239,6 +241,7 @@ func TestMap(t *testing.T) {
 			Block:           "block_value",
 			BlkMntPoint:     "point_value",
 			MountRootfs:     "false",
+			NetDev:          "netdev_value",
 		}
 		expectedMap := map[string]string{
 			annotCmdLine:       "cmd_value",
@@ -249,6 +252,7 @@ func TestMap(t *testing.T) {
 			annotBlock:         "block_value",
 			annotBlockMntPoint: "point_value",
 			annotMountRootfs:   "false",
+			annotNetDev:        "netdev_value",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -86,6 +86,7 @@ type UnikernelParams struct {
 	Monitor    string   // The monitor where guest will execute
 	Version    string   // The version of the unikernel
 	InitrdPath string   // The path to the initrd of the unikernel
+	NetDevName string   // The name of the guest network device declared at build time
 	Net        NetDevParams
 	Block      []BlockDevParams
 	Rootfs     RootfsParams  // Information about rootfs

--- a/pkg/unikontainers/unikernels/mirage.go
+++ b/pkg/unikontainers/unikernels/mirage.go
@@ -24,10 +24,11 @@ import (
 const MirageUnikernel string = "mirage"
 
 type Mirage struct {
-	Command string
-	Monitor string
-	Net     MirageNet
-	Block   []MirageBlock
+	Command    string
+	Monitor    string
+	Net        MirageNet
+	Block      []MirageBlock
+	netDevName string
 }
 
 type MirageNet struct {
@@ -57,8 +58,8 @@ func (m *Mirage) SupportsFS(_ string) bool {
 func (m *Mirage) MonitorNetCli(ifName string, mac string) string {
 	switch m.Monitor {
 	case "hvt", "spt":
-		netOption := "--net:service=" + ifName
-		netOption += " --net-mac:service=" + mac
+		netOption := "--net:" + m.netDevName + "=" + ifName
+		netOption += " --net-mac:" + m.netDevName + "=" + mac
 		return netOption
 	default:
 		return ""
@@ -103,8 +104,18 @@ func (m *Mirage) Init(data types.UnikernelParams) error {
 		if err != nil {
 			return err
 		}
-		m.Net.Address = fmt.Sprintf("--ipv4=%s/%d", data.Net.IP, mask)
-		m.Net.Gateway = "--ipv4-gateway=" + data.Net.Gateway
+		// Mirage groups a network device's command line options under a prefix,
+		// and that prefix is the device name. The default device "service" uses
+		// the plain --ipv4 and --ipv4-gateway flags, but any other device needs
+		// its name as the prefix, like --management-ipv4 for a device called
+		// "management". So we only add the prefix when the device is not "service".
+		if data.NetDevName != "" && data.NetDevName != "service" {
+			m.Net.Address = fmt.Sprintf("--%s-ipv4=%s/%d", data.NetDevName, data.Net.IP, mask)
+			m.Net.Gateway = "--" + data.NetDevName + "-ipv4-gateway=" + data.Net.Gateway
+		} else {
+			m.Net.Address = fmt.Sprintf("--ipv4=%s/%d", data.Net.IP, mask)
+			m.Net.Gateway = "--ipv4-gateway=" + data.Net.Gateway
+		}
 	}
 	m.Block = make([]MirageBlock, 0, len(data.Block))
 	for _, blk := range data.Block {
@@ -117,6 +128,12 @@ func (m *Mirage) Init(data types.UnikernelParams) error {
 
 	m.Command = strings.Join(data.CmdLine, " ")
 	m.Monitor = data.Monitor
+
+	if data.NetDevName != "" {
+		m.netDevName = data.NetDevName
+	} else {
+		m.netDevName = "service"
+	}
 
 	return nil
 }

--- a/pkg/unikontainers/unikernels/mirage_test.go
+++ b/pkg/unikontainers/unikernels/mirage_test.go
@@ -73,3 +73,25 @@ func TestMirageInitSubnetMask(t *testing.T) {
 		})
 	}
 }
+
+func TestMirageNetDevName(t *testing.T) {
+	t.Run("uses net device name from annotation", func(t *testing.T) {
+		t.Parallel()
+		m := &Mirage{}
+		err := m.Init(types.UnikernelParams{Monitor: "hvt", NetDevName: "management"})
+		assert.NoError(t, err)
+		cli := m.MonitorNetCli("tap0", "aa:bb:cc:dd:ee:ff")
+		assert.Contains(t, cli, "--net:management=tap0")
+		assert.Contains(t, cli, "--net-mac:management=aa:bb:cc:dd:ee:ff")
+	})
+
+	t.Run("falls back to service when annotation is absent", func(t *testing.T) {
+		t.Parallel()
+		m := &Mirage{}
+		err := m.Init(types.UnikernelParams{Monitor: "hvt"})
+		assert.NoError(t, err)
+		cli := m.MonitorNetCli("tap0", "aa:bb:cc:dd:ee:ff")
+		assert.Contains(t, cli, "--net:service=tap0")
+		assert.Contains(t, cli, "--net-mac:service=aa:bb:cc:dd:ee:ff")
+	})
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -439,11 +439,12 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// UnikernelParams
 	// populate unikernel params
 	unikernelParams := types.UnikernelParams{
-		CmdLine:  u.Spec.Process.Args,
-		EnvVars:  u.Spec.Process.Env,
-		Monitor:  vmmType,
-		Version:  unikernelVersion,
-		ProcConf: procAttrs,
+		CmdLine:    u.Spec.Process.Args,
+		EnvVars:    u.Spec.Process.Env,
+		Monitor:    vmmType,
+		Version:    unikernelVersion,
+		ProcConf:   procAttrs,
+		NetDevName: u.State.Annotations[annotNetDev],
 	}
 	if len(unikernelParams.CmdLine) == 0 {
 		unikernelParams.CmdLine = strings.Fields(u.State.Annotations[annotCmdLine])


### PR DESCRIPTION
## Description

mirageos unikernels declare their network device names at build time through the solo5 manifest. the problem was urunc always hardcoded "service" as the device name, so if you built a unikernel with a different name it would just fail.
i added a new annotation `com.urunc.unikernel.netDev` so image builders can set the name at build time and urunc picks it up at runtime. if the annotation isn't there it falls back to "service" so existing images still work.

block device naming and multi network support i left for follow up prs as discussed.

### Related issues

- Fixes #315

### How was this tested?

```bash
go test ./pkg/unikontainers/unikernels/... -v -run TestMirageNetDevName

=== RUN   TestMirageNetDevName
=== RUN   TestMirageNetDevName/uses_net_device_name_from_annotation
=== PAUSE TestMirageNetDevName/uses_net_device_name_from_annotation
=== RUN   TestMirageNetDevName/falls_back_to_service_when_annotation_is_absent
=== PAUSE TestMirageNetDevName/falls_back_to_service_when_annotation_is_absent
=== CONT  TestMirageNetDevName/uses_net_device_name_from_annotation
=== CONT  TestMirageNetDevName/falls_back_to_service_when_annotation_is_absent
--- PASS: TestMirageNetDevName (0.00s)
    --- PASS: TestMirageNetDevName/uses_net_device_name_from_annotation (0.00s)
    --- PASS: TestMirageNetDevName/falls_back_to_service_when_annotation_is_absent (0.00s)
PASS
ok      github.com/urunc-dev/urunc/pkg/unikontainers/unikernels (cached)
```

### LLM usage

Claude Sonnet 4.6

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).