### PR TITLE
fix(unikontainers): add default hook timeout to prevent Exec() hang

### DIFF
--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -890,7 +890,7 @@ func (u *Unikontainer) executeHooksConcurrently(name string, hooks []specs.Hook,
 		wg.Add(1)
 		go func(h specs.Hook) {
 			defer wg.Done()
-			err := executeHook(h, s)
+			err := executeHook(h, s, u.UruncCfg.DefaultHookTimeoutSec)
 			if err != nil {
 				uniklog.WithFields(logrus.Fields{
 					"id":    u.State.ID,
@@ -930,7 +930,7 @@ func (u *Unikontainer) executeHooksSequentially(name string, hooks []specs.Hook,
 			"args": hooks[i].Args,
 		}).Debug("Executing hook")
 
-		err := executeHook(hooks[i], s)
+		err := executeHook(hooks[i], s, u.UruncCfg.DefaultHookTimeoutSec)
 		if err != nil {
 			uniklog.WithFields(logrus.Fields{
 				"id":    u.State.ID,

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -35,10 +35,11 @@ type UruncTimestamps struct {
 }
 
 type UruncConfig struct {
-	Log        UruncLog                        `toml:"log"`
-	Timestamps UruncTimestamps                 `toml:"timestamps"`
-	Monitors   map[string]types.MonitorConfig  `toml:"monitors"`
-	ExtraBins  map[string]types.ExtraBinConfig `toml:"extra_binaries"`
+	Log                   UruncLog                        `toml:"log"`
+	Timestamps            UruncTimestamps                 `toml:"timestamps"`
+	Monitors              map[string]types.MonitorConfig  `toml:"monitors"`
+	ExtraBins             map[string]types.ExtraBinConfig `toml:"extra_binaries"`
+	DefaultHookTimeoutSec uint                            `toml:"default_hook_timeout_sec"`
 }
 
 // this struct is used to parse only the log and timestamp section of the urunc config file
@@ -96,10 +97,11 @@ func defaultExtraBinConfig() map[string]types.ExtraBinConfig {
 
 func defaultUruncConfig() *UruncConfig {
 	return &UruncConfig{
-		Log:        defaultLogConfig(),
-		Timestamps: defaultTimestampsConfig(),
-		Monitors:   defaultMonitorsConfig(),
-		ExtraBins:  defaultExtraBinConfig(),
+		Log:                   defaultLogConfig(),
+		Timestamps:            defaultTimestampsConfig(),
+		Monitors:              defaultMonitorsConfig(),
+		ExtraBins:             defaultExtraBinConfig(),
+		DefaultHookTimeoutSec: 30,
 	}
 }
 

--- a/pkg/unikontainers/urunc_config_test.go
+++ b/pkg/unikontainers/urunc_config_test.go
@@ -525,6 +525,7 @@ func TestDefaultConfigs(t *testing.T) {
 		assert.Equal(t, testTimestampsPath, config.Timestamps.Destination)
 		assert.Len(t, config.Monitors, 5)
 		assert.Len(t, config.ExtraBins, 1)
+		assert.Equal(t, uint(30), config.DefaultHookTimeoutSec)
 	})
 
 	t.Run("defaultLogMetricsConfig", func(t *testing.T) {

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -304,7 +304,7 @@ func rmMultipleDirs(prefixPath string, dirs []string) error {
 	return nil
 }
 
-func executeHook(hook specs.Hook, state []byte) error {
+func executeHook(hook specs.Hook, state []byte, defaultTimeoutSec uint) error {
 	var stdout, stderr bytes.Buffer
 	var cancel context.CancelFunc
 	ctx := context.Background()
@@ -312,6 +312,8 @@ func executeHook(hook specs.Hook, state []byte) error {
 	// Apply hook-specific timeout if set, otherwise use global config timeout
 	if hook.Timeout != nil && *hook.Timeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(*hook.Timeout)*time.Second)
+	} else if defaultTimeoutSec > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(defaultTimeoutSec)*time.Second)
 	}
 	if cancel != nil {
 		defer cancel()


### PR DESCRIPTION
## Description

In pkg/unikontainers/utils.go executeHook() sets a contexts timeout only when hook.Timeout is set, per the OCI spec. That spec indicates that it is an optional field, *int and omitempty. If it is not set, executeHook() defaults to context.Background() which can never be cancelled. If a hook hangs indefinitely then executeHook() will never return, thereby hanging wg.Wait() called from executeHooksConcurrently(), which means errChan will never be closed and Exec() can hang forever and never log an error or warning. The comment on line 312 indicated that in the 'otherwise' case, we should use global config timeout, but this was not implemented in UruncConfig. Take the config value from UruncConfig and if the OCI spec hook has no timeout set, use it. Add a field to UruncConfig to indicate the default hook timeout in seconds. Add it to urunc.json.orig, set it to 30s.

Files changed:
- `pkg/unikontainers/urunc_config.go` — added `DefaultHookTimeoutSec`
- `pkg/unikontainers/utils.go` — use default timeout as fallback
- `pkg/unikontainers/unikontainers.go` — pass default timeout to callers
- `pkg/unikontainers/urunc_config_test.go` — assert default value is 30s

### Related issues
- Fixes: #700

### How was this tested?
All existing unit tests pass (`make unittest`). Build passes (`make`). Added assertion for `DefaultHookTimeoutSec` in `TestDefaultConfigs`.

### LLM usage
N/A

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).