### PR TITLE
fix(unikontainers): validate containerID before path construction

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -90,8 +90,7 @@ var createCommand = &cli.Command{
 func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (err error) {
 	err = nil
 	containerID := cmd.Args().First()
-	if containerID == "" {
-		err = fmt.Errorf("container id cannot be empty")
+	if err = unikontainers.ValidateID(containerID); err != nil {
 		return err
 	}
 	metrics.SetLoggerContainerID(containerID)

--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
+	"github.com/urunc-dev/urunc/pkg/unikontainers"
 )
 
 var deleteCommand = &cli.Command{
@@ -58,8 +59,8 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				containerID := cmd.Args().First()
-				if containerID == "" {
-					return ErrEmptyContainerID
+				if err = unikontainers.ValidateID(containerID); err != nil {
+					return err
 				}
 				rootDir := cmd.String("root")
 				containerDir := filepath.Join(rootDir, containerID)

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -36,8 +36,6 @@ const (
 	maxArgs          // Checks for a maximum number of arguments.
 )
 
-var ErrEmptyContainerID = errors.New("container ID can not be empty")
-
 // checkArgs checks the number of arguments provided in the command-line context
 // against the expected number, based on the specified checkType.
 func checkArgs(cmd *cli.Command, expected, checkType int) error {
@@ -69,8 +67,8 @@ func checkArgs(cmd *cli.Command, expected, checkType int) error {
 
 func getUnikontainer(cmd *cli.Command) (*unikontainers.Unikontainer, error) {
 	containerID := cmd.Args().First()
-	if containerID == "" {
-		return nil, ErrEmptyContainerID
+	if err := unikontainers.ValidateID(containerID); err != nil {
+		return nil, err
 	}
 
 	// We have already made sure in main.go that root is not nil

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -51,6 +51,7 @@ var uniklog = logrus.WithField("subsystem", "unikontainers")
 var ErrQueueProxy = errors.New("this a queue proxy container")
 var ErrNotUnikernel = errors.New("this is not a unikernel container")
 var ErrNotExistingNS = errors.New("the namespace does not exist")
+var ErrInvalidContainerID = errors.New("invalid container ID")
 
 // Unikontainer holds the data necessary to create, manage and delete unikernel containers
 type Unikontainer struct {
@@ -63,8 +64,30 @@ type Unikontainer struct {
 	Conn     *net.UnixConn
 }
 
+// ValidateID checks containerID against the allowed character set,
+func ValidateID(id string) error {
+	if id == "" {
+		return ErrInvalidContainerID
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_', c == '+', c == '-', c == '.':
+		default:
+			return fmt.Errorf("%w: invalid character %q in id %q", ErrInvalidContainerID, c, id)
+		}
+	}
+	return nil
+}
+
 // New parses the bundle and creates a new Unikontainer object
 func New(bundlePath string, containerID string, rootDir string, cfg *UruncConfig) (*Unikontainer, error) {
+	if err := ValidateID(containerID); err != nil {
+		return nil, err
+	}
 	spec, err := loadSpec(bundlePath)
 	if err != nil {
 		return nil, err
@@ -113,6 +136,9 @@ func New(bundlePath string, containerID string, rootDir string, cfg *UruncConfig
 
 // Get retrieves unikernel data from disk to create a Unikontainer object
 func Get(containerID string, rootDir string) (*Unikontainer, error) {
+	if err := ValidateID(containerID); err != nil {
+		return nil, err
+	}
 	u := &Unikontainer{}
 	containerDir := filepath.Join(rootDir, containerID)
 	stateFilePath := filepath.Join(containerDir, stateFilename)


### PR DESCRIPTION
## Description
Constructing a `containerDir` path from an unvalidated `containerID` before calling `filepath.Join` + `os.RemoveAll` is a path traversal risk. A malicious ID like `../../etc/cron.d` passes through ` filepath.Join` unchanged and escapes `rootDir`.

This PR adds `ValidateID` to `pkg/unikontainers`, mirroring runc's `validateID` in `libcontainer/factory_linux.go`. Allowed characters: `a-z A-Z 0-9 _ + - .`

Changes:
- Add `ValidateID` and `ErrInvalidContainerID` to `pkg/unikontainers/unikontainers.go`
- Call `ValidateID` at the top of `New()` and `Get()` where  `filepath.Join(rootDir, containerID)` actually executes
- Call `ValidateID` in the `ErrNotExist` fallback in `delete.go`   the original bug site. This branch re-reads `containerID` from args and calls `os.RemoveAll` directly without going through `New` or `Get`
- Add early-exit calls in `getUnikontainer()` and  `createUnikontainer()` at the cmd layer for fast failure

`session.go` in the containerd-shim is intentionally not touched  `containerID` there comes from the containerd API, not raw CLI input.


### Related issues
- Fixes #714

### How was this tested?
Built two binaries from the same codebase  one before and one after the patch  and ran both against a malicious container ID:

<img width="670" height="430" alt="Screenshot from 2026-06-23 14-05-33" src="https://github.com/user-attachments/assets/f76a3c7c-4c25-4664-82bb-8fbfac37ac5d" />


### LLM usage
N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
My changes only add input validation before path construction and do not affect container  execution logic, so e2e behavior is unchanged.
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).

