### PR TITLE
unikernels/linux: remove always-true conditional in firecracker block

### DIFF
--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -170,12 +170,8 @@ func (l *Linux) MonitorBlockCli() []types.MonitorBlockArgs {
 		}
 	case "firecracker":
 		for _, aBlock := range l.Blk {
-			id := aBlock.ID
-			if l.Monitor == "firecracker" {
-				id = "FC" + aBlock.ID
-			}
 			blkArgs = append(blkArgs, types.MonitorBlockArgs{
-				ID:   id,
+				ID:   "FC" + aBlock.ID,
 				Path: aBlock.Source,
 			})
 		}


### PR DESCRIPTION
﻿Fixes the redundant conditional inside MonitorBlockCli() in
pkg/unikontainers/unikernels/linux.go.

## What

The case "firecracker": arm of the switch already guarantees that
l.Monitor == "firecracker" is true. The inner if l.Monitor == "firecracker"
check can therefore never evaluate to false, making it dead code.

Before:
```go
case "firecracker":
    for _, aBlock := range l.Blk {
        id := aBlock.ID
        if l.Monitor == "firecracker" {   // always true
            id = "FC" + aBlock.ID
        }
        blkArgs = append(blkArgs, types.MonitorBlockArgs{ID: id, Path: aBlock.Source})
    }
```

After:
```go
case "firecracker":
    for _, aBlock := range l.Blk {
        blkArgs = append(blkArgs, types.MonitorBlockArgs{
            ID:   "FC" + aBlock.ID,
            Path: aBlock.Source,
        })
    }
```

## Testing

Existing unit tests cover this path. No behaviour change — the "FC" prefix was
always applied; this just removes the dead branch.

Closes #747
