### PR TITLE
ref: Select the rootfs in the create step instead of Exec

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -420,3 +420,4 @@ onsi
 ESRCH
 Prafful
 praffq
+libcontainers

--- a/pkg/containerd-shim/task_service.go
+++ b/pkg/containerd-shim/task_service.go
@@ -16,7 +16,6 @@ package containerdshim
 
 import (
 	"context"
-	"errors"
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/log"
@@ -53,16 +52,18 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 		return resp, err
 	}
 
+	// TODO: #816 - Restore rootfs choice here once shim integration is complete.
+	// For now, rootfs is selected during urunc create (InitialSetup phase).
 	// ChooseRootfs after inner task Create so bundle rootfs is mounted;
 	// params are persisted in bundle config.json for runtime Exec.
-	if err := chooseGuestRootfs(r); err != nil {
-		if errors.Is(err, errGuestRootfsChoiceSkipped) {
-			log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
-			return resp, nil
-		}
-		log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
-		return nil, err
-	}
+	// if err := chooseGuestRootfs(r); err != nil {
+	// 	if errors.Is(err, errGuestRootfsChoiceSkipped) {
+	// 		log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
+	// 		return resp, nil
+	// 	}
+	// 	log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
+	// 	return nil, err
+	// }
 
 	return resp, nil
 }

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -120,15 +120,15 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 	blkMntPoint := spec.Annotations[annotBlockMntPoint]
 	MountRootfs := spec.Annotations[annotMountRootfs]
 	uniklog.WithFields(logrus.Fields{
-		"unikernelType":    tryDecode(unikernelType),
-		"unikernelVersion": tryDecode(unikernelVersion),
-		"unikernelCmd":     tryDecode(unikernelCmd),
-		"unikernelBinary":  tryDecode(unikernelBinary),
-		"hypervisor":       tryDecode(hypervisor),
-		"initrd":           tryDecode(initrd),
-		"block":            tryDecode(block),
-		"blkMntPoint":      tryDecode(blkMntPoint),
-		"mountRootfs":      tryDecode(MountRootfs),
+		"unikernelType":    unikernelType,
+		"unikernelVersion": unikernelVersion,
+		"unikernelCmd":     unikernelCmd,
+		"unikernelBinary":  unikernelBinary,
+		"hypervisor":       hypervisor,
+		"initrd":           initrd,
+		"block":            block,
+		"blkMntPoint":      blkMntPoint,
+		"mountRootfs":      MountRootfs,
 	}).WithField("source", "spec").Debug("urunc annotations")
 
 	return &UnikernelConfig{

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -151,20 +151,68 @@ func (u *Unikontainer) InitialSetup() error {
 		return err
 	}
 
-	// Ensure the container's rootfs has the correct propagation flag
-	// so if we unmount it later, it gets unmounted from other mount peer
-	// groups too. We do that regardless of the type of the container's
-	// rootfs (e.g. block-based, overlay) abd this is ok, because we later
-	// cut off all propagation from reexec.
-	// TODO: Move this to the shim, when we finally make it.
-	err = unix.Mount("", rootfsDir, "", unix.MS_SHARED|unix.MS_REC, "")
-	if err != nil && !errors.Is(err, unix.EINVAL) {
-		// An EINVAL error is fine, because it means that the
-		// rootfs is not really a mountpoint. This could be the case when
-		// using urunc directly from its cli and the rootfs is a normal
-		// directory
-		uniklog.Errorf("could not set propagation flag as shared for container's rootfs: %v", err)
+	unikernelPath := u.State.Annotations[annotBinary]
+	initrdPath := u.State.Annotations[annotInitrd]
+	unikernelType := u.State.Annotations[annotType]
+	unikernel, err := unikernels.New(unikernelType)
+	if err != nil {
 		return err
+	}
+
+	// handle guest's rootfs.
+	// There are four options:
+	// 1. No rootfs for guest
+	// 2. Use initrd or a block image inside the container's rootfs
+	// 3. Use the devmapper snapshot as a block device for the guest's rootfs
+	// 4. Use 9pfs to share the container's rootfs as the guest's rootfs
+	// By default, urunc will not set any rootfs for the guest. However,
+	// if the respective annotation is set then, depending on the guest
+	// (supports block or 9pfs), it will use the supported option. In case
+	// both ae supported, then the block option will be used by default.
+	var rootfsParams types.RootfsParams
+
+	// Read the rootfs choice written by the shim.
+	if rootfsParamsJSON := u.Spec.Annotations[annotRootfsParams]; rootfsParamsJSON != "" {
+		if err := json.Unmarshal([]byte(rootfsParamsJSON), &rootfsParams); err != nil {
+			return fmt.Errorf("could not decode guest rootfs params: %w", err)
+		}
+	}
+
+	if rootfsParams.MonRootfs == "" {
+		rootfsParams, err = ChooseRootfs(bundleDir, rootfsDir, u.State.Annotations, u.UruncCfg)
+		if err != nil {
+			uniklog.Errorf("could not choose guest rootfs: %v", err)
+			return err
+		}
+		encoded, err := json.Marshal(rootfsParams)
+		if err != nil {
+			return err
+		}
+		u.State.Annotations[annotRootfsParams] = string(encoded)
+	}
+	uniklog.WithFields(logrus.Fields{
+		"rootfs_type": rootfsParams.Type,
+		"rootfs_path": rootfsParams.Path,
+		"mon_rootfs":  rootfsParams.MonRootfs,
+		"mountedPath": rootfsParams.MountedPath,
+	}).Debug("guest rootfs params")
+
+	if rootfsParams.Type == "block" {
+		rfsBuilder := blockRootfs{
+			mounts:        u.Spec.Mounts,
+			monRootfs:     rootfsParams.MonRootfs,
+			mountedPath:   rootfsParams.MountedPath,
+			path:          rootfsParams.Path,
+			kernelPath:    unikernelPath,
+			initrdPath:    initrdPath,
+			uruncJSONPath: uruncJSONFilename,
+			guestType:     unikernelType,
+			guest:         unikernel,
+		}
+		err := rfsBuilder.preSetup()
+		if err != nil {
+			return fmt.Errorf("pre setup step for rootfs failed: %w", err)
+		}
 	}
 
 	u.State.Status = specs.StateCreating
@@ -433,19 +481,15 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	var rootfsParams types.RootfsParams
 
 	// Read the rootfs choice written by the shim.
-	if rootfsParamsJSON := u.Spec.Annotations[annotRootfsParams]; rootfsParamsJSON != "" {
+	if rootfsParamsJSON := u.State.Annotations[annotRootfsParams]; rootfsParamsJSON != "" {
 		if err := json.Unmarshal([]byte(rootfsParamsJSON), &rootfsParams); err != nil {
 			return fmt.Errorf("could not decode guest rootfs params: %w", err)
 		}
 	}
 
-	// If there is no shim choice, the runtime chooses rootfs here.
 	if rootfsParams.MonRootfs == "" {
-		rootfsParams, err = ChooseRootfs(u.State.Bundle, u.Spec.Root.Path, u.State.Annotations, u.UruncCfg)
-		if err != nil {
-			uniklog.Errorf("could not choose guest rootfs: %v", err)
-			return err
-		}
+		uniklog.Errorf("missing annotations from selected rootfs")
+		return fmt.Errorf("missing metadata for rootfs preparation")
 	}
 	uniklog.WithFields(logrus.Fields{
 		"rootfs_type": rootfsParams.Type,
@@ -502,11 +546,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	if err = os.MkdirAll(rootfsParams.MonRootfs, 0o755); err != nil {
 		return fmt.Errorf("failed to create monitor rootfs directory %s: %w", rootfsParams.MonRootfs, err)
-	}
-
-	err = rfsBuilder.preSetup()
-	if err != nil {
-		return fmt.Errorf("pre setup step for rootfs failed: %w", err)
 	}
 
 	// Prepare Monitor rootfs


### PR DESCRIPTION
## Description

Move the `chooseRootfs` function from reexec to the create process. In this way we can perform the `preSetup` function of a block based rootfs before creating any namespace. This was a block for the adoption of libcontainers, because when we use libcontainers for the monitor execution environment, we will not be able to perform such operations like the `preSetup` step.

This will also allow us to immediately unmount the rootfs created by containerd before creating any mount namespaces and having troubles with mount events and their propagation.

Furthermore, since `chooseRootfs` takes place in`urunc create`, we need to disable the same operation from the shim which takes place after `urunc create` finishes and therefore it might fail since in block-based rootfs the rootfs will get unmounted. However, this is a temporary solution and related to https://github.com/urunc-dev/urunc/issues/816. The rootfs handling needs better control from the create task of the shim and hence we need to get deeper in the shim for a proper solution.

At last, give this opportunity, remove the `tryDecode` function from printing the annotations when we get them from the Spec. 

### Related issues

- Fixes  https://github.com/urunc-dev/urunc/issues/779

### How was this tested?

Running the e2e tests

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
