### PR TITLE
fix(unikontainers): lowercase error strings and enforce via revive rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,10 @@ linters:
     staticcheck:
       checks:
         - all
+    revive:
+      confidence: 0.6
+      rules:
+        - name: error-strings
   exclusions:
     generated: lax
     presets:
@@ -37,6 +41,14 @@ linters:
           - dupl
       - path: tests/e2e/.*_test\.go
         text: "dot-imports"
+        linters:
+          - revive
+      - path: _test\.go
+        text: "error-strings"
+        linters:
+          - revive
+      - path: tests/e2e/
+        text: "error-strings"
         linters:
           - revive
     paths:

--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -130,7 +130,7 @@ func extractBootFiles(rootfsPath string, newRootfsPath string, unikernel string,
 	targetUnikernelDir, _ := filepath.Split(targetUnikernelPath)
 	err := moveFile(currentUnikernelPath, targetUnikernelDir)
 	if err != nil {
-		return fmt.Errorf("Could not move %s to %s: %w", currentUnikernelPath, targetUnikernelPath, err)
+		return fmt.Errorf("could not move %s to %s: %w", currentUnikernelPath, targetUnikernelPath, err)
 	}
 
 	if initrd != "" {
@@ -139,14 +139,14 @@ func extractBootFiles(rootfsPath string, newRootfsPath string, unikernel string,
 		targetInitrdDir, _ := filepath.Split(targetInitrdPath)
 		err = moveFile(currentInitrdPath, targetInitrdDir)
 		if err != nil {
-			return fmt.Errorf("Could not move %s to %s: %w", currentInitrdPath, targetInitrdPath, err)
+			return fmt.Errorf("could not move %s to %s: %w", currentInitrdPath, targetInitrdPath, err)
 		}
 	}
 
 	currentConfigPath := filepath.Join(rootfsPath, uruncJSON)
 	err = moveFile(currentConfigPath, newRootfsPath)
 	if err != nil {
-		return fmt.Errorf("Could not move %s to %s: %w", currentConfigPath, newRootfsPath, err)
+		return fmt.Errorf("could not move %s to %s: %w", currentConfigPath, newRootfsPath, err)
 	}
 
 	return nil

--- a/pkg/unikontainers/mount.go
+++ b/pkg/unikontainers/mount.go
@@ -220,7 +220,7 @@ func fileFromHost(monRootfs string, hostPath string, target string, mFlags int, 
 		flags := mFlags | unix.MS_BIND | unix.MS_REMOUNT
 		err = unix.Mount(dstPath, dstPath, "", uintptr(flags), "")
 		if err != nil {
-			return fmt.Errorf("Failed to set mount flags for %s: %w", dstPath, err)
+			return fmt.Errorf("failed to set mount flags for %s: %w", dstPath, err)
 		}
 	}
 
@@ -298,7 +298,7 @@ func rootfsParentMountPrivate(path string) error {
 		path = filepath.Dir(path)
 	}
 
-	return fmt.Errorf("Could not remount as private the parent mount of %s", path)
+	return fmt.Errorf("could not remount as private the parent mount of %s", path)
 }
 
 // prepareRoot prepares the directory of the container's rootfs to safely pivot
@@ -368,7 +368,7 @@ func mountVolumes(rootfsPath string, mounts []specs.Mount) error {
 		for _, pFlag := range propFlag {
 			err = unix.Mount(dstPath, dstPath, "", uintptr(pFlag), "")
 			if err != nil {
-				return fmt.Errorf("Failed to set propagation flag for %s: %w", m.Source, err)
+				return fmt.Errorf("failed to set propagation flag for %s: %w", m.Source, err)
 			}
 		}
 	}

--- a/pkg/unikontainers/shared_fs.go
+++ b/pkg/unikontainers/shared_fs.go
@@ -60,7 +60,7 @@ func (s sharedfsRootfs) postSetup() error {
 		// Get the virtiofsd binary from host in monRootfs
 		err = fileFromHost(s.monRootfs, s.vfsdConfig.Path, "", unix.MS_BIND|unix.MS_PRIVATE, false)
 		if err != nil {
-			return fmt.Errorf("Could not bind mount %s: %w", s.vfsdConfig.Path, err)
+			return fmt.Errorf("could not bind mount %s: %w", s.vfsdConfig.Path, err)
 		}
 	}
 

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -73,7 +73,7 @@ func (r *Rumprun) CommandString() (string, error) {
 	}
 	cmdJSON, err := json.Marshal(cmd)
 	if err != nil {
-		return "", fmt.Errorf("Could not Marshal cmdline: %v", err)
+		return "", fmt.Errorf("could not marshal cmdline: %v", err)
 	}
 	cmdJSONString = string(cmdJSON)
 	for i, eVar := range r.Envs {
@@ -82,7 +82,7 @@ func (r *Rumprun) CommandString() (string, error) {
 		}
 		oneVarJSON, err := json.Marshal(eVar)
 		if err != nil {
-			return "", fmt.Errorf("Could not Marshal environment variable: %v", err)
+			return "", fmt.Errorf("could not marshal environment variable: %v", err)
 		}
 		if i != 0 {
 			envJSONString += ","

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -259,7 +259,7 @@ func findNS(namespaces []specs.LinuxNamespace, nsType specs.LinuxNamespaceType) 
 		}
 	}
 
-	return "", fmt.Errorf("Namespace %s was not found", string(nsType))
+	return "", fmt.Errorf("namespace %s was not found", string(nsType))
 }
 
 // findQemuDataDir tries to find the location of data and BIOS files for Qemu.


### PR DESCRIPTION
## Description
Ten error strings across five files start with an uppercase letter, violating Go's error string convention. Errors that begin with a capital letter produce awkward wrapped messages (e.g. `"outer: Could not open file"`). The `revive`  linter, enabled in `.golangci.yml`, enforces this.

The `revive` `error-strings` rule emits violations at confidence 0.6 for  capitalized strings, but the default revive confidence threshold is 0.8, which  silently filtered them out. This PR also adds `confidence: 0.6` to the revive  settings block so the rule actually enforces the convention.

  No logic changes — string content and linter config only.

  ### Related issues
  - Fixes #694 

  ### How was this tested?
  Verified by code inspection: all 10 capitalized error strings confirmed present  before the change via grep. Confirmed the rule was silently broken without  `confidence: 0.6` (golangci-lint returned `0 issues` on upstream files).  After adding `confidence: 0.6`, running `golangci-lint run pkg/unikontainers/...`
  - `pkg/unikontainers/utils.go` — 1 string (`Namespace %s was not found`)
  - `pkg/unikontainers/shared_fs.go` — 1 string (`Could not bind mount`)
  - `pkg/unikontainers/unikernels/rumprun.go` — 2 strings (`Could not marshal
    cmdline`, `Could not marshal environment variable`)



  ### LLM usage
  N/A


### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).