### PR TITLE
fix(unikontainers): warn on vAccel misconfiguration

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -104,3 +104,6 @@ users:
   abhaygoudannavar:
     name: AbhayGoudannavar
     email: abhaysgoudnvr@gmail.com
+  Chennamma-Hotkar:
+    name: Chennamma Hotkar
+    email: channuhotkar@gmail.com

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -553,7 +553,9 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// vAccel setup
 	vAccelType, vsockSocketPath, rpcAddress, err := resolveVAccelConfig(u.State.Annotations[annotHypervisor], u.Spec.Annotations)
 	if err != nil {
-		uniklog.Debugf("vAccel config: %v", err)
+		if !errors.Is(err, ErrVAccelDisabled) {
+			uniklog.Warnf("vAccel misconfiguration: %v", err)
+		}
 	}
 
 	if vAccelType == "vsock" && err == nil {

--- a/pkg/unikontainers/vaccel.go
+++ b/pkg/unikontainers/vaccel.go
@@ -15,11 +15,16 @@
 package unikontainers
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
 	"golang.org/x/sys/unix"
 )
+
+// ErrVAccelDisabled is returned by resolveVAccelConfig when the vAccel
+// annotation is absent. This is an expected condition, not a misconfiguration.
+var ErrVAccelDisabled = errors.New("vaccel is disabled")
 
 // idToGuestCID generates a deterministic guest CID (Context Identifier)
 // for vsock communication based on a container or VM ID.
@@ -87,8 +92,7 @@ func resolveVAccelConfig(hypervisor string, annotations map[string]string) (stri
 			return vAccelType, "", "", err
 		}
 	} else {
-		err = fmt.Errorf("vaccel is disabled")
-		return vAccelType, "", "", err
+		return "", "", "", ErrVAccelDisabled
 	}
 
 	if vAccelType == "vsock" {

--- a/pkg/unikontainers/vaccel_test.go
+++ b/pkg/unikontainers/vaccel_test.go
@@ -15,6 +15,7 @@
 package unikontainers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -168,3 +169,46 @@ func TestIsValidVSockAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveVAccelConfig(t *testing.T) {
+	t.Run("vaccel disabled returns ErrVAccelDisabled", func(t *testing.T) {
+		t.Parallel()
+		annotations := map[string]string{}
+		_, _, _, err := resolveVAccelConfig("qemu", annotations)
+		assert.ErrorIs(t, err, ErrVAccelDisabled)
+	})
+
+	t.Run("vaccel enabled but rpc address missing returns error", func(t *testing.T) {
+		t.Parallel()
+		annotations := map[string]string{
+			"com.urunc.unikernel.vAccel": "vsock",
+		}
+		_, _, _, err := resolveVAccelConfig("qemu", annotations)
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrVAccelDisabled), "missing rpc address should not be ErrVAccelDisabled")
+	})
+
+	t.Run("vaccel enabled with malformed rpc address returns error", func(t *testing.T) {
+		t.Parallel()
+		annotations := map[string]string{
+			"com.urunc.unikernel.vAccel":      "vsock",
+			"com.urunc.unikernel.RPCAddress":  "invalid-address",
+		}
+		_, _, _, err := resolveVAccelConfig("qemu", annotations)
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrVAccelDisabled), "malformed address should not be ErrVAccelDisabled")
+	})
+
+	t.Run("vaccel enabled with valid qemu vsock address succeeds", func(t *testing.T) {
+		t.Parallel()
+		annotations := map[string]string{
+			"com.urunc.unikernel.vAccel":     "vsock",
+			"com.urunc.unikernel.RPCAddress": "vsock://2:1234",
+		}
+		vAccelType, _, addr, err := resolveVAccelConfig("qemu", annotations)
+		assert.NoError(t, err)
+		assert.Equal(t, "vsock", vAccelType)
+		assert.Equal(t, "vsock://2:1234", addr)
+	})
+}
+

--- a/pkg/unikontainers/vaccel_test.go
+++ b/pkg/unikontainers/vaccel_test.go
@@ -191,8 +191,8 @@ func TestResolveVAccelConfig(t *testing.T) {
 	t.Run("vaccel enabled with malformed rpc address returns error", func(t *testing.T) {
 		t.Parallel()
 		annotations := map[string]string{
-			"com.urunc.unikernel.vAccel":      "vsock",
-			"com.urunc.unikernel.RPCAddress":  "invalid-address",
+			"com.urunc.unikernel.vAccel":     "vsock",
+			"com.urunc.unikernel.RPCAddress": "invalid-address",
 		}
 		_, _, _, err := resolveVAccelConfig("qemu", annotations)
 		assert.Error(t, err)
@@ -211,4 +211,3 @@ func TestResolveVAccelConfig(t *testing.T) {
 		assert.Equal(t, "vsock://2:1234", addr)
 	})
 }
-


### PR DESCRIPTION
## Description

When calling `resolveVAccelConfig()` in `pkg/unikontainers/unikontainers.go`, we only print the error at DEBUG level. The function returns the same error type in 2 different cases: 
       1) when vAccel is disabled and 
       2) when a bad configuration is detected (i.e. missing or bad RPCAddress). 
Therefore the error is always ignored and the container launched in with no vAccel but with no warning of the situation.

The fix adds a sentinel error `ErrVAccelDisabled` to treat the two cases differently. When vAccel is not configured, we expect an error and log it at Debug. When there is a genuine misconfiguration, we Warn so operators can see the
issue without having to enable debug log level. Added unit tests for all four paths in `resolveVAccelConfig`.

Files changed:
- `pkg/unikontainers/vaccel.go` — added `ErrVAccelDisabled` sentinel error
- `pkg/unikontainers/unikontainers.go` — log Warn on misconfiguration
- `pkg/unikontainers/vaccel_test.go` — 4 new unit tests

### Related issues
- Fixes: #698

### How was this tested?
All existing unit tests pass (`make unittest`). Build passes (`make`). Four new unit tests added covering disabled, missing address, malformed address and valid address cases.

### LLM usage
N/A

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).