### PR TITLE
refactor(shim): consolidate config.json I/O during Create

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("git", "show", "HEAD~1:pkg/containerd-shim/task_service.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+	fmt.Println(string(out))
+}

--- a/pkg/containerd-shim/containerd/annotations.go
+++ b/pkg/containerd-shim/containerd/annotations.go
@@ -162,5 +162,3 @@ func readBlob(ctx context.Context, namespace string, contentClient contentapi.Co
 
 	return raw, nil
 }
-
-

--- a/pkg/containerd-shim/containerd/annotations.go
+++ b/pkg/containerd-shim/containerd/annotations.go
@@ -19,8 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
@@ -73,20 +71,33 @@ func newAnnotationFetcher(ctx context.Context, session *Session) (*annotationFet
 	return fetcher, nil
 }
 
-func InjectUruncAnnotations(ctx context.Context, session *Session, bundlePath string) error {
+func InjectUruncAnnotations(ctx context.Context, session *Session, spec *runtimespec.Spec) (bool, error) {
 	fetcher, err := newAnnotationFetcher(ctx, session)
 	if err != nil {
-		return fmt.Errorf("create annotation fetcher: %w", err)
+		return false, fmt.Errorf("create annotation fetcher: %w", err)
 	}
 	annotations, err := fetcher.fetchUruncAnnotations(ctx)
 	if err != nil {
-		return fmt.Errorf("fetch urunc annotations: %w", err)
+		return false, fmt.Errorf("fetch urunc annotations: %w", err)
 	}
 	if len(annotations) == 0 {
-		return nil
+		return false, nil
 	}
 
-	return patchConfigJSON(bundlePath, annotations)
+	if spec.Annotations == nil {
+		spec.Annotations = make(map[string]string)
+	}
+
+	changed := false
+	for k, v := range annotations {
+		if _, exists := spec.Annotations[k]; exists {
+			continue
+		}
+		spec.Annotations[k] = v
+		changed = true
+	}
+
+	return changed, nil
 }
 
 func (f *annotationFetcher) fetchUruncAnnotations(ctx context.Context) (map[string]string, error) {
@@ -152,84 +163,4 @@ func readBlob(ctx context.Context, namespace string, contentClient contentapi.Co
 	return raw, nil
 }
 
-// patchConfigJSON injects missing annotations into the OCI runtime spec
-// stored in the bundle's config.json.
-//
-// Existing annotations in config.json are preserved. Only annotation keys that
-// are not already present in the runtime spec are added.
-func patchConfigJSON(bundlePath string, annotations map[string]string) error {
-	configPath := filepath.Join(bundlePath, "config.json")
 
-	fi, err := os.Stat(configPath)
-	if err != nil {
-		return fmt.Errorf("stat config.json: %w", err)
-	}
-
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return fmt.Errorf("read config.json: %w", err)
-	}
-
-	var spec runtimespec.Spec
-	if err := json.Unmarshal(data, &spec); err != nil {
-		return fmt.Errorf("unmarshal spec: %w", err)
-	}
-
-	if spec.Annotations == nil {
-		spec.Annotations = make(map[string]string)
-	}
-
-	for k, v := range annotations {
-		if _, exists := spec.Annotations[k]; exists {
-			continue
-		}
-		spec.Annotations[k] = v
-	}
-
-	patched, err := json.MarshalIndent(spec, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal spec: %w", err)
-	}
-
-	if err := atomicWriteFile(configPath, patched, fi.Mode()); err != nil {
-		return fmt.Errorf("write config.json atomically: %w", err)
-	}
-	return nil
-}
-
-func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
-	tmpDir := filepath.Dir(path)
-
-	f, err := os.CreateTemp(tmpDir, "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-
-	tmpName := f.Name()
-	defer os.Remove(tmpName)
-
-	if err := f.Chmod(mode); err != nil {
-		_ = f.Close()
-		return err
-	}
-
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		return err
-	}
-
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		return err
-	}
-
-	if err := f.Close(); err != nil {
-		return err
-	}
-
-	if err := os.Rename(tmpName, path); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/pkg/containerd-shim/guest_rootfs.go
+++ b/pkg/containerd-shim/guest_rootfs.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urunc-dev/urunc/pkg/unikontainers"
+	"path/filepath"
 )
 
 const annotRootfsParams = "com.urunc.internal.rootfs.params"

--- a/pkg/containerd-shim/guest_rootfs.go
+++ b/pkg/containerd-shim/guest_rootfs.go
@@ -18,10 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-
-	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urunc-dev/urunc/pkg/unikontainers"
 )
@@ -33,60 +30,45 @@ var errGuestRootfsChoiceSkipped = errors.New("guest rootfs choice skipped")
 // chooseGuestRootfs runs the same ChooseRootfs logic as runtime Exec after inner
 // task Create (#684) and records the result in annotRootfsParams so Exec knows
 // selection already happened.
-func chooseGuestRootfs(r *taskAPI.CreateTaskRequest) error {
-	configPath := filepath.Join(r.Bundle, "config.json")
-	info, err := os.Stat(configPath)
-	if err != nil {
-		return fmt.Errorf("stat config.json: %w", err)
-	}
-
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return fmt.Errorf("read config.json: %w", err)
-	}
-
-	var spec specs.Spec
-	if err := json.Unmarshal(data, &spec); err != nil {
-		return fmt.Errorf("unmarshal config.json: %w", err)
-	}
+func chooseGuestRootfs(bundle string, spec *specs.Spec) (bool, error) {
 	if spec.Root == nil {
-		return fmt.Errorf("invalid OCI spec: root section is required")
+		return false, fmt.Errorf("invalid OCI spec: root section is required")
 	}
 
-	config, err := unikontainers.GetUnikernelConfig(filepath.Clean(r.Bundle), &spec)
+	config, err := unikontainers.GetUnikernelConfig(filepath.Clean(bundle), spec)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errGuestRootfsChoiceSkipped, err)
+		return false, fmt.Errorf("%w: %w", errGuestRootfsChoiceSkipped, err)
 	}
 
 	annotations := config.Map()
 	uruncCfg, err := unikontainers.LoadUruncConfig(unikontainers.UruncConfigPath)
 	if err != nil && uruncCfg == nil {
-		return err
+		return false, err
 	}
 
 	rootfsParams, err := unikontainers.ChooseRootfs(
-		filepath.Clean(r.Bundle),
+		filepath.Clean(bundle),
 		spec.Root.Path,
 		annotations,
 		uruncCfg,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	encoded, err := json.Marshal(rootfsParams)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if spec.Annotations == nil {
 		spec.Annotations = make(map[string]string)
 	}
-	spec.Annotations[annotRootfsParams] = string(encoded)
 
-	patched, err := json.MarshalIndent(spec, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal config.json: %w", err)
+	val := string(encoded)
+	if spec.Annotations[annotRootfsParams] == val {
+		return false, nil
 	}
+	spec.Annotations[annotRootfsParams] = val
 
-	return os.WriteFile(configPath, patched, info.Mode())
+	return true, nil
 }

--- a/pkg/containerd-shim/task_service.go
+++ b/pkg/containerd-shim/task_service.go
@@ -16,11 +16,16 @@ package containerdshim
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	containerdShim "github.com/urunc-dev/urunc/pkg/containerd-shim/containerd"
 )
 
@@ -34,6 +39,11 @@ type taskService struct {
 }
 
 func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (*taskAPI.CreateTaskResponse, error) {
+	spec, mode, err := readSpec(r.Bundle)
+	if err != nil {
+		return nil, err
+	}
+
 	session, err := containerdShim.OpenSession(ctx, s.containerdAddress, r.ID)
 	if err != nil {
 		log.G(ctx).WithError(err).Warn("urunc(shim): failed to open containerd session")
@@ -43,8 +53,13 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 				log.G(ctx).WithError(err).Warn("urunc(shim): failed to close containerd session")
 			}
 		}()
-		if err := containerdShim.InjectUruncAnnotations(ctx, session, r.Bundle); err != nil {
+		changed, err := containerdShim.InjectUruncAnnotations(ctx, session, spec)
+		if err != nil {
 			log.G(ctx).WithError(err).Warn("urunc(shim): failed to inject annotations to spec")
+		} else if changed {
+			if err := writeSpec(r.Bundle, spec, mode); err != nil {
+				log.G(ctx).WithError(err).Warn("urunc(shim): failed to write injected annotations to spec")
+			}
 		}
 	}
 
@@ -55,13 +70,20 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 
 	// ChooseRootfs after inner task Create so bundle rootfs is mounted;
 	// params are persisted in bundle config.json for runtime Exec.
-	if err := chooseGuestRootfs(r); err != nil {
+	changed, err := chooseGuestRootfs(r.Bundle, spec)
+	if err != nil {
 		if errors.Is(err, errGuestRootfsChoiceSkipped) {
 			log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
 			return resp, nil
 		}
 		log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
 		return nil, err
+	}
+	if changed {
+		if err := writeSpec(r.Bundle, spec, mode); err != nil {
+			log.G(ctx).WithError(err).Warn("urunc(shim): failed to write guest rootfs to spec")
+			return nil, err
+		}
 	}
 
 	return resp, nil
@@ -73,5 +95,72 @@ func (s *taskService) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*ta
 
 func (s *taskService) RegisterTTRPC(server *ttrpc.Server) error {
 	taskAPI.RegisterTaskService(server, s)
+	return nil
+}
+
+func readSpec(bundle string) (*specs.Spec, os.FileMode, error) {
+	configPath := filepath.Join(bundle, "config.json")
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return nil, 0, fmt.Errorf("stat config.json: %w", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read config.json: %w", err)
+	}
+
+	var spec specs.Spec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, 0, fmt.Errorf("unmarshal config.json: %w", err)
+	}
+
+	return &spec, info.Mode(), nil
+}
+
+func writeSpec(bundle string, spec *specs.Spec, mode os.FileMode) error {
+	configPath := filepath.Join(bundle, "config.json")
+	patched, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config.json: %w", err)
+	}
+
+	return atomicWriteFile(configPath, patched, mode)
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	tmpDir := filepath.Dir(path)
+
+	f, err := os.CreateTemp(tmpDir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+
+	tmpName := f.Name()
+	defer os.Remove(tmpName)
+
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/containerd-shim/task_service.go
+++ b/pkg/containerd-shim/task_service.go
@@ -39,10 +39,7 @@ type taskService struct {
 }
 
 func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (*taskAPI.CreateTaskResponse, error) {
-	spec, mode, err := readSpec(r.Bundle)
-	if err != nil {
-		return nil, err
-	}
+	spec, mode, specErr := readSpec(r.Bundle)
 
 	session, err := containerdShim.OpenSession(ctx, s.containerdAddress, r.ID)
 	if err != nil {
@@ -53,12 +50,16 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 				log.G(ctx).WithError(err).Warn("urunc(shim): failed to close containerd session")
 			}
 		}()
-		changed, err := containerdShim.InjectUruncAnnotations(ctx, session, spec)
-		if err != nil {
-			log.G(ctx).WithError(err).Warn("urunc(shim): failed to inject annotations to spec")
-		} else if changed {
-			if err := writeSpec(r.Bundle, spec, mode); err != nil {
-				log.G(ctx).WithError(err).Warn("urunc(shim): failed to write injected annotations to spec")
+		if specErr != nil {
+			log.G(ctx).WithError(specErr).Warn("urunc(shim): failed to inject annotations to spec")
+		} else {
+			changed, err := containerdShim.InjectUruncAnnotations(ctx, session, spec)
+			if err != nil {
+				log.G(ctx).WithError(err).Warn("urunc(shim): failed to inject annotations to spec")
+			} else if changed {
+				if err := writeSpec(r.Bundle, spec, mode); err != nil {
+					log.G(ctx).WithError(err).Warn("urunc(shim): failed to inject annotations to spec")
+				}
 			}
 		}
 	}
@@ -70,6 +71,12 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 
 	// ChooseRootfs after inner task Create so bundle rootfs is mounted;
 	// params are persisted in bundle config.json for runtime Exec.
+	if specErr != nil {
+		err := fmt.Errorf("%w: %w", errGuestRootfsChoiceSkipped, specErr)
+		log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
+		return resp, nil
+	}
+
 	changed, err := chooseGuestRootfs(r.Bundle, spec)
 	if err != nil {
 		if errors.Is(err, errGuestRootfsChoiceSkipped) {
@@ -81,7 +88,7 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 	}
 	if changed {
 		if err := writeSpec(r.Bundle, spec, mode); err != nil {
-			log.G(ctx).WithError(err).Warn("urunc(shim): failed to write guest rootfs to spec")
+			log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description

Refactor the shim's `config.json` handling to avoid multiple reads during
`TaskService.Create()`.

Previously, both `InjectUruncAnnotations` and `chooseGuestRootfs`
performed their own `config.json` read → modify → write cycle.

This change moves ownership of `config.json` I/O into
`TaskService.Create()`, where the OCI spec is read once and reused across
both mutation phases.

`InjectUruncAnnotations` and `chooseGuestRootfs` are refactored to
operate directly on the in-memory `*specs.Spec` instead of performing
their own file I/O. `TaskService.Create()` performs conditional writes
only when a mutation actually changes the spec.

The ordering of the two mutation phases remains unchanged:

- urunc annotations are still written before the inner `TaskService.Create()`
  so the OCI runtime can recognize the container as a unikernel.
- guest rootfs parameters are still written after the inner `TaskService.Create()`,
  once the rootfs has been mounted.

This avoids the previously rejected callback-style abstraction while
reducing duplicate `config.json` reads and keeping the implementation
localized.

### Related issues

- Fixes #719

### LLM usage

Claude Sonnet 5 High was used to help analyze the existing code flow,
understand the maintainer feedback on the previous PR, and assist in
implementing the refactor. The generated changes were reviewed and
validated before submission.

### Checklist

- [x] I have read the contribution guide.
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the LLM policy.