### PR TITLE
fix(unikernels): use actual subnet mask in Mirage IP configuration instead of hardcoded /24

### DIFF
--- a/pkg/unikontainers/unikernels/mirage.go
+++ b/pkg/unikontainers/unikernels/mirage.go
@@ -99,7 +99,11 @@ func (m *Mirage) MonitorCli() types.MonitorCliArgs {
 func (m *Mirage) Init(data types.UnikernelParams) error {
 	// if Mask is empty, there is no network support
 	if data.Net.Mask != "" {
-		m.Net.Address = "--ipv4=" + data.Net.IP + "/24"
+		mask, err := subnetMaskToCIDR(data.Net.Mask)
+		if err != nil {
+			return err
+		}
+		m.Net.Address = fmt.Sprintf("--ipv4=%s/%d", data.Net.IP, mask)
 		m.Net.Gateway = "--ipv4-gateway=" + data.Net.Gateway
 	}
 	m.Block = make([]MirageBlock, 0, len(data.Block))

--- a/pkg/unikontainers/unikernels/mirage_test.go
+++ b/pkg/unikontainers/unikernels/mirage_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestMirageInitSubnetMask(t *testing.T) {
+	tests := []struct {
+		name        string
+		mask        string
+		ip          string
+		gateway     string
+		wantAddress string
+		wantGateway string
+	}{
+		{
+			name:        "non-/24 mask is used correctly",
+			mask:        "255.255.255.240",
+			ip:          "10.0.0.1",
+			gateway:     "10.0.0.14",
+			wantAddress: "--ipv4=10.0.0.1/28",
+			wantGateway: "--ipv4-gateway=10.0.0.14",
+		},
+		{
+			name:        "/24 mask still works",
+			mask:        "255.255.255.0",
+			ip:          "192.168.1.5",
+			gateway:     "192.168.1.1",
+			wantAddress: "--ipv4=192.168.1.5/24",
+			wantGateway: "--ipv4-gateway=192.168.1.1",
+		},
+		{
+			name:        "no network when mask is empty",
+			mask:        "",
+			ip:          "",
+			gateway:     "",
+			wantAddress: "",
+			wantGateway: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newMirage()
+			params := types.UnikernelParams{
+				Net: types.NetDevParams{
+					IP:      tt.ip,
+					Mask:    tt.mask,
+					Gateway: tt.gateway,
+				},
+			}
+			err := m.Init(params)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantAddress, m.Net.Address)
+			assert.Equal(t, tt.wantGateway, m.Net.Gateway)
+		})
+	}
+}


### PR DESCRIPTION
## Description
`Mirage.Init()` reads the subnet mask from `data.Net.Mask` but ignores it, always hardcoding `/24` into the IP address 
string. Any network with a prefix other than `/24` produces a wrong kernel command line, causing incorrect routing inside 
the MirageOS unikernel.

The fix calls `subnetMaskToCIDR()` — already present in the same package and used correctly by `Hermit.Init()` and 
`Mewz.Init()` — and uses the returned CIDR prefix instead of the hardcoded `/24`.

### Related issues
- Fixes #693

### How was this tested?
Added `TestMirageInitSubnetMask` in `pkg/unikontainers/unikernels/mirage_test.go` with three  sub-tests: a non-/24 mask (`255.255.255.240` → `/28`), a /24 mask (regression check), and no network (empty mask guard).

### Before fix
<img width="1242" height="574" alt="Screenshot 2026-05-17 094253" src="https://github.com/user-attachments/assets/bed4936a-5c7a-439e-9f24-adebd64f87e1" />

###  After fix:

<img width="1204" height="265" alt="Screenshot 2026-05-17 094340" src="https://github.com/user-attachments/assets/8af16d9d-e69f-4172-9dbd-91e5226b9647" />

  ### LLM usage
  N/A

  ### Checklist
  - [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
  - [x] The linter passes locally (`make lint`).
  - [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
  - [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
