### PR TITLE
fix(hypervisors): treat zombie VMM as dead in killProcess to avoid 2s deadlock

### DIFF
--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -17,8 +17,10 @@ package hypervisors
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -85,6 +87,13 @@ func killProcess(pid int) error {
 			}
 			return fmt.Errorf("error checking if process with pid %d is alive: %w", pid, err)
 		}
+		// unix.Kill(pid, 0) also succeeds for a zombie (defunct) process: the
+		// VMM has terminated but has not yet been reaped by its parent (the
+		// containerd shim). Such a process is effectively dead, so treat it as
+		// gone instead of blocking here for the full timeout.
+		if isZombie(pid) {
+			break
+		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timeout waiting for pid %d to die", pid)
 		}
@@ -92,4 +101,29 @@ func killProcess(pid int) error {
 	}
 
 	return nil
+}
+
+// isZombie reports whether the process with the given pid is in the zombie
+// (defunct) state, i.e. it has terminated but has not yet been reaped by its
+// parent. If the process' stat file cannot be read (e.g. it has already been
+// reaped), the process is considered gone.
+func isZombie(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return true
+	}
+	return statIsZombie(data)
+}
+
+// statIsZombie reports whether the contents of a /proc/<pid>/stat file describe
+// a process in the zombie ("Z") state. The state is the third field, but the
+// second field (comm) is wrapped in parentheses and may itself contain spaces
+// or ')', so the state is read as the first non-space byte after the final ')'.
+func statIsZombie(stat []byte) bool {
+	s := string(stat)
+	i := strings.LastIndexByte(s, ')')
+	if i < 0 || i+2 >= len(s) {
+		return false
+	}
+	return s[i+2] == 'Z'
 }

--- a/pkg/unikontainers/hypervisors/utils_test.go
+++ b/pkg/unikontainers/hypervisors/utils_test.go
@@ -71,3 +71,29 @@ func TestBytesToMB(t *testing.T) {
 		})
 	}
 }
+
+func TestStatIsZombie(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		stat     string
+		expected bool
+	}{
+		{"zombie process", "1234 (firecracker) Z 1 1234 1234 0 -1 4194560 0 0", true},
+		{"running process", "1234 (firecracker) R 1 1234 1234 0 -1 4194560 0 0", false},
+		{"sleeping process", "1234 (qemu-system-x86) S 1 1234 1234 0 -1 4194560", false},
+		// The comm field may contain spaces and ')', which must not break parsing.
+		{"comm with parens and spaces, zombie", "42 (weird ) name) Z 1 42 42 0", true},
+		{"comm with parens and spaces, running", "42 (weird ) name) R 1 42 42 0", false},
+		{"malformed without closing paren", "1234 firecracker Z", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, statIsZombie([]byte(tc.stat)))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Closes #790.

When a VMM (Firecracker/QEMU/HVT/SPT/Cloud Hypervisor) terminates it enters the **zombie** (defunct) state until its parent — the containerd shim — reaps it with `waitpid`. `killProcess` sends `SIGKILL` and then polls `unix.Kill(pid, 0)` waiting for `ESRCH`:

```go
for {
    if err := unix.Kill(pid, 0); err != nil {
        if errors.Is(err, unix.ESRCH) { break } // never reached for a zombie
        ...
    }
    if time.Now().After(deadline) {
        return fmt.Errorf("timeout waiting for pid %d to die", pid)
    }
    time.Sleep(100 * time.Millisecond)
}
```

`unix.Kill(pid, 0)` returns **nil** for a zombie (it still exists in the process table), so the loop never sees `ESRCH`. Every forced-cleanup path (e.g. `urunc delete --force`) therefore blocks for the **full 2-second timeout** and then returns a bogus `"timeout waiting for pid to die"` error, even though the VMM is already dead.

## Fix

Detect the zombie state via `/proc/<pid>/stat` and treat it as dead, breaking out of the loop immediately:

- `isZombie(pid)` reads the stat file (missing file → already reaped → treated as gone).
- `statIsZombie([]byte)` is a pure helper that reads the process state field. It parses the state as the first byte after the **final** `)`, so a `comm` field containing spaces or `)` cannot corrupt parsing.

**Result:** forced cleanup returns as soon as the VMM is dead instead of waiting ~2000 ms, and no longer reports a false timeout error.

## Tests

`TestStatIsZombie` covers zombie/running/sleeping states, a `comm` with embedded spaces and `)`, and malformed/empty input.

## Verification

`go build`, `go vet` and test compilation pass (cross-compiled to `linux/amd64`). The pure `statIsZombie` logic was also run directly against all test cases. CI will run the full suite on Linux.