### PR TITLE
fix: Bring back the --all flag of kill

### DIFF
--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -41,6 +41,13 @@ For example, if the container id is "ubuntu01" the following will send a "KILL"
 signal to the init process of the "ubuntu01" container:
 
 	# urunc kill ubuntu01 KILL`,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "all",
+			Aliases: []string{"a"},
+			Usage:   "send the specified signal to all processes inside the container",
+		},
+	},
 	Action: func(_ context.Context, cmd *cli.Command) error {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()


### PR DESCRIPTION
## Description

The shim uses the `--all` flag in Kubernetes settings when calling the low level runtime. We previously removed this flag causing issues in the deletion path of the pod. Therefore, we need to bring it back.

### Related issues

- Fixes https://github.com/urunc-dev/urunc/issues/716

### How was this tested?

In a kubernetes single node cluster deployed a urunc container and then removed it.

Before the fix, the pod was staying as Terminating forever. With this fix the pod is getting removed correctly.

### LLM usage

N/A

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
