### PR TITLE
fix(config): remove spurious error log from tryDecode on decode failure

### DIFF
--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -196,7 +196,6 @@ func getConfigFromJSON(jsonFilePath string) (*UnikernelConfig, error) {
 func tryDecode(s string) string {
 	decoded, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		uniklog.WithError(err).Errorf("Failed to decode string: %s", s)
 		return s
 	}
 	return string(decoded)


### PR DESCRIPTION
## Description

`tryDecode()` in `pkg/unikontainers/config.go` logs at error level when base64 decoding fails. Since annotation values like `"qemu"` or `"unikraft"` are plain text, this fires on every container start — not a real error. 
The fallback to the original string is the intended behavior. Removed the log call entirely.

### Related issues
- Fixes #691 

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).