### PR TITLE
fix(unikernels/linux): remove always-true conditional in firecracker …

### DIFF
--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -170,12 +170,8 @@ func (l *Linux) MonitorBlockCli() []types.MonitorBlockArgs {
 		}
 	case "firecracker":
 		for _, aBlock := range l.Blk {
-			id := aBlock.ID
-			if l.Monitor == "firecracker" {
-				id = "FC" + aBlock.ID
-			}
 			blkArgs = append(blkArgs, types.MonitorBlockArgs{
-				ID:   id,
+				ID:   "FC" + aBlock.ID,
 				Path: aBlock.Source,
 			})
 		}


### PR DESCRIPTION
…block

In MonitorBlockCli, the firecracker switch case contained an inner check `if l.Monitor == "firecracker"` which is always true since we are already inside the "firecracker" case. Remove the redundant conditional and directly prepend the "FC" prefix to the block ID.

## Description

<!-- Describe the changes and why they are needed. -->

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #

### How was this tested?

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
