### PR TITLE
fix: Base64 and plaintext annotation

### DIFF
--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -120,15 +122,15 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 	blkMntPoint := spec.Annotations[annotBlockMntPoint]
 	MountRootfs := spec.Annotations[annotMountRootfs]
 	uniklog.WithFields(logrus.Fields{
-		"unikernelType":    tryDecode(unikernelType),
-		"unikernelVersion": tryDecode(unikernelVersion),
-		"unikernelCmd":     tryDecode(unikernelCmd),
-		"unikernelBinary":  tryDecode(unikernelBinary),
-		"hypervisor":       tryDecode(hypervisor),
-		"initrd":           tryDecode(initrd),
-		"block":            tryDecode(block),
-		"blkMntPoint":      tryDecode(blkMntPoint),
-		"mountRootfs":      tryDecode(MountRootfs),
+		"unikernelType":    logConfigValue(unikernelType),
+		"unikernelVersion": logConfigValue(unikernelVersion),
+		"unikernelCmd":     logConfigValue(unikernelCmd),
+		"unikernelBinary":  logConfigValue(unikernelBinary),
+		"hypervisor":       logConfigValue(hypervisor),
+		"initrd":           logConfigValue(initrd),
+		"block":            logConfigValue(block),
+		"blkMntPoint":      logConfigValue(blkMntPoint),
+		"mountRootfs":      logConfigValue(MountRootfs),
 	}).WithField("source", "spec").Debug("urunc annotations")
 
 	return &UnikernelConfig{
@@ -171,85 +173,86 @@ func getConfigFromJSON(jsonFilePath string) (*UnikernelConfig, error) {
 		return nil, err
 	}
 	uniklog.WithFields(logrus.Fields{
-		"unikernelType":    tryDecode(conf.UnikernelType),
-		"unikernelVersion": tryDecode(conf.UnikernelVersion),
-		"unikernelCmd":     tryDecode(conf.UnikernelCmd),
-		"unikernelBinary":  tryDecode(conf.UnikernelBinary),
-		"hypervisor":       tryDecode(conf.Hypervisor),
-		"initrd":           tryDecode(conf.Initrd),
-		"block":            tryDecode(conf.Block),
-		"blkMntPoint":      tryDecode(conf.BlkMntPoint),
-		"mountRootfs":      tryDecode(conf.MountRootfs),
+		"unikernelType":    logConfigValue(conf.UnikernelType),
+		"unikernelVersion": logConfigValue(conf.UnikernelVersion),
+		"unikernelCmd":     logConfigValue(conf.UnikernelCmd),
+		"unikernelBinary":  logConfigValue(conf.UnikernelBinary),
+		"hypervisor":       logConfigValue(conf.Hypervisor),
+		"initrd":           logConfigValue(conf.Initrd),
+		"block":            logConfigValue(conf.Block),
+		"blkMntPoint":      logConfigValue(conf.BlkMntPoint),
+		"mountRootfs":      logConfigValue(conf.MountRootfs),
 	}).WithField("source", uruncJSONFilename).Debug("urunc annotations")
 
 	return &conf, nil
 }
 
-func tryDecode(s string) string {
-	decoded, err := base64.StdEncoding.DecodeString(s)
+func logConfigValue(s string) string {
+	decoded, err := decodeConfigValue(s)
 	if err != nil {
 		uniklog.WithError(err).Errorf("Failed to decode string: %s", s)
 		return s
 	}
-	return string(decoded)
+	return decoded
 }
 
-// decode decodes the base64 encoded values of the Unikernel config
+func decodeConfigValue(s string) (string, error) {
+	if s == "" {
+		return s, nil
+	}
+	
+	// 1. Primary path: Strict prefix checking
+	if strings.HasPrefix(s, "b64:") {
+		encodedStr := strings.TrimPrefix(s, "b64:")
+		decoded, err := base64.StdEncoding.DecodeString(encodedStr)
+		if err != nil {
+			return "", fmt.Errorf("invalid base64 encoding for prefixed string: %w", err)
+		}
+		return string(decoded), nil
+	}
+
+	// 2. Legacy fallback for old bunny versions emitting raw base64.
+	// WARNING: This carries a documented risk of silent data corruption if a short
+	// plaintext config label happens to be valid base64 and decodes to valid UTF-8.
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err == nil && utf8.Valid(decoded) {
+		return string(decoded), nil
+	}
+
+	// 3. No prefix and not valid raw base64, return exactly as plaintext
+	return s, nil
+}
+
+// decode decodes the base64 encoded values of the Unikernel config, safely falling back to plaintext
 func (c *UnikernelConfig) decode() error {
-	decoded, err := base64.StdEncoding.DecodeString(c.UnikernelCmd)
-	if err != nil {
-		return fmt.Errorf("failed to decode UnikernelCmd: %v", err)
+	var err error
+	if c.UnikernelCmd, err = decodeConfigValue(c.UnikernelCmd); err != nil {
+		return err
 	}
-	c.UnikernelCmd = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.Hypervisor)
-	if err != nil {
-		return fmt.Errorf("failed to decode Hypervisor: %v", err)
+	if c.Hypervisor, err = decodeConfigValue(c.Hypervisor); err != nil {
+		return err
 	}
-	c.Hypervisor = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.UnikernelType)
-	if err != nil {
-		return fmt.Errorf("failed to decode UnikernelType: %v", err)
+	if c.UnikernelType, err = decodeConfigValue(c.UnikernelType); err != nil {
+		return err
 	}
-	c.UnikernelType = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.UnikernelVersion)
-	if err != nil {
-		return fmt.Errorf("failed to decode UnikernelVersion: %v", err)
+	if c.UnikernelVersion, err = decodeConfigValue(c.UnikernelVersion); err != nil {
+		return err
 	}
-	c.UnikernelVersion = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.UnikernelBinary)
-	if err != nil {
-		return fmt.Errorf("failed to decode UnikernelBinary: %v", err)
+	if c.UnikernelBinary, err = decodeConfigValue(c.UnikernelBinary); err != nil {
+		return err
 	}
-	c.UnikernelBinary = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.Initrd)
-	if err != nil {
-		return fmt.Errorf("failed to decode Initrd: %v", err)
+	if c.Initrd, err = decodeConfigValue(c.Initrd); err != nil {
+		return err
 	}
-	c.Initrd = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.Block)
-	if err != nil {
-		return fmt.Errorf("failed to decode Block: %v", err)
+	if c.Block, err = decodeConfigValue(c.Block); err != nil {
+		return err
 	}
-	c.Block = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.BlkMntPoint)
-	if err != nil {
-		return fmt.Errorf("failed to decode BlockMntPoint: %v", err)
+	if c.BlkMntPoint, err = decodeConfigValue(c.BlkMntPoint); err != nil {
+		return err
 	}
-	c.BlkMntPoint = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.MountRootfs)
-	if err != nil {
-		return fmt.Errorf("failed to decode mountRootfs: %v", err)
+	if c.MountRootfs, err = decodeConfigValue(c.MountRootfs); err != nil {
+		return err
 	}
-	c.MountRootfs = string(decoded)
-
 	return nil
 }
 

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -180,12 +180,12 @@ func TestGetConfigFromJSON(t *testing.T) {
 func TestDecode(t *testing.T) {
 	t.Run("decode success", func(t *testing.T) {
 		t.Parallel()
-		// Prepare the encoded values
-		encodedCmd := base64.StdEncoding.EncodeToString([]byte("testCmd"))
-		encodedHypervisor := base64.StdEncoding.EncodeToString([]byte("testHypervisor"))
-		encodedType := base64.StdEncoding.EncodeToString([]byte("testType"))
-		encodedBinary := base64.StdEncoding.EncodeToString([]byte("testBinary"))
-		encodedInitrd := base64.StdEncoding.EncodeToString([]byte("testInitrd"))
+		// Prepare the encoded values with b64: prefix
+		encodedCmd := "b64:" + base64.StdEncoding.EncodeToString([]byte("testCmd"))
+		encodedHypervisor := "b64:" + base64.StdEncoding.EncodeToString([]byte("testHypervisor"))
+		encodedType := "b64:" + base64.StdEncoding.EncodeToString([]byte("testType"))
+		encodedBinary := "b64:" + base64.StdEncoding.EncodeToString([]byte("testBinary"))
+		encodedInitrd := "b64:" + base64.StdEncoding.EncodeToString([]byte("testInitrd"))
 
 		config := &UnikernelConfig{
 			UnikernelCmd:    encodedCmd,
@@ -207,10 +207,37 @@ func TestDecode(t *testing.T) {
 		assert.Equal(t, "testInitrd", config.Initrd)
 	})
 
-	t.Run("decode invalid base64", func(t *testing.T) {
+	t.Run("decode legacy raw base64 fallback", func(t *testing.T) {
 		t.Parallel()
-		// Prepare invalid base64 values
-		invalidBase64 := "invalid-base64"
+		// Prepare the encoded values without a prefix to simulate old bunny versions
+		encodedCmd := base64.StdEncoding.EncodeToString([]byte("legacyCmd"))
+		encodedHypervisor := base64.StdEncoding.EncodeToString([]byte("legacyHypervisor"))
+		encodedType := base64.StdEncoding.EncodeToString([]byte("legacyType"))
+		encodedBinary := base64.StdEncoding.EncodeToString([]byte("legacyBinary"))
+		encodedInitrd := base64.StdEncoding.EncodeToString([]byte("legacyInitrd"))
+
+		config := &UnikernelConfig{
+			UnikernelCmd:    encodedCmd,
+			Hypervisor:      encodedHypervisor,
+			UnikernelType:   encodedType,
+			UnikernelBinary: encodedBinary,
+			Initrd:          encodedInitrd,
+		}
+
+		err := config.decode()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "legacyCmd", config.UnikernelCmd)
+		assert.Equal(t, "legacyHypervisor", config.Hypervisor)
+		assert.Equal(t, "legacyType", config.UnikernelType)
+		assert.Equal(t, "legacyBinary", config.UnikernelBinary)
+		assert.Equal(t, "legacyInitrd", config.Initrd)
+	})
+
+	t.Run("decode plaintext fallback", func(t *testing.T) {
+		t.Parallel()
+		// Prepare plaintext values that are invalid base64
+		invalidBase64 := "invalid-base64!"
 
 		config := &UnikernelConfig{
 			UnikernelCmd:    invalidBase64,
@@ -219,10 +246,34 @@ func TestDecode(t *testing.T) {
 			UnikernelBinary: invalidBase64,
 			Initrd:          invalidBase64,
 		}
+		// Call the decode method and expect no error
+		err := config.decode()
+
+		// Assert that no error occurred and original strings are kept
+		assert.NoError(t, err)
+		assert.Equal(t, invalidBase64, config.UnikernelCmd)
+		assert.Equal(t, invalidBase64, config.Hypervisor)
+		assert.Equal(t, invalidBase64, config.UnikernelType)
+		assert.Equal(t, invalidBase64, config.UnikernelBinary)
+		assert.Equal(t, invalidBase64, config.Initrd)
+	})
+
+	t.Run("decode invalid prefixed base64", func(t *testing.T) {
+		t.Parallel()
+		// Prepare invalid base64 values with the valid prefix
+		invalidPrefixedBase64 := "b64:invalid-base64!"
+
+		config := &UnikernelConfig{
+			UnikernelCmd:    invalidPrefixedBase64,
+			Hypervisor:      invalidPrefixedBase64,
+			UnikernelType:   invalidPrefixedBase64,
+			UnikernelBinary: invalidPrefixedBase64,
+			Initrd:          invalidPrefixedBase64,
+		}
 		// Call the decode method and expect an error
 		err := config.decode()
 
-		// Assert that an error occurred
+		// Assert that an error occurred because the strict prefix was present but data was invalid
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Description

<!-- Describe the changes and why they are needed. -->
`bunny` uses Base64 encoding for OCI annotations, but not for config labels. This creates mixed encoded/plain cases that `urunc` currently cannot reliably distinguish. In `pkg/unikontainers/config.go`, the `decode()` method blindly calls `base64.StdEncoding.DecodeString()` on these values, causing the container creation to crash if a plaintext string is passed.
 To prevent silent data corruption:
- **Primary Path**: Checks for an explicit `b64:` prefix before strictly decoding. If malformed, it throws a hard error.
- **Legacy Fallback**: To prevent breaking existing `bunny` deployments, it temporarily retains a raw `base64` decode + `utf8.Valid()` check for unprefixed strings. The residual false-positive risk of this heuristic is now explicitly documented.
- **Plaintext Fallback**: Safely treats anything else as exact plaintext.
- Also a [PR](https://github.com/nubificus/bunny/pull/53) is raised to remove legacy fallback in future
### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #771 

### How was this tested?

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->
Update pkg/unikontainers/config_test.go with mixed-case test scenarios (pure plaintext, valid Base64, and plaintext that falsely decodes).

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->
Gemini

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
