### PR TITLE
pkg/unikontainers: extract Exec phases into helper methods

### DIFF
--- a/pkg/unikontainers/exec_helpers.go
+++ b/pkg/unikontainers/exec_helpers.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package unikontainers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+// buildVMMArgs constructs the ExecArgs for the VMM from the unikontainer spec and config.
+func (u *Unikontainer) buildVMMArgs(vmmType, unikernelPath, initrdPath string) (types.ExecArgs, error) {
+	defaultVCPUs := u.UruncCfg.Monitors[vmmType].DefaultVCPUs
+	if defaultVCPUs < 1 {
+		defaultVCPUs = 1
+	}
+	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
+
+	args := types.ExecArgs{
+		ContainerID:   u.State.ID,
+		UnikernelPath: unikernelPath,
+		InitrdPath:    initrdPath,
+		Seccomp:       true,
+		MemSizeB:      uint64(defaultMemSizeMB * 1024 * 1024),
+		VCPUs:         uint(defaultVCPUs),
+		Environment:   os.Environ(),
+	}
+
+	if u.Spec.Linux.Resources != nil && u.Spec.Linux.Resources.Memory != nil {
+		if u.Spec.Linux.Resources.Memory.Limit != nil {
+			if *u.Spec.Linux.Resources.Memory.Limit > 0 {
+				args.MemSizeB = uint64(*u.Spec.Linux.Resources.Memory.Limit) //nolint:gosec
+			}
+		}
+	}
+
+	if u.Spec.Linux.Seccomp == nil {
+		uniklog.Warn("Seccomp is disabled")
+		args.Seccomp = false
+	}
+
+	return args, nil
+}
+
+// buildUnikernelParams constructs the UnikernelParams from the unikontainer spec.
+func (u *Unikontainer) buildUnikernelParams(vmmType, unikernelVersion string) types.UnikernelParams {
+	procAttrs := types.ProcessConfig{
+		UID:     u.Spec.Process.User.UID,
+		GID:     u.Spec.Process.User.GID,
+		WorkDir: u.Spec.Process.Cwd,
+	}
+
+	params := types.UnikernelParams{
+		CmdLine:  u.Spec.Process.Args,
+		EnvVars:  u.Spec.Process.Env,
+		Monitor:  vmmType,
+		Version:  unikernelVersion,
+		ProcConf: procAttrs,
+	}
+
+	if len(params.CmdLine) == 0 {
+		params.CmdLine = strings.Fields(u.State.Annotations[annotCmdLine])
+	}
+
+	return params
+}
+
+// setupRootfs selects and prepares the guest rootfs, returning the builder and params.
+func (u *Unikontainer) setupRootfs(
+	vmmType, unikernelType, unikernelPath, initrdPath string,
+	unikernel types.Unikernel,
+	vmm types.VMM,
+	vmmArgs *types.ExecArgs,
+	withTUNTAP bool,
+) (rootfsBuilder, types.RootfsParams, error) {
+	rootfsParams, err := u.chooseRootfs()
+	if err != nil {
+		return nil, types.RootfsParams{}, fmt.Errorf("setupRootfs: choose rootfs: %w", err)
+	}
+
+	virtiofsdConfig := u.UruncCfg.ExtraBins["virtiofsd"]
+
+	var rfsBuilder rootfsBuilder
+	switch rootfsParams.Type {
+	case "block":
+		rfsBuilder = blockRootfs{
+			mounts:        u.Spec.Mounts,
+			monRootfs:     rootfsParams.MonRootfs,
+			mountedPath:   rootfsParams.MountedPath,
+			path:          rootfsParams.Path,
+			kernelPath:    unikernelPath,
+			initrdPath:    initrdPath,
+			uruncJSONPath: uruncJSONFilename,
+			guestType:     unikernelType,
+			guest:         unikernel,
+		}
+	case "initrd":
+		rfsBuilder = initrdRootfs{
+			mounts:             u.Spec.Mounts,
+			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
+			monRootfs:          rootfsParams.MonRootfs,
+		}
+	case "virtiofs", "9pfs":
+		rfsBuilder = sharedfsRootfs{
+			mounts:      u.Spec.Mounts,
+			monRootfs:   rootfsParams.MonRootfs,
+			mountedPath: rootfsParams.MountedPath,
+			sfsType:     rootfsParams.Type,
+			vfsdConfig:  virtiofsdConfig,
+			sharedPath:  containerRootfsMountPath,
+			memory:      vmmArgs.MemSizeB,
+		}
+		vmmArgs.UnikernelPath = adjustPathsForSharedfs(vmmArgs.UnikernelPath)
+		vmmArgs.InitrdPath = adjustPathsForSharedfs(vmmArgs.InitrdPath)
+	default:
+		uniklog.Debug("No rootfs for guest")
+		rfsBuilder = noRootfs{
+			monRootfs:            rootfsParams.MonRootfs,
+			annotBlockPath:       u.State.Annotations[annotBlock],
+			annotBlockMountPoint: u.State.Annotations[annotBlockMntPoint],
+		}
+	}
+
+	if err := rfsBuilder.preSetup(); err != nil {
+		return nil, types.RootfsParams{}, fmt.Errorf("setupRootfs: preSetup: %w", err)
+	}
+	if err := prepareRoot(rootfsParams.MonRootfs, u.Spec.Linux.RootfsPropagation); err != nil {
+		return nil, types.RootfsParams{}, fmt.Errorf("setupRootfs: prepareRoot: %w", err)
+	}
+	if err := prepareMonRootfs(rootfsParams.MonRootfs, vmm.Path(), u.UruncCfg.Monitors[vmmType].DataPath, vmm.UsesKVM(), withTUNTAP); err != nil {
+		return nil, types.RootfsParams{}, fmt.Errorf("setupRootfs: prepareMonRootfs: %w", err)
+	}
+	if err := rfsBuilder.postSetup(); err != nil {
+		return nil, types.RootfsParams{}, fmt.Errorf("setupRootfs: postSetup: %w", err)
+	}
+
+	return rfsBuilder, rootfsParams, nil
+}
+
+// setupVAccel configures vAccel acceleration if annotations are present.
+// It mutates vmmArgs and unikernelParams in place.
+func (u *Unikontainer) setupVAccel(
+	vmmArgs *types.ExecArgs,
+	unikernelParams *types.UnikernelParams,
+	monRootfs string,
+) {
+	vAccelType, vsockSocketPath, rpcAddress, err := resolveVAccelConfig(
+		u.State.Annotations[annotHypervisor],
+		u.Spec.Annotations,
+	)
+	if err != nil {
+		uniklog.Debugf("vAccel config: %v", err)
+		return
+	}
+	if vAccelType != "vsock" {
+		return
+	}
+
+	for i, envVar := range unikernelParams.EnvVars {
+		if strings.HasPrefix(envVar, "VACCEL_RPC_ADDRESS=") {
+			unikernelParams.EnvVars = remove(unikernelParams.EnvVars, i)
+			break
+		}
+	}
+	unikernelParams.EnvVars = append(unikernelParams.EnvVars, "VACCEL_RPC_ADDRESS="+rpcAddress)
+
+	if err := prepareVSockEnvironment(monRootfs, u.State.Annotations[annotHypervisor], vsockSocketPath); err != nil {
+		uniklog.Debugf("failed to prepare vsock mounts: %v", err)
+	}
+
+	vmmArgs.VAccelType = vAccelType
+	vmmArgs.VSockDevPath = vsockSocketPath
+	vmmArgs.VSockDevID = idToGuestCID(u.State.ID)
+}

--- a/pkg/unikontainers/exec_helpers_test.go
+++ b/pkg/unikontainers/exec_helpers_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package unikontainers
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func makeTestUnikontainer(vmmType string, memMB uint, vcpus uint) *Unikontainer {
+	cfg := defaultUruncConfig()
+	cfg.Monitors[vmmType] = types.MonitorConfig{
+		DefaultMemoryMB: memMB,
+		DefaultVCPUs:    vcpus,
+	}
+	return &Unikontainer{
+		State: &specs.State{
+			ID: "container123",
+			Annotations: map[string]string{},
+		},
+		Spec: &specs.Spec{
+			Process: &specs.Process{
+				Args: []string{"/bin/sh", "-c", "echo hi"},
+				Env:  []string{"FOO=bar"},
+				Cwd:  "/",
+				User: specs.User{UID: 1000, GID: 1000},
+			},
+			Linux: &specs.Linux{
+				Seccomp: &specs.LinuxSeccomp{},
+			},
+		},
+		UruncCfg: cfg,
+	}
+}
+
+func TestBuildVMMArgs(t *testing.T) {
+	t.Run("default memory and vcpus", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 2)
+		args, err := u.buildVMMArgs("qemu", "/bin/unikernel", "/tmp/initrd")
+		assert.NoError(t, err)
+		assert.Equal(t, "container123", args.ContainerID)
+		assert.Equal(t, "/bin/unikernel", args.UnikernelPath)
+		assert.Equal(t, "/tmp/initrd", args.InitrdPath)
+		assert.Equal(t, uint64(256*1024*1024), args.MemSizeB)
+		assert.Equal(t, uint(2), args.VCPUs)
+		assert.True(t, args.Seccomp, "seccomp should be enabled by default")
+	})
+
+	t.Run("seccomp disabled when nil", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 2)
+		u.Spec.Linux.Seccomp = nil
+		args, err := u.buildVMMArgs("qemu", "/bin/unikernel", "")
+		assert.NoError(t, err)
+		assert.False(t, args.Seccomp, "seccomp should be disabled")
+	})
+
+	t.Run("memory limit from spec overrides default", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 2)
+		limit := int64(512 * 1024 * 1024)
+		u.Spec.Linux.Resources = &specs.LinuxResources{
+			Memory: &specs.LinuxMemory{Limit: &limit},
+		}
+		args, err := u.buildVMMArgs("qemu", "/bin/unikernel", "")
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(limit), args.MemSizeB)
+	})
+
+	t.Run("vcpus defaults to 1 if zero", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 0)
+		args, err := u.buildVMMArgs("qemu", "/bin/unikernel", "")
+		assert.NoError(t, err)
+		assert.Equal(t, uint(1), args.VCPUs, "zero vcpus should default to 1")
+	})
+}
+
+func TestBuildUnikernelParams(t *testing.T) {
+	t.Run("cmdline from spec args", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 2)
+		params := u.buildUnikernelParams("qemu", "0.1")
+		assert.Equal(t, []string{"/bin/sh", "-c", "echo hi"}, params.CmdLine)
+		assert.Equal(t, []string{"FOO=bar"}, params.EnvVars)
+		assert.Equal(t, "qemu", params.Monitor)
+		assert.Equal(t, "0.1", params.Version)
+		assert.Equal(t, uint32(1000), params.ProcConf.UID)
+		assert.Equal(t, uint32(1000), params.ProcConf.GID)
+	})
+
+	t.Run("cmdline falls back to annotation", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 2)
+		u.Spec.Process.Args = nil
+		u.State.Annotations[annotCmdLine] = "echo hello world"
+		params := u.buildUnikernelParams("qemu", "")
+		assert.Equal(t, []string{"echo", "hello", "world"}, params.CmdLine)
+	})
+
+	t.Run("empty cmdline and no annotation", func(t *testing.T) {
+		t.Parallel()
+		u := makeTestUnikontainer("qemu", 256, 2)
+		u.Spec.Process.Args = nil
+		params := u.buildUnikernelParams("qemu", "")
+		assert.Empty(t, params.CmdLine)
+	})
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -344,58 +343,12 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		"initrd Path":       initrdPath,
 	}).Debug("Initialization values")
 
-	// ExecArgs
-	defaultVCPUs := u.UruncCfg.Monitors[vmmType].DefaultVCPUs
-	if defaultVCPUs < 1 {
-		defaultVCPUs = 1
+		// build VMM args and unikernel params via helpers
+	vmmArgs, err := u.buildVMMArgs(vmmType, unikernelPath, initrdPath)
+	if err != nil {
+		return err
 	}
-	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
-
-	// ExecArgs
-	vmmArgs := types.ExecArgs{
-		ContainerID:   u.State.ID,
-		UnikernelPath: unikernelPath,
-		InitrdPath:    initrdPath,
-		Seccomp:       true, // Enable Seccomp by default
-		MemSizeB:      uint64(defaultMemSizeMB * 1024 * 1024),
-		VCPUs:         uint(defaultVCPUs),
-		Environment:   os.Environ(),
-	}
-
-	// ExecArgs
-	// If memory limit is set in spec, use it instead of the config default value
-	if u.Spec.Linux.Resources != nil && u.Spec.Linux.Resources.Memory != nil {
-		if u.Spec.Linux.Resources.Memory.Limit != nil {
-			if *u.Spec.Linux.Resources.Memory.Limit > 0 {
-				vmmArgs.MemSizeB = uint64(*u.Spec.Linux.Resources.Memory.Limit) // nolint:gosec
-			}
-		}
-	}
-
-	// ExecArgs
-	// Check if container is set to unconfined -- disable seccomp
-	if u.Spec.Linux.Seccomp == nil {
-		uniklog.Warn("Seccomp is disabled")
-		vmmArgs.Seccomp = false
-	}
-
-	procAttrs := types.ProcessConfig{
-		UID:     u.Spec.Process.User.UID,
-		GID:     u.Spec.Process.User.GID,
-		WorkDir: u.Spec.Process.Cwd,
-	}
-	// UnikernelParams
-	// populate unikernel params
-	unikernelParams := types.UnikernelParams{
-		CmdLine:  u.Spec.Process.Args,
-		EnvVars:  u.Spec.Process.Env,
-		Monitor:  vmmType,
-		Version:  unikernelVersion,
-		ProcConf: procAttrs,
-	}
-	if len(unikernelParams.CmdLine) == 0 {
-		unikernelParams.CmdLine = strings.Fields(u.State.Annotations[annotCmdLine])
-	}
+	unikernelParams := u.buildUnikernelParams(vmmType, unikernelVersion)
 
 	// handle network
 	netArgs, err := u.SetupNet()
@@ -412,9 +365,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// ExecArgs
 	vmmArgs.Net = netArgs
 
-	// virtiofsd config
-	virtiofsdConfig := u.UruncCfg.ExtraBins["virtiofsd"]
-
 	// guest rootfs
 	// block
 	// handle guest's rootfs.
@@ -426,131 +376,27 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// if the respective annotation is set then, depending on the guest
 	// (supports block or 9pfs), it will use the supported option. In case
 	// both ae supported, then the block option will be used by default.
-	rootfsParams, err := u.chooseRootfs()
-	if err != nil {
-		uniklog.Errorf("could not choose guest rootfs: %v", err)
-		return err
-	}
-
-	// TODO: Add support for using both an existing
-	// block based snapshot of the container's rootfs
-	// and an auxiliary block image placed in the container's image
-	// Currently if a block Image is present in the container's image, then
-	// we will just use this image.
-	var rfsBuilder rootfsBuilder
-	switch rootfsParams.Type {
-	case "block":
-		rfsBuilder = blockRootfs{
-			mounts:        u.Spec.Mounts,
-			monRootfs:     rootfsParams.MonRootfs,
-			mountedPath:   rootfsParams.MountedPath,
-			path:          rootfsParams.Path,
-			kernelPath:    unikernelPath,
-			initrdPath:    initrdPath,
-			uruncJSONPath: uruncJSONFilename,
-			guestType:     unikernelType,
-			guest:         unikernel,
-		}
-	case "initrd":
-		rfsBuilder = initrdRootfs{
-			mounts:             u.Spec.Mounts,
-			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
-			monRootfs:          rootfsParams.MonRootfs,
-		}
-	case "virtiofs", "9pfs":
-		rfsBuilder = sharedfsRootfs{
-			mounts:      u.Spec.Mounts,
-			monRootfs:   rootfsParams.MonRootfs,
-			mountedPath: rootfsParams.MountedPath,
-			sfsType:     rootfsParams.Type,
-			vfsdConfig:  virtiofsdConfig,
-			sharedPath:  containerRootfsMountPath,
-			memory:      vmmArgs.MemSizeB,
-		}
-		// Update the paths of the files we need to pass in the monitor process.
-		vmmArgs.UnikernelPath = adjustPathsForSharedfs(vmmArgs.UnikernelPath)
-		vmmArgs.InitrdPath = adjustPathsForSharedfs(vmmArgs.InitrdPath)
-	default:
-		uniklog.Debug("No rootfs for guest")
-		rfsBuilder = noRootfs{
-			monRootfs:            rootfsParams.MonRootfs,
-			annotBlockPath:       u.State.Annotations[annotBlock],
-			annotBlockMountPoint: u.State.Annotations[annotBlockMntPoint],
-		}
-	}
-
-	err = rfsBuilder.preSetup()
-	if err != nil {
-		return fmt.Errorf("pre setup step for rootfs failed: %w", err)
-	}
-
-	// Prepare Monitor rootfs
-	// Make sure that rootfs is mounted with the correct propagation
-	// flags so we can later pivot if needed.
-	err = prepareRoot(rootfsParams.MonRootfs, u.Spec.Linux.RootfsPropagation)
+	rfsBuilder, rootfsParams, err := u.setupRootfs(vmmType, unikernelType, unikernelPath, initrdPath, unikernel, vmm, &vmmArgs, withTUNTAP)
 	if err != nil {
 		return err
 	}
-
-	// Setup the rootfs for the monitor execution, creating necessary
-	// devices and the monitor's binary.
-	err = prepareMonRootfs(rootfsParams.MonRootfs, vmm.Path(), u.UruncCfg.Monitors[vmmType].DataPath, vmm.UsesKVM(), withTUNTAP)
-	if err != nil {
-		return err
-	}
-
-	err = rfsBuilder.postSetup()
-	if err != nil {
-		return fmt.Errorf("post setup step for block based rootfs failed: %w", err)
-	}
-
-	blockArgs, err := rfsBuilder.getBlockDevs()
-	if err != nil {
-		return fmt.Errorf("failed to get block devices to attach in sandbox: %w", err)
-	}
-
-	sharedfsArgs, err := rfsBuilder.getSharedDirs()
-	if err != nil {
-		uniklog.Errorf("failed to get directories to share with sandbox: %v", err)
-		return err
-	}
-
-	unikernelParams.Rootfs = rootfsParams
 
 	metrics.Capture(m.TS17)
 
 	// unikernelParams
+	blockArgs, err := rfsBuilder.getBlockDevs()
+	if err != nil {
+		return fmt.Errorf("failed to get block devices: %w", err)
+	}
+	sharedfsArgs, err := rfsBuilder.getSharedDirs()
+	if err != nil {
+		return fmt.Errorf("failed to get shared dirs: %w", err)
+	}
 	unikernelParams.Block = blockArgs
-
-	// ExecArgs
 	vmmArgs.Sharedfs = sharedfsArgs
 
 	// vAccel setup
-	vAccelType, vsockSocketPath, rpcAddress, err := resolveVAccelConfig(u.State.Annotations[annotHypervisor], u.Spec.Annotations)
-	if err != nil {
-		uniklog.Debugf("vAccel config: %v", err)
-	}
-
-	if vAccelType == "vsock" && err == nil {
-		// Remove any existing VACCEL_RPC_ADDRESS and set the new value
-		for i, envVar := range unikernelParams.EnvVars {
-			if strings.HasPrefix(envVar, "VACCEL_RPC_ADDRESS"+"=") {
-				unikernelParams.EnvVars = remove(unikernelParams.EnvVars, i)
-				break
-			}
-		}
-		unikernelParams.EnvVars = append(unikernelParams.EnvVars, "VACCEL_RPC_ADDRESS="+rpcAddress)
-
-		// Prepare the guest environment for vAccel vsock communication
-		err = prepareVSockEnvironment(rootfsParams.MonRootfs, u.State.Annotations[annotHypervisor], vsockSocketPath)
-		if err != nil {
-			uniklog.Debugf("failed to prepare all required vsock mounts: %v", err)
-		}
-
-		vmmArgs.VAccelType = vAccelType
-		vmmArgs.VSockDevPath = vsockSocketPath
-		vmmArgs.VSockDevID = idToGuestCID(u.State.ID)
-	}
+	u.setupVAccel(&vmmArgs, &unikernelParams, rootfsParams.MonRootfs)
 
 	// unikernel
 	err = unikernel.Init(unikernelParams)


### PR DESCRIPTION
The Exec() method in unikontainers.go spans 300+ lines across 11 phases.
This PR extracts four of those phases into dedicated methods in a new
file exec_helpers.go:

- buildVMMArgs: builds ExecArgs from OCI spec and urunc config
- buildUnikernelParams: builds UnikernelParams from OCI spec
- setupRootfs: selects rootfs type and runs pre/post setup steps
- setupVAccel: configures vAccel vsock environment if annotated

Unit tests added for buildVMMArgs and buildUnikernelParams in
exec_helpers_test.go covering memory override, vcpu defaulting,
seccomp toggle, and cmdline annotation fallback.

No behaviour change. All existing tests pass (make unittest).

Closes #502