### PR TITLE
feat: checkpoint/restore support via VMM snapshots

### DIFF
--- a/cmd/urunc/checkpoint.go
+++ b/cmd/urunc/checkpoint.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+var checkpointCommand = &cli.Command{
+	Name:  "checkpoint",
+	Usage: "checkpoint a running container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+checkpointed.`,
+	Description: `The checkpoint command pauses the container's microVM and saves a full
+snapshot of its state (device model and guest memory) into the image
+directory, so it can later be restored with "urunc restore".
+
+Unlike runc, urunc does not use CRIU: the snapshot is taken by the VMM
+(Firecracker or Cloud Hypervisor) through its control API. CRIU-specific
+options are accepted for CLI compatibility with runc, but are ignored.`,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "image-path",
+			Value: "",
+			Usage: "path for saving checkpoint image files",
+		},
+		&cli.StringFlag{
+			Name:  "work-path",
+			Value: "",
+			Usage: "path for saving work files and logs (ignored, runc compatibility)",
+		},
+		&cli.StringFlag{
+			Name:  "parent-path",
+			Value: "",
+			Usage: "path for previous criu image files in pre-dump (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "leave-running",
+			Usage: "leave the container running after writing the checkpoint to disk",
+		},
+		&cli.BoolFlag{
+			Name:  "tcp-established",
+			Usage: "allow open tcp connections (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "ext-unix-sk",
+			Usage: "allow external unix sockets (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "shell-job",
+			Usage: "allow shell jobs (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "lazy-pages",
+			Usage: "use lazy migration mechanism (ignored, runc compatibility)",
+		},
+		&cli.StringFlag{
+			Name:  "status-fd",
+			Value: "",
+			Usage: "criu writes \\0 to this FD once lazy-pages is ready (ignored, runc compatibility)",
+		},
+		&cli.StringFlag{
+			Name:  "page-server",
+			Value: "",
+			Usage: "ADDRESS:PORT of the page server (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "file-locks",
+			Usage: "handle file locks, for safety (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "pre-dump",
+			Usage: "dump container's memory information only, leave the container running after this (unsupported)",
+		},
+		&cli.StringFlag{
+			Name:  "manage-cgroups-mode",
+			Value: "",
+			Usage: "cgroups mode: 'soft', 'full' and 'strict' (ignored, runc compatibility)",
+		},
+		&cli.StringSliceFlag{
+			Name:  "empty-ns",
+			Usage: "create a namespace, but don't restore its properties (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "auto-dedup",
+			Usage: "enable auto deduplication of memory images (ignored, runc compatibility)",
+		},
+	},
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		// Kill (the default post-checkpoint action) joins the sandbox
+		// network namespace, which requires a locked OS thread.
+		runtime.GOMAXPROCS(1)
+		runtime.LockOSThread()
+		logrus.WithField("command", "CHECKPOINT").WithField("args", os.Args).Debug("urunc INVOKED")
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
+			return err
+		}
+
+		unikontainer, err := getUnikontainer(cmd)
+		if err != nil {
+			return err
+		}
+
+		imagePath, err := resolveImagePath(cmd)
+		if err != nil {
+			return err
+		}
+
+		return unikontainer.Checkpoint(imagePath, cmd.Bool("leave-running"))
+	},
+}
+
+// resolveImagePath returns the checkpoint image directory, defaulting to
+// "checkpoint" under the current working directory like runc does.
+func resolveImagePath(cmd *cli.Command) (string, error) {
+	imagePath := cmd.String("image-path")
+	if imagePath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		imagePath = filepath.Join(cwd, "checkpoint")
+	}
+	return filepath.Abs(imagePath)
+}

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -75,7 +75,7 @@ var createCommand = &cli.Command{
 		}
 		if !cmd.Bool("reexec") {
 			uruncCfg, _ := unikontainers.LoadUruncConfig(unikontainers.UruncConfigPath) // ignore the error and use default config
-			return createUnikontainer(cmd, uruncCfg)
+			return createUnikontainer(cmd, uruncCfg, "")
 		}
 
 		return reexecUnikontainer(cmd)
@@ -86,8 +86,10 @@ var createCommand = &cli.Command{
 // initializes it's base dir and state.json,
 // setups terminal if required and spawns reexec process,
 // waits for reexec process to notify, executes CreateRuntime hooks,
-// sends ACK to reexec process
-func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (err error) {
+// sends ACK to reexec process.
+// A non-empty restorePath marks the container to be restored from the
+// checkpoint image in that directory instead of cold-booting the guest.
+func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig, restorePath string) (err error) {
 	err = nil
 	containerID := cmd.Args().First()
 	if containerID == "" {
@@ -122,6 +124,12 @@ func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (
 		return err
 	}
 	metrics.Capture(m.TS01)
+
+	// Mark the container for restore before the state is first persisted,
+	// so the reexec process observes the annotation.
+	if restorePath != "" {
+		unikontainer.SetRestorePath(restorePath)
+	}
 
 	err = unikontainer.InitialSetup()
 	if err != nil {

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -109,9 +109,13 @@ func main() {
 			},
 		},
 		Commands: []*cli.Command{
+			checkpointCommand,
 			createCommand,
 			deleteCommand,
 			killCommand,
+			pauseCommand,
+			restoreCommand,
+			resumeCommand,
 			runCommand,
 			psCommand,
 			// specCommand,

--- a/cmd/urunc/pause.go
+++ b/cmd/urunc/pause.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+var pauseCommand = &cli.Command{
+	Name:  "pause",
+	Usage: "pause suspends all processes inside the container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+paused. `,
+	Description: `The pause command suspends the container by pausing the vCPUs of its
+microVM through the VMM control API. Use "urunc resume" to resume it.`,
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		logrus.WithField("command", "PAUSE").WithField("args", os.Args).Debug("urunc INVOKED")
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
+			return err
+		}
+		unikontainer, err := getUnikontainer(cmd)
+		if err != nil {
+			return err
+		}
+		return unikontainer.PauseVM()
+	},
+}
+
+var resumeCommand = &cli.Command{
+	Name:  "resume",
+	Usage: "resumes all processes that have been previously paused",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+resumed.`,
+	Description: `The resume command resumes the vCPUs of the container's paused microVM
+through the VMM control API.`,
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		logrus.WithField("command", "RESUME").WithField("args", os.Args).Debug("urunc INVOKED")
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
+			return err
+		}
+		unikontainer, err := getUnikontainer(cmd)
+		if err != nil {
+			return err
+		}
+		return unikontainer.ResumeVM()
+	},
+}

--- a/cmd/urunc/restore.go
+++ b/cmd/urunc/restore.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+	"github.com/urunc-dev/urunc/pkg/unikontainers"
+	"golang.org/x/sys/unix"
+)
+
+var restoreCommand = &cli.Command{
+	Name:  "restore",
+	Usage: "restore a container from a previous checkpoint",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the name for the instance of the container to be
+restored.`,
+	Description: `The restore command creates a new container instance from the bundle and,
+instead of cold-booting the guest, resumes the microVM from the snapshot
+found in the image directory (see "urunc checkpoint").
+
+The restored guest keeps the network identity (MAC, IP) it had at checkpoint
+time, so the target network namespace must provide an equivalent L3
+environment. The container always runs detached; the --detach flag is
+accepted for CLI compatibility with runc.`,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "image-path",
+			Value: "",
+			Usage: "path to criu image files for restoring",
+		},
+		&cli.StringFlag{
+			Name:  "work-path",
+			Value: "",
+			Usage: "path for saving work files and logs (ignored, runc compatibility)",
+		},
+		&cli.StringFlag{
+			Name:    "bundle",
+			Aliases: []string{"b"},
+			Value:   "",
+			Usage:   "path to the root of the bundle directory, defaults to the current directory",
+		},
+		&cli.StringFlag{
+			Name:  "console-socket",
+			Value: "",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
+		},
+		&cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "specify the file to write the process id to",
+		},
+		&cli.BoolFlag{
+			Name:    "detach",
+			Aliases: []string{"d"},
+			Usage:   "detach from the container's process (urunc always detaches)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-subreaper",
+			Usage: "disable the use of the subreaper (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "do not use pivot root (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "tcp-established",
+			Usage: "allow open tcp connections (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "ext-unix-sk",
+			Usage: "allow external unix sockets (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "shell-job",
+			Usage: "allow shell jobs (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "file-locks",
+			Usage: "handle file locks, for safety (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "lazy-pages",
+			Usage: "use lazy migration mechanism (ignored, runc compatibility)",
+		},
+		&cli.StringFlag{
+			Name:  "manage-cgroups-mode",
+			Value: "",
+			Usage: "cgroups mode: 'soft', 'full' and 'strict' (ignored, runc compatibility)",
+		},
+		&cli.StringSliceFlag{
+			Name:  "empty-ns",
+			Usage: "create a namespace, but don't restore its properties (ignored, runc compatibility)",
+		},
+		&cli.BoolFlag{
+			Name:  "auto-dedup",
+			Usage: "enable auto deduplication of memory images (ignored, runc compatibility)",
+		},
+	},
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		logrus.WithField("command", "RESTORE").WithField("args", os.Args).Debug("urunc INVOKED")
+		if err := checkArgs(cmd, 1, exactArgs); err != nil {
+			return err
+		}
+		return restoreUnikontainer(cmd)
+	},
+}
+
+// restoreUnikontainer creates the container with the restore annotation set,
+// starts it (the reexec process launches the VMM in restore mode instead of
+// cold-booting) and then completes the restore through the VMM API.
+func restoreUnikontainer(cmd *cli.Command) error {
+	imagePath, err := resolveImagePath(cmd)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		return fmt.Errorf("cannot access checkpoint image path %s: %w", imagePath, err)
+	}
+
+	uruncCfg, _ := unikontainers.LoadUruncConfig(unikontainers.UruncConfigPath) // ignore the error and use default config
+	if err := createUnikontainer(cmd, uruncCfg, imagePath); err != nil {
+		return err
+	}
+
+	if err := startUnikontainer(cmd); err != nil {
+		return err
+	}
+
+	// The VMM process is up; drive its API to load/resume the snapshot.
+	unikontainer, err := getUnikontainer(cmd)
+	if err != nil {
+		return err
+	}
+	if err := unikontainer.FinishRestore(); err != nil {
+		// The freshly spawned VMM cannot recover from a failed
+		// restore; stop it so the container does not linger half-dead.
+		if killErr := unikontainer.Signal(unix.SIGKILL); killErr != nil {
+			logrus.WithError(killErr).Error("failed to kill VMM after failed restore")
+		}
+		return err
+	}
+
+	return nil
+}

--- a/docs/checkpoint-restore.md
+++ b/docs/checkpoint-restore.md
@@ -1,0 +1,110 @@
+# Checkpoint and Restore
+
+`urunc` supports checkpointing a running container and restoring it later,
+possibly in a different container instance. Since every `urunc` container is
+a microVM, checkpoint/restore is implemented as a **VM snapshot**: the VMM
+pauses the guest and serializes its full state (device model and guest
+memory) to disk, and a fresh VMM process later resumes the guest from that
+state. Unlike `runc`, no CRIU is involved; the snapshot is taken by the VMM
+itself through its control API.
+
+## Supported VMMs
+
+| VMM | Checkpoint/Restore | Mechanism |
+| --- | ------------------ | --------- |
+| Firecracker | ✅ | `PUT /snapshot/create` / `PUT /snapshot/load` over the API socket |
+| Cloud Hypervisor | ✅ | `vm.snapshot` / `--restore` + `vm.resume` over the API socket |
+| QEMU | ❌ (planned, via QMP `migrate`) | — |
+| Solo5-hvt / Solo5-spt / Hedge | ❌ (no snapshot support in the monitor) | — |
+
+To make this possible, `urunc` always starts Firecracker and Cloud
+Hypervisor with their control API enabled on a unix socket
+(`/tmp/urunc-vmm-api.sock` inside the monitor's mount namespace). The socket
+is reachable from the host through `/proc/<pid>/root`.
+
+## Usage
+
+### With the urunc CLI
+
+```bash
+# Checkpoint a running container into a directory and stop it:
+urunc checkpoint --image-path /tmp/ckpt mycontainer
+
+# ...or keep it running after the snapshot:
+urunc checkpoint --image-path /tmp/ckpt --leave-running mycontainer
+
+# Restore a new container instance from the checkpoint:
+urunc restore --image-path /tmp/ckpt --bundle /path/to/bundle mycontainer2
+```
+
+`urunc` also implements `pause` and `resume`, which suspend and resume the
+guest's vCPUs through the VMM API:
+
+```bash
+urunc pause mycontainer
+urunc resume mycontainer
+```
+
+### With containerd
+
+The `checkpoint`, `restore`, `pause` and `resume` commands are CLI-compatible
+with `runc`, so the containerd shim's inherited task service drives them
+directly, e.g.:
+
+```bash
+ctr task pause mycontainer
+ctr task resume mycontainer
+ctr task checkpoint --image-path /tmp/ckpt mycontainer
+```
+
+CRIU-specific flags (`--tcp-established`, `--file-locks`, etc.) are accepted
+for compatibility but ignored: the VM snapshot always captures the complete
+guest state, including open connections' guest-side state and the guest page
+cache.
+
+## What is captured
+
+* **Guest memory and device state**: everything running inside the guest,
+  including the in-memory state of the application.
+* **urunc metadata** (`urunc-checkpoint.json`): the VMM type and the network
+  parameters the VM was started with, used for validation and re-wiring at
+  restore time.
+
+The **rootfs is not captured**: a restored container must be created from
+the same rootfs content the checkpointed container used (for block-based
+rootfs, the same devmapper snapshot content at the same in-guest paths).
+When restoring through containerd, the checkpoint image includes the
+container's rw-layer diff, which containerd re-applies on restore.
+
+## Networking across restore
+
+The guest's network identity (MAC address, IP address, ARP/neighbor state)
+is frozen inside the snapshot. On restore, `urunc` creates a fresh tap
+device in the new network namespace and re-attaches the frozen guest NIC to
+it (via `network_overrides` on Firecracker, or by rewriting the snapshot's
+`config.json` on Cloud Hypervisor). For the restored guest to communicate:
+
+* the new network namespace must provide an **equivalent L3 environment**
+  (same guest IP, mask and gateway); with the default TC-redirect setup this
+  is the case when the container's veth carries the same IP;
+* TCP connections that were open at checkpoint time are **not** guaranteed
+  to survive; the peer side will usually have timed out.
+
+If the restore namespace has a different IP than the checkpointed one,
+`urunc` logs a warning and proceeds: the guest keeps using its original
+address.
+
+## Limitations
+
+* Only Firecracker and Cloud Hypervisor; snapshots are **not** portable
+  across VMM types, and Firecracker additionally requires the same
+  Firecracker version at restore.
+* Restore requires the same CPU vendor/features on the target host.
+* vAccel-enabled containers cannot be checkpointed/restored (the vsock
+  device state references host paths that are not re-wired yet).
+* Shared-fs (virtiofs/9p) rootfs containers are snapshottable only insofar
+  as the shared directory content is unchanged at restore time; block and
+  initrd rootfs types are recommended.
+* Snapshot files are copied into the checkpoint directory (and staged back
+  into the monitor rootfs on restore); for large guest memory sizes this
+  adds a copy cost proportional to memory size.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - Installation: installation.md
   - Configuration: configuration.md
   - VMM/Sandbox Support: hypervisor-support.md
+  - Checkpoint/Restore: checkpoint-restore.md
   - Unikernel Support: unikernel-support.md
   - Building/Packaging unikernels:
       - package/*.md

--- a/pkg/containerd-shim/task_service.go
+++ b/pkg/containerd-shim/task_service.go
@@ -48,6 +48,19 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 		}
 	}
 
+	// When the task is created from a checkpoint, the inner runc task
+	// service invokes `urunc restore`, which creates AND starts the
+	// container in one shot. The guest rootfs choice must therefore
+	// happen before forwarding; for regular creates it happens after,
+	// once the inner task Create has mounted the bundle rootfs.
+	isRestore := r.Checkpoint != ""
+	if isRestore {
+		if err := chooseGuestRootfs(r); err != nil && !errors.Is(err, errGuestRootfsChoiceSkipped) {
+			log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs for restore")
+			return nil, err
+		}
+	}
+
 	resp, err := s.TaskService.Create(ctx, r)
 	if err != nil {
 		return resp, err
@@ -55,13 +68,15 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 
 	// ChooseRootfs after inner task Create so bundle rootfs is mounted;
 	// params are persisted in bundle config.json for runtime Exec.
-	if err := chooseGuestRootfs(r); err != nil {
-		if errors.Is(err, errGuestRootfsChoiceSkipped) {
-			log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
-			return resp, nil
+	if !isRestore {
+		if err := chooseGuestRootfs(r); err != nil {
+			if errors.Is(err, errGuestRootfsChoiceSkipped) {
+				log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
+				return resp, nil
+			}
+			log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
+			return nil, err
 		}
-		log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
-		return nil, err
 	}
 
 	return resp, nil

--- a/pkg/unikontainers/checkpoint.go
+++ b/pkg/unikontainers/checkpoint.go
@@ -1,0 +1,374 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikontainers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/hypervisors"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+const (
+	// annotRestorePath holds the host path of the checkpoint image
+	// directory when a container is being restored instead of cold-booted.
+	// It is set by `urunc restore` before the reexec process starts and is
+	// consumed by Exec to branch into the restore path.
+	annotRestorePath = "com.urunc.internal.restore.path"
+
+	// checkpointMetadataFile is the name of the urunc-specific metadata
+	// file written inside a checkpoint image directory, next to the VMM
+	// snapshot files.
+	checkpointMetadataFile = "urunc-checkpoint.json"
+
+	// netInfoFilename is written in the container base directory by the
+	// reexec process right before it executes the VMM. It records the
+	// network parameters (most importantly the tap device name) of the
+	// spawned VM, which checkpoint and restore need later.
+	netInfoFilename = "netinfo.json"
+
+	// vmmAPIWaitTimeout bounds how long we wait for a freshly spawned
+	// VMM process to expose its API socket. Cloud Hypervisor loads the
+	// whole snapshot before serving the API, so this must accommodate
+	// reading guest memory from disk.
+	vmmAPIWaitTimeout = 60 * time.Second
+)
+
+// CheckpointMetadata describes a urunc checkpoint. It is stored as
+// checkpointMetadataFile inside the checkpoint image directory and validated
+// on restore.
+type CheckpointMetadata struct {
+	// Version of the metadata format.
+	Version int `json:"version"`
+	// VmmType is the hypervisor that produced the snapshot. A snapshot
+	// can only be restored by the same hypervisor type (and, for
+	// Firecracker, the same hypervisor version).
+	VmmType string `json:"vmmType"`
+	// UnikernelType is the guest type of the snapshotted container.
+	UnikernelType string `json:"unikernelType"`
+	// Net records the network parameters the VM was started with. The
+	// guest side (MAC, IP, gateway) is frozen inside the snapshot; the
+	// restore path must present an equivalent L3 environment.
+	Net types.NetDevParams `json:"net"`
+	// SnapshotFiles lists the snapshot files in the checkpoint directory.
+	SnapshotFiles []string `json:"snapshotFiles"`
+}
+
+// vmmSnapshotter returns the container's VMM together with its Snapshotter
+// capability, or ErrSnapshotNotSupported if the VMM cannot snapshot.
+func (u *Unikontainer) vmmSnapshotter() (types.VMM, hypervisors.Snapshotter, error) {
+	vmmType := u.State.Annotations[annotHypervisor]
+	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
+	if err != nil {
+		return nil, nil, err
+	}
+	snapshotter, ok := vmm.(hypervisors.Snapshotter)
+	if !ok || !snapshotter.SupportsSnapshot() {
+		return nil, nil, fmt.Errorf("%w: %s", hypervisors.ErrSnapshotNotSupported, vmmType)
+	}
+	return vmm, snapshotter, nil
+}
+
+// apiSockHostPath returns a host-resolvable path to the VMM API socket of the
+// running container. The socket lives inside the monitor's mount namespace,
+// so it is reached through the /proc/<pid>/root magic link.
+func (u *Unikontainer) apiSockHostPath() string {
+	return filepath.Join(fmt.Sprintf("/proc/%d/root", u.State.Pid), hypervisors.InNsAPISockPath)
+}
+
+// procRootDir returns the host-resolvable path of the monitor's root
+// directory, through the /proc/<pid>/root magic link.
+func (u *Unikontainer) procRootDir() string {
+	return fmt.Sprintf("/proc/%d/root", u.State.Pid)
+}
+
+// PauseVM pauses the vCPUs of the container's VM through the VMM API.
+func (u *Unikontainer) PauseVM() error {
+	if !u.isRunning() {
+		return fmt.Errorf("container %s is not running", u.State.ID)
+	}
+	_, snapshotter, err := u.vmmSnapshotter()
+	if err != nil {
+		return err
+	}
+	if err := snapshotter.PauseVM(u.apiSockHostPath()); err != nil {
+		return err
+	}
+	u.State.Status = "paused"
+	return u.saveContainerState()
+}
+
+// ResumeVM resumes the vCPUs of the container's paused VM through the VMM API.
+func (u *Unikontainer) ResumeVM() error {
+	if !u.isRunning() {
+		return fmt.Errorf("container %s is not running", u.State.ID)
+	}
+	_, snapshotter, err := u.vmmSnapshotter()
+	if err != nil {
+		return err
+	}
+	if err := snapshotter.ResumeVM(u.apiSockHostPath()); err != nil {
+		return err
+	}
+	u.State.Status = specs.StateRunning
+	return u.saveContainerState()
+}
+
+// Checkpoint pauses the container's VM, writes a full snapshot of it (device
+// state and guest memory) into imagePath along with urunc metadata, and then
+// either resumes the VM (leaveRunning) or stops it, matching runc's
+// checkpoint semantics.
+func (u *Unikontainer) Checkpoint(imagePath string, leaveRunning bool) error {
+	if !u.isRunning() {
+		return fmt.Errorf("cannot checkpoint container %s: not running", u.State.ID)
+	}
+	_, snapshotter, err := u.vmmSnapshotter()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(imagePath, 0o700); err != nil {
+		return fmt.Errorf("failed to create checkpoint directory %s: %w", imagePath, err)
+	}
+
+	sockPath := u.apiSockHostPath()
+	if err := snapshotter.PauseVM(sockPath); err != nil {
+		return fmt.Errorf("failed to pause VM: %w", err)
+	}
+
+	// The VMM writes the snapshot inside its own mount namespace; create
+	// the target directory and collect the files through /proc/<pid>/root.
+	hostSnapDir := filepath.Join(u.procRootDir(), hypervisors.InNsSnapshotDir)
+	if err := os.MkdirAll(hostSnapDir, 0o700); err != nil {
+		resumeErr := snapshotter.ResumeVM(sockPath)
+		return fmt.Errorf("failed to create in-guest snapshot directory %s: %w (resume error: %v)",
+			hostSnapDir, err, resumeErr)
+	}
+
+	if err := snapshotter.SnapshotVM(sockPath, hypervisors.InNsSnapshotDir); err != nil {
+		resumeErr := snapshotter.ResumeVM(sockPath)
+		return fmt.Errorf("failed to snapshot VM: %w (resume error: %v)", err, resumeErr)
+	}
+
+	snapshotFiles, err := moveDirContents(hostSnapDir, imagePath)
+	if err != nil {
+		return fmt.Errorf("failed to collect snapshot files: %w", err)
+	}
+
+	netParams, err := u.loadNetInfo()
+	if err != nil {
+		uniklog.Warnf("could not load network info for checkpoint: %v", err)
+	}
+
+	metadata := CheckpointMetadata{
+		Version:       1,
+		VmmType:       u.State.Annotations[annotHypervisor],
+		UnikernelType: u.State.Annotations[annotType],
+		Net:           netParams,
+		SnapshotFiles: snapshotFiles,
+	}
+	if err := writeCheckpointMetadata(imagePath, metadata); err != nil {
+		return err
+	}
+
+	if leaveRunning {
+		if err := snapshotter.ResumeVM(sockPath); err != nil {
+			return fmt.Errorf("failed to resume VM after checkpoint: %w", err)
+		}
+		return nil
+	}
+
+	// Match runc semantics: after a successful checkpoint the container
+	// stops, so the shim observes a task exit.
+	return u.Kill()
+}
+
+// FinishRestore completes a restore after the fresh VMM process is up: it
+// waits for the VMM API socket and asks the VMM to load (Firecracker) or
+// resume (Cloud Hypervisor) the staged snapshot, re-wiring the frozen guest
+// network device to the freshly-created tap device.
+func (u *Unikontainer) FinishRestore() error {
+	_, snapshotter, err := u.vmmSnapshotter()
+	if err != nil {
+		return err
+	}
+
+	netParams, err := u.loadNetInfo()
+	if err != nil {
+		uniklog.Warnf("could not load network info for restore: %v", err)
+	}
+
+	sockPath := u.apiSockHostPath()
+	if err := hypervisors.WaitForVMMAPI(sockPath, vmmAPIWaitTimeout); err != nil {
+		return err
+	}
+
+	netOverride := hypervisors.NetOverride{
+		IfaceID: "net1",
+		TapDev:  netParams.TapDev,
+	}
+	if err := snapshotter.FinishRestore(sockPath, hypervisors.InNsSnapshotDir, netOverride); err != nil {
+		return fmt.Errorf("failed to finish VM restore: %w", err)
+	}
+	return nil
+}
+
+// RestorePath returns the checkpoint image directory this container should be
+// restored from, or an empty string for a regular cold boot.
+func (u *Unikontainer) RestorePath() string {
+	return u.State.Annotations[annotRestorePath]
+}
+
+// SetRestorePath marks this container to be restored from the checkpoint
+// image directory at imagePath. It must be called before InitialSetup so the
+// reexec process observes the annotation in state.json.
+func (u *Unikontainer) SetRestorePath(imagePath string) {
+	u.State.Annotations[annotRestorePath] = imagePath
+}
+
+// stageRestore copies the checkpoint image directory into the monitor rootfs
+// (so the VMM can reach the snapshot files after pivoting) and performs
+// backend-specific fixups on the staged copy. It runs in the reexec process
+// before changeRoot, while host paths are still resolvable. It returns the
+// staged directory as seen from inside the monitor's mount namespace.
+func (u *Unikontainer) stageRestore(snapshotter hypervisors.Snapshotter, monRootfs string, netArgs types.NetDevParams) (string, error) {
+	restorePath := u.RestorePath()
+
+	metadata, err := readCheckpointMetadata(restorePath)
+	if err != nil {
+		return "", err
+	}
+	vmmType := u.State.Annotations[annotHypervisor]
+	if metadata.VmmType != vmmType {
+		return "", fmt.Errorf("checkpoint was taken with VMM %q but container uses %q",
+			metadata.VmmType, vmmType)
+	}
+	if metadata.Net.TapDev != "" && netArgs.IP != "" && metadata.Net.IP != netArgs.IP {
+		// The guest network stack is frozen in the snapshot: restoring
+		// under a different IP means the guest will keep using the old
+		// one. Warn instead of failing, as some setups (e.g. flat L2
+		// with proxy-ARP) may still be reachable.
+		uniklog.Warnf("restoring snapshot with guest IP %s in a namespace with IP %s: "+
+			"the guest will keep its original address", metadata.Net.IP, netArgs.IP)
+	}
+
+	stagedHostDir := filepath.Join(monRootfs, hypervisors.InNsSnapshotDir)
+	if err := os.MkdirAll(stagedHostDir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create staging directory %s: %w", stagedHostDir, err)
+	}
+	if _, err := copyDirContents(restorePath, stagedHostDir); err != nil {
+		return "", fmt.Errorf("failed to stage snapshot files: %w", err)
+	}
+
+	netOverride := hypervisors.NetOverride{
+		IfaceID: "net1",
+		TapDev:  netArgs.TapDev,
+	}
+	if err := snapshotter.PrepareRestore(stagedHostDir, netOverride); err != nil {
+		return "", fmt.Errorf("failed to prepare staged snapshot: %w", err)
+	}
+
+	return hypervisors.InNsSnapshotDir, nil
+}
+
+// saveNetInfo persists the network parameters of the VM in the container
+// base directory. It is called by the reexec process right before executing
+// the VMM, so that later checkpoint/restore invocations know the tap device
+// the VM is attached to.
+func (u *Unikontainer) saveNetInfo(netArgs types.NetDevParams) error {
+	data, err := json.Marshal(netArgs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal network info: %w", err)
+	}
+	return os.WriteFile(filepath.Join(u.BaseDir, netInfoFilename), data, 0o644) //nolint: gosec
+}
+
+// loadNetInfo loads the network parameters persisted by saveNetInfo.
+func (u *Unikontainer) loadNetInfo() (types.NetDevParams, error) {
+	var netParams types.NetDevParams
+	data, err := os.ReadFile(filepath.Join(u.BaseDir, netInfoFilename))
+	if err != nil {
+		return netParams, err
+	}
+	err = json.Unmarshal(data, &netParams)
+	return netParams, err
+}
+
+func writeCheckpointMetadata(imagePath string, metadata CheckpointMetadata) error {
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal checkpoint metadata: %w", err)
+	}
+	metadataPath := filepath.Join(imagePath, checkpointMetadataFile)
+	if err := os.WriteFile(metadataPath, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write checkpoint metadata %s: %w", metadataPath, err)
+	}
+	return nil
+}
+
+func readCheckpointMetadata(imagePath string) (CheckpointMetadata, error) {
+	var metadata CheckpointMetadata
+	metadataPath := filepath.Join(imagePath, checkpointMetadataFile)
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return metadata, fmt.Errorf("failed to read checkpoint metadata %s: %w", metadataPath, err)
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return metadata, fmt.Errorf("failed to parse checkpoint metadata %s: %w", metadataPath, err)
+	}
+	return metadata, nil
+}
+
+// copyDirContents copies all regular files directly under srcDir into dstDir
+// and returns their names. Snapshot directories are flat (both Firecracker
+// and Cloud Hypervisor write plain files), so no recursion is needed.
+func copyDirContents(srcDir string, dstDir string) ([]string, error) {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		if err := copyFile(filepath.Join(srcDir, entry.Name()), filepath.Join(dstDir, entry.Name())); err != nil {
+			return nil, err
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+// moveDirContents copies all regular files from srcDir to dstDir and removes
+// the originals. A plain rename cannot be used because source and destination
+// live on different filesystems (the source is behind /proc/<pid>/root).
+func moveDirContents(srcDir string, dstDir string) ([]string, error) {
+	names, err := copyDirContents(srcDir, dstDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range names {
+		if err := os.Remove(filepath.Join(srcDir, name)); err != nil {
+			uniklog.Warnf("failed to remove staged snapshot file %s: %v", name, err)
+		}
+	}
+	return names, nil
+}

--- a/pkg/unikontainers/checkpoint_test.go
+++ b/pkg/unikontainers/checkpoint_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikontainers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestCheckpointMetadataRoundtrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	metadata := CheckpointMetadata{
+		Version:       1,
+		VmmType:       "firecracker",
+		UnikernelType: "linux",
+		Net: types.NetDevParams{
+			IP:      "10.4.0.5",
+			Mask:    "255.255.255.0",
+			Gateway: "10.4.0.1",
+			MAC:     "aa:bb:cc:dd:ee:ff",
+			TapDev:  "tap0_urunc",
+			MTU:     1500,
+		},
+		SnapshotFiles: []string{"vmstate", "memory"},
+	}
+
+	require.NoError(t, writeCheckpointMetadata(dir, metadata))
+	got, err := readCheckpointMetadata(dir)
+	require.NoError(t, err)
+	assert.Equal(t, metadata, got)
+}
+
+func TestReadCheckpointMetadataMissing(t *testing.T) {
+	t.Parallel()
+	_, err := readCheckpointMetadata(t.TempDir())
+	assert.Error(t, err)
+}
+
+func TestCopyAndMoveDirContents(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dst := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "vmstate"), []byte("state"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "memory"), []byte("mem"), 0o600))
+	// Non-regular entries (directories) are skipped.
+	require.NoError(t, os.Mkdir(filepath.Join(src, "subdir"), 0o700))
+
+	names, err := copyDirContents(src, dst)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"vmstate", "memory"}, names)
+	data, err := os.ReadFile(filepath.Join(dst, "vmstate"))
+	require.NoError(t, err)
+	assert.Equal(t, "state", string(data))
+	// Source files remain after a copy.
+	_, err = os.Stat(filepath.Join(src, "vmstate"))
+	assert.NoError(t, err)
+
+	dst2 := t.TempDir()
+	names, err = moveDirContents(src, dst2)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"vmstate", "memory"}, names)
+	// Source files are removed after a move.
+	_, err = os.Stat(filepath.Join(src, "vmstate"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestNetInfoRoundtrip(t *testing.T) {
+	t.Parallel()
+	u := &Unikontainer{BaseDir: t.TempDir()}
+	netArgs := types.NetDevParams{
+		IP:     "10.4.0.5",
+		MAC:    "aa:bb:cc:dd:ee:ff",
+		TapDev: "tap2_urunc",
+		MTU:    1500,
+	}
+	require.NoError(t, u.saveNetInfo(netArgs))
+	got, err := u.loadNetInfo()
+	require.NoError(t, err)
+	assert.Equal(t, netArgs, got)
+}

--- a/pkg/unikontainers/hypervisors/api_client.go
+++ b/pkg/unikontainers/hypervisors/api_client.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// vmmAPIClient is a minimal HTTP-over-unix-socket client used to drive the
+// control API of a running VMM (Firecracker or Cloud Hypervisor). Both VMMs
+// speak plain HTTP/1.1 over a unix socket, so a single client covers both.
+type vmmAPIClient struct {
+	sockPath string
+	httpc    *http.Client
+}
+
+func newVMMAPIClient(sockPath string) *vmmAPIClient {
+	return &vmmAPIClient{
+		sockPath: sockPath,
+		httpc: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", sockPath)
+				},
+			},
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// request performs an HTTP request against the VMM API socket. A nil body
+// sends an empty request. Any non-2xx response is returned as an error
+// containing the response body.
+func (c *vmmAPIClient) request(method string, path string, body any) error {
+	var rdr io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal VMM API request body: %w", err)
+		}
+		rdr = bytes.NewReader(data)
+	}
+
+	// The host part of the URL is ignored; the transport always dials the
+	// unix socket. "localhost" keeps net/http happy.
+	req, err := http.NewRequest(method, "http://localhost"+path, rdr)
+	if err != nil {
+		return fmt.Errorf("failed to create VMM API request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return fmt.Errorf("VMM API request %s %s failed: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("VMM API request %s %s returned %d: %s",
+			method, path, resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+// waitForSocket waits until the VMM API socket accepts connections or the
+// timeout expires. It is used right after spawning a VMM process to make
+// sure the control API is up before issuing requests.
+func (c *vmmAPIClient) waitForSocket(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("unix", c.sockPath, time.Second)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for VMM API socket %s: %w", c.sockPath, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -15,7 +15,10 @@
 package hypervisors
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
@@ -68,7 +71,9 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	chMem := BytesToStringMB(args.MemSizeB)
 
 	// Start building the command
-	exArgs := []string{ch.binaryPath}
+	// The API socket stays enabled so a running microVM can later be
+	// paused/resumed and snapshotted (checkpoint/restore).
+	exArgs := []string{ch.binaryPath, "--api-socket", InNsAPISockPath}
 
 	// Memory configuration
 	if args.Sharedfs.Type == "virtiofs" {
@@ -158,4 +163,103 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 // PreExec performs pre-execution setup. Cloud Hypervisor has no special pre-exec requirements.
 func (ch *CloudHypervisor) PreExec(_ types.ExecArgs) error {
 	return nil
+}
+
+// CHSnapshotConfigFile is the name of the VM configuration file inside a
+// Cloud Hypervisor snapshot directory. Cloud Hypervisor additionally writes
+// state.json and one or more memory-ranges files in the same directory.
+const CHSnapshotConfigFile string = "config.json"
+
+// SupportsSnapshot returns true as Cloud Hypervisor supports snapshot/restore
+// through its HTTP API.
+func (ch *CloudHypervisor) SupportsSnapshot() bool {
+	return true
+}
+
+// PauseVM pauses the vCPUs of a running Cloud Hypervisor microVM.
+func (ch *CloudHypervisor) PauseVM(sockPath string) error {
+	client := newVMMAPIClient(sockPath)
+	return client.request("PUT", "/api/v1/vm.pause", nil)
+}
+
+// ResumeVM resumes the vCPUs of a paused Cloud Hypervisor microVM.
+func (ch *CloudHypervisor) ResumeVM(sockPath string) error {
+	client := newVMMAPIClient(sockPath)
+	return client.request("PUT", "/api/v1/vm.resume", nil)
+}
+
+// SnapshotVM writes a full snapshot (config.json, state.json and memory
+// ranges) of a paused microVM into inNsDir, which Cloud Hypervisor resolves
+// inside its own mount namespace.
+func (ch *CloudHypervisor) SnapshotVM(sockPath string, inNsDir string) error {
+	client := newVMMAPIClient(sockPath)
+	body := map[string]string{
+		"destination_url": "file://" + inNsDir,
+	}
+	return client.request("PUT", "/api/v1/vm.snapshot", body)
+}
+
+// BuildRestoreCmd builds the argv to launch a fresh Cloud Hypervisor process
+// that restores the VM from the snapshot staged in inNsDir at process start.
+// The restored VM stays paused until FinishRestore resumes it.
+func (ch *CloudHypervisor) BuildRestoreCmd(args types.ExecArgs, inNsDir string) ([]string, error) {
+	exArgs := []string{
+		ch.binaryPath,
+		"--api-socket", InNsAPISockPath,
+		"--restore", "source_url=file://" + inNsDir,
+	}
+	if args.Seccomp {
+		exArgs = append(exArgs, "--seccomp", "true")
+	} else {
+		exArgs = append(exArgs, "--seccomp", "false")
+	}
+	return exArgs, nil
+}
+
+// PrepareRestore rewrites the tap device name in the staged snapshot's
+// config.json so the restored VM attaches to the freshly-created host tap
+// device. The guest-visible side of the device (MAC, IP) is frozen in the
+// snapshot and must not change.
+func (ch *CloudHypervisor) PrepareRestore(hostDir string, net NetOverride) error {
+	if net.TapDev == "" {
+		return nil
+	}
+
+	configPath := filepath.Join(hostDir, CHSnapshotConfigFile)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read snapshot VM config %s: %w", configPath, err)
+	}
+
+	// Parse the VM config generically so we do not have to track the full
+	// Cloud Hypervisor VmConfig schema; only the tap name is rewritten.
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("failed to parse snapshot VM config %s: %w", configPath, err)
+	}
+
+	netDevs, ok := config["net"].([]any)
+	if !ok || len(netDevs) == 0 {
+		// The snapshotted VM had no network device; nothing to rewrite.
+		return nil
+	}
+	for _, dev := range netDevs {
+		netDev, ok := dev.(map[string]any)
+		if !ok {
+			continue
+		}
+		netDev["tap"] = net.TapDev
+	}
+
+	patched, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal snapshot VM config: %w", err)
+	}
+	return os.WriteFile(configPath, patched, 0o644) //nolint: gosec
+}
+
+// FinishRestore resumes the restored microVM. The state load itself already
+// happened at process start through the --restore flag.
+func (ch *CloudHypervisor) FinishRestore(sockPath string, _ string, _ NetOverride) error {
+	return ch.ResumeVM(sockPath)
 }

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -108,7 +108,9 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
-	cmdString := fc.Path() + " --no-api --config-file "
+	// The API socket stays enabled so a running microVM can later be
+	// paused/resumed and snapshotted (checkpoint/restore).
+	cmdString := fc.Path() + " --api-sock " + InNsAPISockPath + " --config-file "
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	cmdString += JSONConfigFile
 	if !args.Seccomp {
@@ -207,4 +209,82 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 // PreExec performs pre-execution setup. Firecracker has no special pre-exec requirements.
 func (fc *Firecracker) PreExec(_ types.ExecArgs) error {
 	return nil
+}
+
+// Names of the files a Firecracker snapshot consists of.
+const (
+	FCSnapshotStateFile string = "vmstate"
+	FCSnapshotMemFile   string = "memory"
+)
+
+// SupportsSnapshot returns true as Firecracker supports snapshot/restore
+// through its HTTP API.
+func (fc *Firecracker) SupportsSnapshot() bool {
+	return true
+}
+
+// PauseVM pauses the vCPUs of a running Firecracker microVM.
+func (fc *Firecracker) PauseVM(sockPath string) error {
+	client := newVMMAPIClient(sockPath)
+	return client.request("PATCH", "/vm", map[string]string{"state": "Paused"})
+}
+
+// ResumeVM resumes the vCPUs of a paused Firecracker microVM.
+func (fc *Firecracker) ResumeVM(sockPath string) error {
+	client := newVMMAPIClient(sockPath)
+	return client.request("PATCH", "/vm", map[string]string{"state": "Resumed"})
+}
+
+// SnapshotVM writes a full snapshot (vmstate + guest memory) of a paused
+// microVM into inNsDir, which Firecracker resolves inside its own mount
+// namespace.
+func (fc *Firecracker) SnapshotVM(sockPath string, inNsDir string) error {
+	client := newVMMAPIClient(sockPath)
+	body := map[string]string{
+		"snapshot_type": "Full",
+		"snapshot_path": filepath.Join(inNsDir, FCSnapshotStateFile),
+		"mem_file_path": filepath.Join(inNsDir, FCSnapshotMemFile),
+	}
+	return client.request("PUT", "/snapshot/create", body)
+}
+
+// BuildRestoreCmd builds the argv to launch a fresh Firecracker process that
+// will later load the snapshot through the API (see FinishRestore). No boot
+// resources may be pre-configured, so no config file is passed.
+func (fc *Firecracker) BuildRestoreCmd(args types.ExecArgs, _ string) ([]string, error) {
+	exArgs := []string{fc.Path(), "--api-sock", InNsAPISockPath}
+	if !args.Seccomp {
+		exArgs = append(exArgs, "--no-seccomp")
+	}
+	return exArgs, nil
+}
+
+// PrepareRestore is a no-op for Firecracker: the new tap device name is
+// passed at load time through network_overrides (see FinishRestore).
+func (fc *Firecracker) PrepareRestore(_ string, _ NetOverride) error {
+	return nil
+}
+
+// FinishRestore loads the staged snapshot into a freshly-launched Firecracker
+// process and resumes the microVM. The frozen guest network device is
+// re-attached to the new host tap device via network_overrides.
+func (fc *Firecracker) FinishRestore(sockPath string, inNsDir string, net NetOverride) error {
+	client := newVMMAPIClient(sockPath)
+	body := map[string]any{
+		"snapshot_path": filepath.Join(inNsDir, FCSnapshotStateFile),
+		"mem_backend": map[string]string{
+			"backend_type": "File",
+			"backend_path": filepath.Join(inNsDir, FCSnapshotMemFile),
+		},
+		"resume_vm": true,
+	}
+	if net.TapDev != "" {
+		body["network_overrides"] = []map[string]string{
+			{
+				"iface_id":      net.IfaceID,
+				"host_dev_name": net.TapDev,
+			},
+		}
+	}
+	return client.request("PUT", "/snapshot/load", body)
 }

--- a/pkg/unikontainers/hypervisors/snapshot.go
+++ b/pkg/unikontainers/hypervisors/snapshot.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"errors"
+	"time"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+const (
+	// InNsAPISockPath is the path of the VMM control API socket, as seen
+	// from inside the monitor's mount namespace. The monitor rootfs always
+	// contains a /tmp directory, so the socket is placed there. From the
+	// host, the socket is reachable via /proc/<pid>/root + InNsAPISockPath.
+	InNsAPISockPath = "/tmp/urunc-vmm-api.sock"
+
+	// InNsSnapshotDir is the directory, inside the monitor's mount
+	// namespace, where snapshot files are written on checkpoint and staged
+	// on restore.
+	InNsSnapshotDir = "/urunc-snapshot"
+)
+
+// ErrSnapshotNotSupported is returned when checkpoint/restore is requested
+// for a VMM that has no snapshot capability (e.g. solo5-spt, solo5-hvt,
+// hedge) or one for which urunc has not implemented it yet (e.g. QEMU).
+var ErrSnapshotNotSupported = errors.New("the VMM does not support snapshot/restore")
+
+// NetOverride describes how the network device of a snapshotted VM must be
+// re-wired at restore time. The guest-visible device (MAC, IP, queues) is
+// frozen in the snapshot; only the host-side backend (the tap device name)
+// can change between checkpoint and restore.
+type NetOverride struct {
+	// IfaceID is the VMM-internal network interface identifier
+	// (e.g. "net1" for Firecracker).
+	IfaceID string
+	// TapDev is the name of the freshly-created host tap device the
+	// restored VM must attach to.
+	TapDev string
+}
+
+// WaitForVMMAPI waits until the VMM API socket at sockPath (a host-resolvable
+// path) accepts connections, or fails after timeout. Callers use it after
+// spawning a fresh VMM process, before driving its API.
+func WaitForVMMAPI(sockPath string, timeout time.Duration) error {
+	return newVMMAPIClient(sockPath).waitForSocket(timeout)
+}
+
+// Snapshotter is the optional capability interface a VMM backend implements
+// to support checkpoint/restore. Checkpoint maps to "pause the VM and write
+// its full state (device model + guest memory) to a directory"; restore maps
+// to "launch a fresh VMM process and resume the VM from that directory".
+//
+// Path arguments are always expressed as seen from inside the monitor's
+// mount namespace (the VMM resolves them), while sockPath arguments are
+// host-resolvable paths to the API socket (typically via /proc/<pid>/root).
+type Snapshotter interface {
+	// SupportsSnapshot reports whether this backend can checkpoint/restore.
+	SupportsSnapshot() bool
+	// PauseVM pauses the vCPUs of a running VM.
+	PauseVM(sockPath string) error
+	// ResumeVM resumes the vCPUs of a paused VM.
+	ResumeVM(sockPath string) error
+	// SnapshotVM writes a full snapshot of a paused VM into inNsDir.
+	SnapshotVM(sockPath string, inNsDir string) error
+	// BuildRestoreCmd builds the argv to launch a fresh VMM process that
+	// will restore the VM from the snapshot staged in inNsDir. Depending
+	// on the backend, the actual state load happens either at process
+	// start (Cloud Hypervisor --restore) or via a later FinishRestore
+	// API call (Firecracker PUT /snapshot/load).
+	BuildRestoreCmd(args types.ExecArgs, inNsDir string) ([]string, error)
+	// PrepareRestore performs backend-specific fixups on the staged
+	// snapshot directory (hostDir is the host-resolvable path of the
+	// staged copy) before the VMM process is launched. For example,
+	// Cloud Hypervisor needs the tap device name in the snapshot's
+	// config.json rewritten to the freshly-created tap.
+	PrepareRestore(hostDir string, net NetOverride) error
+	// FinishRestore completes the restore against the VMM API after the
+	// fresh VMM process is up: for Firecracker it loads the snapshot and
+	// resumes; for Cloud Hypervisor it resumes the already-restored VM.
+	FinishRestore(sockPath string, inNsDir string, net NetOverride) error
+}

--- a/pkg/unikontainers/hypervisors/snapshot_test.go
+++ b/pkg/unikontainers/hypervisors/snapshot_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+// capturedRequest records one HTTP request received by the fake VMM API.
+type capturedRequest struct {
+	Method string
+	Path   string
+	Body   string
+}
+
+// fakeVMMAPI is a minimal HTTP server listening on a unix socket, standing in
+// for the Firecracker / Cloud Hypervisor control API.
+type fakeVMMAPI struct {
+	sockPath string
+	mu       sync.Mutex
+	requests []capturedRequest
+	status   int
+}
+
+func startFakeVMMAPI(t *testing.T, status int) *fakeVMMAPI {
+	t.Helper()
+	f := &fakeVMMAPI{
+		sockPath: filepath.Join(t.TempDir(), "api.sock"),
+		status:   status,
+	}
+	ln, err := net.Listen("unix", f.sockPath)
+	require.NoError(t, err)
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			f.mu.Lock()
+			f.requests = append(f.requests, capturedRequest{
+				Method: r.Method,
+				Path:   r.URL.Path,
+				Body:   string(body),
+			})
+			f.mu.Unlock()
+			w.WriteHeader(f.status)
+			if f.status >= 400 {
+				_, _ = w.Write([]byte("fake VMM error"))
+			}
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return f
+}
+
+func (f *fakeVMMAPI) captured() []capturedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]capturedRequest(nil), f.requests...)
+}
+
+func TestFirecrackerBuildExecCmdEnablesAPISocket(t *testing.T) {
+	fc := &Firecracker{binary: FirecrackerBinary, binaryPath: "/usr/bin/firecracker"}
+	args := types.ExecArgs{
+		UnikernelPath: testKernelPath,
+		Command:       testCommand,
+		Seccomp:       true,
+	}
+	cmd, err := fc.BuildExecCmd(args, &fakeUnikernel{})
+	require.NoError(t, err)
+	joined := strings.Join(cmd, " ")
+	assert.Contains(t, joined, "--api-sock "+InNsAPISockPath)
+	assert.NotContains(t, joined, "--no-api")
+}
+
+func TestFirecrackerBuildRestoreCmd(t *testing.T) {
+	fc := &Firecracker{binary: FirecrackerBinary, binaryPath: "/usr/bin/firecracker"}
+
+	cmd, err := fc.BuildRestoreCmd(types.ExecArgs{Seccomp: true}, InNsSnapshotDir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/usr/bin/firecracker", "--api-sock", InNsAPISockPath}, cmd)
+
+	cmd, err = fc.BuildRestoreCmd(types.ExecArgs{Seccomp: false}, InNsSnapshotDir)
+	require.NoError(t, err)
+	assert.Contains(t, cmd, "--no-seccomp")
+	// A restore launch must not pre-configure boot resources.
+	assert.NotContains(t, strings.Join(cmd, " "), "--config-file")
+}
+
+func TestFirecrackerSnapshotAPIRequests(t *testing.T) {
+	fc := &Firecracker{binary: FirecrackerBinary, binaryPath: "/usr/bin/firecracker"}
+	api := startFakeVMMAPI(t, http.StatusNoContent)
+
+	require.NoError(t, fc.PauseVM(api.sockPath))
+	require.NoError(t, fc.SnapshotVM(api.sockPath, InNsSnapshotDir))
+	require.NoError(t, fc.ResumeVM(api.sockPath))
+	require.NoError(t, fc.FinishRestore(api.sockPath, InNsSnapshotDir, NetOverride{
+		IfaceID: "net1",
+		TapDev:  "tap0_urunc",
+	}))
+
+	reqs := api.captured()
+	require.Len(t, reqs, 4)
+
+	assert.Equal(t, "PATCH", reqs[0].Method)
+	assert.Equal(t, "/vm", reqs[0].Path)
+	assert.JSONEq(t, `{"state":"Paused"}`, reqs[0].Body)
+
+	assert.Equal(t, "PUT", reqs[1].Method)
+	assert.Equal(t, "/snapshot/create", reqs[1].Path)
+	assert.JSONEq(t, `{
+		"snapshot_type": "Full",
+		"snapshot_path": "/urunc-snapshot/vmstate",
+		"mem_file_path": "/urunc-snapshot/memory"
+	}`, reqs[1].Body)
+
+	assert.Equal(t, "PATCH", reqs[2].Method)
+	assert.JSONEq(t, `{"state":"Resumed"}`, reqs[2].Body)
+
+	assert.Equal(t, "PUT", reqs[3].Method)
+	assert.Equal(t, "/snapshot/load", reqs[3].Path)
+	assert.JSONEq(t, `{
+		"snapshot_path": "/urunc-snapshot/vmstate",
+		"mem_backend": {"backend_type": "File", "backend_path": "/urunc-snapshot/memory"},
+		"resume_vm": true,
+		"network_overrides": [{"iface_id": "net1", "host_dev_name": "tap0_urunc"}]
+	}`, reqs[3].Body)
+}
+
+func TestCloudHypervisorBuildExecCmdEnablesAPISocket(t *testing.T) {
+	ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: "/usr/bin/cloud-hypervisor"}
+	args := types.ExecArgs{
+		UnikernelPath: testKernelPath,
+		Command:       testCommand,
+		Seccomp:       true,
+	}
+	cmd, err := ch.BuildExecCmd(args, &fakeUnikernel{})
+	require.NoError(t, err)
+	joined := strings.Join(cmd, " ")
+	assert.Contains(t, joined, "--api-socket "+InNsAPISockPath)
+}
+
+func TestCloudHypervisorBuildRestoreCmd(t *testing.T) {
+	ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: "/usr/bin/cloud-hypervisor"}
+	cmd, err := ch.BuildRestoreCmd(types.ExecArgs{Seccomp: true}, InNsSnapshotDir)
+	require.NoError(t, err)
+	joined := strings.Join(cmd, " ")
+	assert.Contains(t, joined, "--api-socket "+InNsAPISockPath)
+	assert.Contains(t, joined, "--restore source_url=file://"+InNsSnapshotDir)
+	assert.Contains(t, joined, "--seccomp true")
+}
+
+func TestCloudHypervisorSnapshotAPIRequests(t *testing.T) {
+	ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: "/usr/bin/cloud-hypervisor"}
+	api := startFakeVMMAPI(t, http.StatusNoContent)
+
+	require.NoError(t, ch.PauseVM(api.sockPath))
+	require.NoError(t, ch.SnapshotVM(api.sockPath, InNsSnapshotDir))
+	require.NoError(t, ch.FinishRestore(api.sockPath, InNsSnapshotDir, NetOverride{}))
+
+	reqs := api.captured()
+	require.Len(t, reqs, 3)
+	assert.Equal(t, "/api/v1/vm.pause", reqs[0].Path)
+	assert.Equal(t, "/api/v1/vm.snapshot", reqs[1].Path)
+	assert.JSONEq(t, `{"destination_url":"file:///urunc-snapshot"}`, reqs[1].Body)
+	assert.Equal(t, "/api/v1/vm.resume", reqs[2].Path)
+}
+
+func TestCloudHypervisorPrepareRestoreRewritesTap(t *testing.T) {
+	ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: "/usr/bin/cloud-hypervisor"}
+	dir := t.TempDir()
+	config := map[string]any{
+		"cpus": map[string]any{"boot_vcpus": 1},
+		"net": []any{
+			map[string]any{
+				"tap": "tap3_urunc",
+				"mac": "aa:bb:cc:dd:ee:ff",
+			},
+		},
+	}
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CHSnapshotConfigFile), data, 0o644))
+
+	err = ch.PrepareRestore(dir, NetOverride{IfaceID: "net1", TapDev: "tap0_urunc"})
+	require.NoError(t, err)
+
+	patched, err := os.ReadFile(filepath.Join(dir, CHSnapshotConfigFile))
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(patched, &got))
+	netDev := got["net"].([]any)[0].(map[string]any)
+	assert.Equal(t, "tap0_urunc", netDev["tap"])
+	// The guest-visible MAC is frozen in the snapshot and must not change.
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", netDev["mac"])
+}
+
+func TestCloudHypervisorPrepareRestoreNoNet(t *testing.T) {
+	ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: "/usr/bin/cloud-hypervisor"}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CHSnapshotConfigFile), []byte(`{"cpus":{}}`), 0o644))
+
+	// A snapshot without network devices needs no rewrite and must not fail.
+	assert.NoError(t, ch.PrepareRestore(dir, NetOverride{TapDev: "tap0_urunc"}))
+	// An empty override means nothing to rewrite, even without a config file.
+	assert.NoError(t, ch.PrepareRestore(t.TempDir(), NetOverride{}))
+}
+
+func TestVMMAPIClientErrorStatus(t *testing.T) {
+	fc := &Firecracker{binary: FirecrackerBinary, binaryPath: "/usr/bin/firecracker"}
+	api := startFakeVMMAPI(t, http.StatusBadRequest)
+
+	err := fc.PauseVM(api.sockPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "fake VMM error")
+}
+
+func TestWaitForVMMAPI(t *testing.T) {
+	api := startFakeVMMAPI(t, http.StatusNoContent)
+	assert.NoError(t, WaitForVMMAPI(api.sockPath, time.Second))
+
+	missing := filepath.Join(t.TempDir(), "missing.sock")
+	err := WaitForVMMAPI(missing, 100*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -410,6 +410,13 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	metrics.Capture(m.TS16)
 	withTUNTAP := netArgs.IP != ""
 
+	// Persist the network parameters (most importantly the tap device
+	// name) so that later checkpoint/restore invocations, which run in a
+	// different process, know how the VM is wired.
+	if err := u.saveNetInfo(netArgs); err != nil {
+		uniklog.Warnf("failed to persist network info: %v", err)
+	}
+
 	// UnikernelParams
 	unikernelParams.Net = netArgs
 
@@ -598,6 +605,28 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// ExecArgs
 	vmmArgs.Command = unikernelCmd
 
+	// Restore path: if this container is being restored from a checkpoint,
+	// stage the snapshot files into the monitor rootfs while host paths
+	// are still resolvable (we have not pivoted yet) and remember the
+	// snapshotter to build the restore command later.
+	isRestore := u.RestorePath() != ""
+	var restoreSnapshotter hypervisors.Snapshotter
+	var restoreInNsDir string
+	if isRestore {
+		if vmmArgs.VAccelType != "" {
+			return fmt.Errorf("restore is not supported for containers with vAccel enabled")
+		}
+		_, restoreSnapshotter, err = u.vmmSnapshotter()
+		if err != nil {
+			return err
+		}
+		restoreInNsDir, err = u.stageRestore(restoreSnapshotter, rootfsParams.MonRootfs, netArgs)
+		if err != nil {
+			uniklog.WithError(err).Error("failed to stage checkpoint for restore")
+			return err
+		}
+	}
+
 	// pivot
 	_, err = findNS(u.Spec.Linux.Namespaces, specs.MountNamespace)
 	// We just want to check if a mount namespace was define din the list
@@ -637,7 +666,14 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// Build the VMM command once and verify it can be constructed successfully.
 	// This ensures we don't report the container as started if command building fails.
-	execCmd, err := vmm.BuildExecCmd(vmmArgs, unikernel)
+	// On restore, the VMM is launched to resume from the staged snapshot
+	// instead of cold-booting the unikernel.
+	var execCmd []string
+	if isRestore {
+		execCmd, err = restoreSnapshotter.BuildRestoreCmd(vmmArgs, restoreInNsDir)
+	} else {
+		execCmd, err = vmm.BuildExecCmd(vmmArgs, unikernel)
+	}
 	if err != nil {
 		uniklog.WithError(err).Error("failed to build VMM command")
 		return err


### PR DESCRIPTION
## What

Adds checkpoint/restore support to urunc, implemented as **VMM-level snapshots** (no CRIU): the VMM pauses the guest and serializes device state + guest memory to a directory; a fresh VMM process later resumes the guest from it.

- **New CLI commands**: `checkpoint`, `restore`, `pause`, `resume` — flag-compatible with runc, so containerd's inherited runc task service drives them directly (`ctr task pause/checkpoint`, restore-on-create), and external orchestrators that drive OCI runtimes CLI-first (e.g. Agent Substrate's `ateom` model, which shells out to `runsc checkpoint/restore`) get the same surface from urunc.
- **VMM backends**: Firecracker (`PUT /snapshot/create` / `PUT /snapshot/load` + `network_overrides`) and Cloud Hypervisor (`vm.snapshot` / `--restore` + `vm.resume`, tap name rewritten in the snapshot's `config.json`). Both VMMs now always run with their API socket enabled at `/tmp/urunc-vmm-api.sock` inside the monitor mount namespace, reachable from the host via `/proc/<pid>/root`. QEMU (QMP migrate) is a planned follow-up; solo5/hedge have no snapshot mechanism.
- **Restore path**: `urunc restore` creates the container with a restore annotation; the reexec process stages the snapshot into the monitor rootfs pre-pivot, creates fresh networking, and launches the VMM in restore mode; the parent completes the restore over the VMM API and re-wires the frozen guest NIC to the new tap.
- **Shim**: guest rootfs choice moves before the inner Create when restoring (restore creates+starts in one shot).
- **Docs**: `docs/checkpoint-restore.md` (mechanism, usage, networking semantics, limitations).

## Design notes

- The guest network identity (MAC/IP/ARP) is frozen in the snapshot; restore recreates the tap and requires an equivalent L3 environment (warns on IP mismatch).
- Checkpoint metadata (`urunc-checkpoint.json`) pins the VMM type and net params for validation at restore.
- Default checkpoint semantics match runc: VM stops after a successful dump unless `--leave-running`.
- vAccel-enabled containers are rejected on restore (vsock paths not re-wired yet).

## Testing

- `go build`, `go vet`, `golangci-lint` and all unit tests pass on linux/amd64 (containerized), including new tests: a fake VMM API server over a unix socket asserting the exact snapshot request sequences/bodies for both backends, CH `config.json` tap rewriting, restore argv construction, metadata round-trip.
- e2e (real VMM checkpoint→restore round-trip) still needs a KVM host; planned as a follow-up on the lab testbed before undrafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)