### PR TITLE
fix: use annotation for MirageOS block device name

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -424,3 +424,4 @@ praffq
 libcontainers
 securejoin
 cyphar
+blkdev

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -46,6 +46,7 @@ const (
 	annotBlockMntPoint = "com.urunc.unikernel.blkMntPoint"
 	annotMountRootfs   = "com.urunc.unikernel.mountRootfs"
 	annotNetDev        = "com.urunc.unikernel.solo5NetDev"
+	annotBlkDev        = "com.urunc.unikernel.solo5BlkDev"
 )
 
 // A UnikernelConfig struct holds the info provided by bima image on how to execute our unikernel
@@ -60,6 +61,7 @@ type UnikernelConfig struct {
 	BlkMntPoint      string `json:"com.urunc.unikernel.blkMntPoint,omitempty"`
 	MountRootfs      string `json:"com.urunc.unikernel.mountRootfs"`
 	NetDev           string `json:"com.urunc.unikernel.solo5NetDev,omitempty"`
+	BlkDev           string `json:"com.urunc.unikernel.solo5BlkDev,omitempty"`
 }
 
 // validate checks if the mandatory configuration fields are present.
@@ -122,6 +124,7 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 	blkMntPoint := spec.Annotations[annotBlockMntPoint]
 	MountRootfs := spec.Annotations[annotMountRootfs]
 	netDev := spec.Annotations[annotNetDev]
+	blkDev := spec.Annotations[annotBlkDev]
 	uniklog.WithFields(logrus.Fields{
 		"unikernelType":    unikernelType,
 		"unikernelVersion": unikernelVersion,
@@ -133,6 +136,7 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 		"blkMntPoint":      blkMntPoint,
 		"mountRootfs":      MountRootfs,
 		"netDev":           netDev,
+		"blkDev":           blkDev,
 	}).WithField("source", "spec").Debug("urunc annotations")
 
 	return &UnikernelConfig{
@@ -146,6 +150,7 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 		BlkMntPoint:      blkMntPoint,
 		MountRootfs:      MountRootfs,
 		NetDev:           netDev,
+		BlkDev:           blkDev,
 	}
 }
 
@@ -186,6 +191,7 @@ func getConfigFromJSON(jsonFilePath string) (*UnikernelConfig, error) {
 		"blkMntPoint":      tryDecode(conf.BlkMntPoint),
 		"mountRootfs":      tryDecode(conf.MountRootfs),
 		"netDev":           tryDecode(conf.NetDev),
+		"blkDev":           tryDecode(conf.BlkDev),
 	}).WithField("source", uruncJSONFilename).Debug("urunc annotations")
 
 	return &conf, nil
@@ -261,6 +267,11 @@ func (c *UnikernelConfig) decode() error {
 		return fmt.Errorf("failed to decode netDev: %v", err)
 	}
 	c.NetDev = string(decoded)
+	decoded, err = base64.StdEncoding.DecodeString(c.BlkDev)
+	if err != nil {
+		return fmt.Errorf("failed to decode blkDev: %v", err)
+	}
+	c.BlkDev = string(decoded)
 
 	return nil
 }
@@ -297,6 +308,9 @@ func (c *UnikernelConfig) Map() map[string]string {
 	}
 	if c.NetDev != "" {
 		myMap[annotNetDev] = c.NetDev
+	}
+	if c.BlkDev != "" {
+		myMap[annotBlkDev] = c.BlkDev
 	}
 
 	return myMap

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -39,6 +39,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 				annotBlockMntPoint: "point1",
 				annotMountRootfs:   "true",
 				annotNetDev:        "management",
+				annotBlkDev:        "database",
 			},
 		}
 
@@ -52,6 +53,7 @@ func TestGetConfigFromSpec(t *testing.T) {
 			BlkMntPoint:     "point1",
 			MountRootfs:     "true",
 			NetDev:          "management",
+			BlkDev:          "database",
 		}
 
 		config := getConfigFromSpec(spec)
@@ -242,6 +244,7 @@ func TestMap(t *testing.T) {
 			BlkMntPoint:     "point_value",
 			MountRootfs:     "false",
 			NetDev:          "netdev_value",
+			BlkDev:          "blkdev_value",
 		}
 		expectedMap := map[string]string{
 			annotCmdLine:       "cmd_value",
@@ -253,6 +256,7 @@ func TestMap(t *testing.T) {
 			annotBlockMntPoint: "point_value",
 			annotMountRootfs:   "false",
 			annotNetDev:        "netdev_value",
+			annotBlkDev:        "blkdev_value",
 		}
 		resultMap := config.Map()
 		assert.Equal(t, expectedMap, resultMap)

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -90,6 +90,7 @@ type UnikernelParams struct {
 	Version    string   // The version of the unikernel
 	InitrdPath string   // The path to the initrd of the unikernel
 	NetDevName string   // The name of the guest network device declared at build time
+	BlkDevName string   // The name of the guest block device declared at build time
 	Net        NetDevParams
 	Block      []BlockDevParams
 	Rootfs     RootfsParams  // Information about rootfs

--- a/pkg/unikontainers/unikernels/mirage.go
+++ b/pkg/unikontainers/unikernels/mirage.go
@@ -29,6 +29,7 @@ type Mirage struct {
 	Net        MirageNet
 	Block      []MirageBlock
 	netDevName string
+	blkDevName string
 }
 
 type MirageNet struct {
@@ -84,7 +85,7 @@ func (m *Mirage) MonitorBlockCli() []types.MonitorBlockArgs {
 		// how MirageOS handles/configures them.
 		return []types.MonitorBlockArgs{
 			{
-				ID:   "storage",
+				ID:   m.blkDevName,
 				Path: m.Block[0].HostPath,
 			},
 		}
@@ -133,6 +134,11 @@ func (m *Mirage) Init(data types.UnikernelParams) error {
 		m.netDevName = data.NetDevName
 	} else {
 		m.netDevName = "service"
+	}
+	if data.BlkDevName != "" {
+		m.blkDevName = data.BlkDevName
+	} else {
+		m.blkDevName = "storage"
 	}
 
 	return nil

--- a/pkg/unikontainers/unikernels/mirage_test.go
+++ b/pkg/unikontainers/unikernels/mirage_test.go
@@ -95,3 +95,33 @@ func TestMirageNetDevName(t *testing.T) {
 		assert.Contains(t, cli, "--net-mac:service=aa:bb:cc:dd:ee:ff")
 	})
 }
+
+func TestMirageBlkDevName(t *testing.T) {
+	t.Run("uses block device name from annotation", func(t *testing.T) {
+		t.Parallel()
+		m := &Mirage{}
+		err := m.Init(types.UnikernelParams{
+			Monitor:    "hvt",
+			BlkDevName: "database",
+			Block:      []types.BlockDevParams{{Source: "/path/to/img"}},
+		})
+		assert.NoError(t, err)
+		args := m.MonitorBlockCli()
+		assert.Len(t, args, 1)
+		assert.Equal(t, "database", args[0].ID)
+		assert.Equal(t, "/path/to/img", args[0].Path)
+	})
+
+	t.Run("falls back to storage when annotation is absent", func(t *testing.T) {
+		t.Parallel()
+		m := &Mirage{}
+		err := m.Init(types.UnikernelParams{
+			Monitor: "hvt",
+			Block:   []types.BlockDevParams{{Source: "/path/to/img"}},
+		})
+		assert.NoError(t, err)
+		args := m.MonitorBlockCli()
+		assert.Len(t, args, 1)
+		assert.Equal(t, "storage", args[0].ID)
+	})
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -531,6 +531,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		Version:    unikernelVersion,
 		ProcConf:   procAttrs,
 		NetDevName: u.State.Annotations[annotNetDev],
+		BlkDevName: u.State.Annotations[annotBlkDev],
 	}
 	if len(unikernelParams.CmdLine) == 0 {
 		unikernelParams.CmdLine = strings.Fields(u.State.Annotations[annotCmdLine])


### PR DESCRIPTION
## Description

MirageOS unikernels declare their block device names at build time through the Solo5 manifest. urunc was hardcoding `"storage"` as the block device ID, so if a unikernel declared a different name it would fail at runtime with `Resource not declared in manifest`.
Added a new annotation `com.urunc.unikernel.blkDev` so image builders can set the block device name at build time. Falls back to `"storage"` when the annotation is absent so existing images keep working.

Same approach as #690 for net device naming. Task 2 of 3 from #315.

### Related issues

- Related: #315

### How was this tested?

```
go test ./pkg/unikontainers/unikernels/... -v -run TestMirageSolo5BlkDevName

=== RUN   TestMirageSolo5BlkDevName
=== RUN   TestMirageSolo5BlkDevName/uses_block_device_name_from_annotation
=== PAUSE TestMirageSolo5BlkDevName/uses_block_device_name_from_annotation
=== RUN   TestMirageSolo5BlkDevName/falls_back_to_storage_when_annotation_is_absent
=== PAUSE TestMirageSolo5BlkDevName/falls_back_to_storage_when_annotation_is_absent
=== CONT  TestMirageSolo5BlkDevName/uses_block_device_name_from_annotation
=== CONT  TestMirageSolo5BlkDevName/falls_back_to_storage_when_annotation_is_absent
--- PASS: TestMirageSolo5BlkDevName (0.00s)
    --- PASS: TestMirageSolo5BlkDevName/uses_block_device_name_from_annotation (0.00s)
    --- PASS: TestMirageSolo5BlkDevName/falls_back_to_storage_when_annotation_is_absent (0.00s)
PASS
ok      github.com/urunc-dev/urunc/pkg/unikontainers/unikernels
```

With annotation (`com.urunc.unikernel.blkDev=storage`, matches kernel manifest):
```
$ sudo nerdctl run --rm --runtime io.containerd.urunc.v2 --snapshotter devmapper --network=none blkdev:fix
WARN[0000] cannot set cgroup manager to "systemd" for runtime "io.containerd.urunc.v2"
            |      ___|
  __|  _ \  |  _ \ __ \
\__ \ (   | | (   |  ) |
____/\___/ _|\___/____/
Solo5: Bindings version v0.9.0
...
2026-06-08T09:57:41-00:00: [INFO] [block] Total tests started: 10
2026-06-08T09:57:41-00:00: [INFO] [block] Total tests passed:  10
2026-06-08T09:57:41-00:00: [INFO] [block] Total tests failed:  0
Solo5: solo5_exit(0) called
```
solo5 accepts `--block:storage=...` and boots.

With wrong annotation (`com.urunc.unikernel.blkDev=blkdata`, mismatches manifest):
```
$ sudo nerdctl run --rm --runtime io.containerd.urunc.v2 --snapshotter devmapper --network=none blkdev:bug
WARN[0000] cannot set cgroup manager to "systemd" for runtime "io.containerd.urunc.v2"
solo5-hvt: Resource not declared in manifest: 'blkdata'
solo5-hvt: Resource not declared in manifest: 'blkdata'
solo5-hvt: Invalid option: `--block:blkdata=/.boot/rootfs'
```
urunc passes the annotation value directly to solo5, solo5 rejects since the manifest only declares `storage`.

Without annotation (falls back to `storage`):
```
$ sudo nerdctl run --rm --runtime io.containerd.urunc.v2 --snapshotter devmapper --network=none block-test-hvt-mirage:latest
WARN[0000] cannot set cgroup manager to "systemd" for runtime "io.containerd.urunc.v2"
...
2026-06-08T09:57:53-00:00: [INFO] [block] Total tests passed:  10
Solo5: solo5_exit(0) called
```
existing images without the annotation fall back to `storage` and keep working.

**Pushed images:**
- [docker.io/pocopepe/blkdev:fix](https://hub.docker.com/r/pocopepe/blkdev/tags?name=fix)
- [docker.io/pocopepe/blkdev:bug](https://hub.docker.com/r/pocopepe/blkdev/tags?name=bug)

### LLM usage

Claude Sonnet 4.6

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).