### PR TITLE
chore: fix typos repo-wide and close the CI spell check gap

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -1,13 +1,15 @@
 {
   "version": "0.2",
-  "dictionaryDefinitions": [ 
-   { 
-    "name": "project-dict", 
-    "path": "urunc-dict.txt" 
-   }
+  "dictionaryDefinitions": [
+    {
+      "name": "project-dict",
+      "path": "urunc-dict.txt"
+    }
   ],
-  "dictionaries": ["project-dict"],
-  "words": [ ], 
+  "dictionaries": [
+    "project-dict"
+  ],
+  "words": [],
   "ignorePaths": [
     "node_modules",
     "vendor",
@@ -40,7 +42,7 @@
   ],
   "ignoreRegExpList": [
     "http[s]?://\\S+",
-    "`[^`]+`",
+    "`[^`\\n]+`",
     "\\$[^\\s]+",
     "/^Signed-off-by:.*$/gm",
     "/^Reviewed-by:.*$/gm",
@@ -48,7 +50,6 @@
     "/^Co-authored-by:.*$/gm",
     "/^Tested-by:.*$/gm",
     "/^Acked-by:.*$/gm",
-    "`[^`]+`",
     "```[\\s\\S]*?```"
   ]
 }

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -8,7 +8,6 @@ Containerd
 Containerfile
 Crictl
 DIRSYNC
-Dcos
 Debugf
 Devmapper
 Dockerfiles
@@ -32,7 +31,6 @@ LAZYTIME
 LIBCONTAINER
 LOGLEVEL
 LOGPIPE
-Liste
 MANDLOCK
 Mainas
 Mewz
@@ -67,7 +65,6 @@ PROJECTNAME
 Poststart
 Poststop
 Prestart
-Prettyfier
 Privs
 Qdisc
 RDONLY
@@ -105,7 +102,6 @@ Vcpu
 Virt
 Warnf
 Zerolog
-abcshd
 ananos
 annot
 artefacts
@@ -121,7 +117,6 @@ buildkit's
 bunix
 bunix's
 bunnyfile
-burdain
 bytemsg
 chttp
 clis
@@ -146,7 +141,6 @@ dind
 dirsync
 distro
 distros
-djaidwnduwk
 dmsetup
 downscript
 dpkg
@@ -156,8 +150,6 @@ encoded
 endmacro
 epoll
 errdefs
-etest
-etesting
 etfs
 execve
 execve's
@@ -175,7 +167,6 @@ golangci
 goscall
 gosec
 govalidator
-grou
 groupid
 headerlink
 htmlmin
@@ -191,7 +182,6 @@ inlinehilite
 inspectp
 iobase
 iosize
-isues
 iversion
 jackpal
 javascripts
@@ -207,7 +197,6 @@ lazytime
 lenag
 lenpg
 leasesapi
-levarage
 libc
 libcontainer
 libseccomp
@@ -265,7 +254,6 @@ paravirtual
 pids
 pluginid
 posixacl
-practises
 prctl
 prebuild
 privs
@@ -282,9 +270,7 @@ rdev
 rdinit
 reexec
 relatime
-remobe
 resourcecontrol
-rhandling
 rootflags
 rootfs
 rootfstype
@@ -298,10 +284,8 @@ runp
 runtimeclasses
 runtimespec
 sandboxing
-scontroller
 seabios
 seccomp
-secomp
 setgroup
 settime
 sgid
@@ -311,12 +295,10 @@ sigaction
 sigreturn
 sigstr
 sirupsen
-socker
 stretchr
 strictatime
 subtest
 superfences
-sworker
 symfollow
 syscall
 syscalls
@@ -328,7 +310,6 @@ tmpfs
 tmpl
 tomlq
 traefik
-triger
 ttrpc
 twemoji
 typesapi
@@ -347,7 +328,6 @@ userns
 urfave
 urunc
 urunc's
-urunce
 uruncts
 urunit
 urunit's
@@ -355,7 +335,6 @@ veth
 virt
 virtio
 vishvananda
-vlaid
 vmcons
 vnet
 yourdockerhubid
@@ -402,7 +381,6 @@ vsock
 Gkeka
 Panagiotis
 Mavrikos
-zyfy
 Dionisia
 Koronellou
 sankalp
@@ -421,3 +399,24 @@ ESRCH
 Prafful
 praffq
 libcontainers
+daemonset
+devroom
+eksctl
+FOSDEM
+keypair
+MMIO
+Muen
+Opam
+paravirtualization
+sandboxed
+snapshotters
+WASI
+Prettyfier
+abcshd
+djaidwnduwk
+etest
+etesting
+scontroller
+sworker
+urunce
+zyfy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * Update instructions for installing Go and remove obsolete image references
 * Add tutorial for using `urunc` with kind
 * Centralize the version definition of the tools mentioned in docs
-* Add instructions fo using blockfile snapshotter with `urunc`
+* Add instructions for using blockfile snapshotter with `urunc`
 * Provide documentation for using the new [monitors-build repository](https://github.com/urunc-dev/monitors-build)
 
 ## New Contributors
@@ -180,7 +180,7 @@ Big thanks for all new contributors in `urunc`:
   - `SupportsFS()` takes as an argument a filesystem type and checks if the unikernel supports that type.
 - Partial unit tests for pkg/unikontainers
 - Refactor devmapper snapshot handling
-- Define new environment variable `USE_DEVMAPPER_AS_BLOCK`to use devmapper's snapshot as a block image for the unikernel
+- Define new environment variable `USE_DEVMAPPER_AS_BLOCK` to use devmapper's snapshot as a block image for the unikernel
 - Handle newer versions of Unikraft unikernels
 - Enable NAT and IP forwarding in static networking
 
@@ -196,7 +196,7 @@ Big thanks for all new contributors in `urunc`:
 
 #### Misc
 * Bug fixes
-* Refactor handling of normal containers and replaces constants in paths and annotations
+* Refactor handling of normal containers and replace constants in paths and annotations
 * Unikraft FC boot on arm64
 * Huge refactor and update of `urunc`'s documentation. The documentation is available at https://nubificus.github.io/urunc/
 

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ clean:
 lint:
 	$(CNTR_TOOL) $(LINT_CNTR_OPTS) $(LINT_CNTR_IMG) $(LINT_CNTR_CMD)
 
-# Dcos targets
+# Docs targets
 ## docs Build and serve urunc's docs locally
 .PHONY: docs
 docs:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ inside the unikernel through the respective VM process.
 
 ## Quick start
 
-The easiest and fastest way to try out `urunc` would be with `docker`
+The easiest and fastest way to try out `urunc` would be with `docker`.
 Before doing so, please make sure that the host system satisfies the
 following dependencies:
 
@@ -145,7 +145,7 @@ supported VM/Sandbox monitors and unikernels:
 | Unikraft  | QEMU, Firecracker                   | x86         | Initrd, 9pfs                            |
 | MirageOS  | QEMU, Solo5-hvt, Solo5-spt          | x86,aarch64 | Block/Devmapper                         |
 | Mewz      | QEMU                                | x86         | In-memory                               |
-| Linux     | QEMU, Firecracker, Cloud-HYpervisor | x86,aarch64 | Initrd, Block/Devmapper, 9pfs, Virtiofs |
+| Linux     | QEMU, Firecracker, Cloud-Hypervisor | x86,aarch64 | Initrd, Block/Devmapper, 9pfs, Virtiofs |
 | Hermit    | QEMU                                | x86         | Initrd                                  |
 
 We plan to add support for more unikernel frameworks and other platforms too.
@@ -210,7 +210,7 @@ document](https://urunc.io/developer-guide/contribute/).
 ## Security policy
 
 In case of a security vulnerability, please refer to the
-[Security Policy document](https://urunc.io/developer-guide/security/).
+[Security Policy document](https://urunc.io/developer-guide/security/)
 for guidelines on how to report it responsibly.
 
 ## Changelog
@@ -226,5 +226,5 @@ for more information on what changed in the latest and previous releases.
 
 We kindly invite everyone interested in `urunc` to join our
 [Slack channel](https://cloud-native.slack.com/archives/C08V201G35J).
-To directly communicate with the maintainers, feel free to drop an email At
+To directly communicate with the maintainers, feel free to drop an email at
 [`urunc`'s maintainers' mailing list](cncf-urunc-maintainers@lists.cncf.io )

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -83,8 +83,8 @@ var createCommand = &cli.Command{
 }
 
 // createUnikontainer creates a Unikernel struct from bundle data,
-// initializes it's base dir and state.json,
-// setups terminal if required and spawns reexec process,
+// initializes its base dir and state.json,
+// sets up terminal if required and spawns reexec process,
 // waits for reexec process to notify, executes CreateRuntime hooks,
 // sends ACK to reexec process
 func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (err error) {
@@ -99,7 +99,7 @@ func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (
 	// We have already made sure in main.go that root is not nil
 	rootDir := cmd.String("root")
 
-	// bundle option cli option is optional. Therefore the bundle directory
+	// bundle cli option is optional. Therefore the bundle directory
 	// is either the CWD or the one defined in the cli option
 	bundlePath := cmd.String("bundle")
 	if bundlePath == "" {
@@ -144,7 +144,7 @@ func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (
 	}()
 
 	// Create log pipe for nsenter
-	// NOTE: We might want to switch form pipe to socketpair for logs too.
+	// NOTE: We might want to switch from pipe to socketpair for logs too.
 	logPipeParent, logPipeChild, err := os.Pipe()
 	if err != nil {
 		err = fmt.Errorf("failed to create pipe for logs: %w", err)
@@ -167,7 +167,7 @@ func createUnikontainer(cmd *cli.Command, uruncCfg *unikontainers.UruncConfig) (
 	// Start reexec process
 	metrics.Capture(m.TS03)
 	// setup terminal if required and start reexec process
-	// TODO: This part of code needs better rhandling. It is not the
+	// TODO: This part of code needs better handling. It is not the
 	// job of the urunc create to setup the terminal for reexec.
 	// The main concern is the nsenter execution before the reexec.
 	// If anything goes wrong and we mess up with nsenter debugging
@@ -298,7 +298,7 @@ func createReexecCmd(initSock *os.File, logPipe *os.File) *exec.Cmd {
 	// first file we added in ExtraFiles, its file descriptor should be 2+1=3,
 	// since 0 is stdin, 1 is stdout and 2 is stderr. Similarly, the logPipeChild
 	// should be right after initSockChild, hence 4
-	// NOTE: THis might need bette rhandling in the future.
+	// NOTE: This might need better handling in the future.
 	reexecCommand.Env = append(reexecCommand.Env, "_LIBCONTAINER_INITPIPE=3")
 	reexecCommand.Env = append(reexecCommand.Env, "_LIBCONTAINER_LOGPIPE=4")
 	logLevel := strconv.Itoa(int(logrus.GetLevel()))
@@ -384,7 +384,7 @@ func reexecUnikontainer(cmd *cli.Command) error {
 
 	// get Unikontainer data from state.json
 	// TODO: We need to find a better way to synchronize and make sure
-	// the pid is written from urunc` create. Right now we rely on receiving
+	// the pid is written from urunc create. Right now we rely on receiving
 	// the AckReexec message, however this is not optimal and we might lose
 	// time because urunc create tries to write in a socket that the reexec
 	// process has not created yet.
@@ -419,7 +419,7 @@ func reexecUnikontainer(cmd *cli.Command) error {
 	// preparation the error will get manifested later. However, if environment
 	// setup goes well and the socket was not cleaned up correctly,
 	// we execve the monitor and we rely on Go's close-on-exec feature in all file
-	// descriptors. THerefore, we might want to rethink this in future and not rely
+	// descriptors. Therefore, we might want to rethink this in future and not rely
 	// on Go, but this requires quite a lot of changes.
 	if awaitErr != nil {
 		awaitErr = fmt.Errorf("error waiting START message: %w", awaitErr)
@@ -438,8 +438,8 @@ func reexecUnikontainer(cmd *cli.Command) error {
 	// ignore any errors, since it is a simple socket cleanup and the process exits.
 	// If unikontainers.Exec succeeds though, then we will never execute this
 	// cleanup, since we execve to the monitor process. In that case, we rely
-	// once more in Go's close on exec handling of all file descriptors.
-	// In the future, we might want to revisit this and rely less in Go.
+	// once more on Go's close on exec handling of all file descriptors.
+	// In the future, we might want to revisit this and rely less on Go.
 	defer func() {
 		tmpErr := unikontainer.DestroyConn(unikontainers.FromReexec)
 		if tmpErr != nil {

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -169,7 +169,7 @@ func reviseRootDir(cmd *cli.Command) error {
 		return err
 	}
 	if root == "/" {
-		// This can happen if --root argument is.
+		// This can happen if --root argument is:
 		//  - "" (i.e. empty);
 		//  - "." (and the CWD is /);
 		//  - "../../.." (enough to get to /);
@@ -210,7 +210,7 @@ func configLogrus(cmd *cli.Command, cfg unikontainers.UruncLog) error {
 	logLevel := max(cfgLogLevel, cliLogLevel)
 	logrus.SetLevel(logLevel)
 
-	// If loglevel is debug or lower, enable report caller with prettyfier for text format
+	// If loglevel is debug or lower, enable report caller with prettifier for text format
 	if logLevel >= logrus.DebugLevel {
 		logrus.SetReportCaller(true)
 		// Shorten function and file names reported by the logger, by

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -21,7 +21,7 @@ Virtual Machine (VM) or a sandbox. At the same time, in the VM context, every
 VM runs as a process. Subsequently, `urunc` combines these two characteristics
 and treats the VM's process, which executes the unikernel that runs the
 application, as the container's process. This way, `urunc` does not require any
-auxiliary process running alongside the unikernel, maintaining as less overhead
+auxiliary process running alongside the unikernel, maintaining as little overhead
 as possible. Instead `urunc` directly manages the application running in the
 unikernel through the VMM or the sandbox monitor. Moreover, `urunc` does not
 require any modifications in the unikernel framework and hence all unikernel
@@ -56,7 +56,7 @@ higher-level runtime (`containerd`) level:
 
 To support unikernels in a containerized environment, `urunc` requires specific
 metadata embedded in OCI container images. These images must include the
-unikernel binary, configuration and any other files required from the application
+unikernel binary, configuration and any other files required by the application
 or the unikernel and the aforementioned metadata which dictate how the unikernel
 should be run. The metadata can be passed to `urunc` either in the form of
 [annotations](https://github.com/opencontainers/runtime-spec/blob/main/config.md#annotations)

--- a/docs/design/seccomp.md
+++ b/docs/design/seccomp.md
@@ -30,7 +30,7 @@ supported VMM. In particular, in the case of:
 - Qemu, 'urunc' makes use of Qemu's sandbox command line options to activate
   all possible seccomp filters in Qemu.
 - Cloud-Hypervisor, 'urunc' makes use of the `--seccomp true` command line
-  options to enable Cloud-Hypervisor's seccomp filters.
+  option to enable Cloud-Hypervisor's seccomp filters.
 - Solo5-hvt, 'urunc' applies the seccomp filters before executing
   'Solo5-hvt'.
 - Solo5-spt, 'urunc' can not do anything since solo5-spt makes use of seccomp by
@@ -64,4 +64,4 @@ Due to its design, 'urunc' does not allow the definition of a seccomp profile ot
 than the default. However, users can totally disable seccomp by using
 the `--security-opt seccomp=unconfined` command line option. In that scenario,
 'urunc' will not make use of any seccomp filters in all the supported VMMs, except
-of 'Solo5-spt'.
+for 'Solo5-spt'.

--- a/docs/developer-guide/contribute.md
+++ b/docs/developer-guide/contribute.md
@@ -144,7 +144,7 @@ A new (draft) PR triggers the following process:
 ## Labels for the CI
 
 We use GitHub workflows to invoke some tests when a new PR opens for `urunc`.
-In particular, we perform the following workflows tests:
+In particular, we perform the following workflow tests:
 
 - Linting of the commit message. Please check the [git commit message style](#git-commit-messages) below for more info.
 - Spell check, since `urunc` repository contains its documentation too.
@@ -160,7 +160,7 @@ three labels which can be used:
 - `ok-to-test`: Runs a full CI workflow, meaning all lint tests (commit
   message, spellcheck, license), Go's linting, building for x86 and aarch64,
   unit tests and at last end-to-end tests.
-- `skip-build`: Skips the building workflows along with unit and end-to end tests
+- `skip-build`: Skips the building workflows along with unit and end-to-end tests
   running all the linting tests. This is useful when
   the PR is related to docs and it can help for catching spelling errors etc. In
   addition, if the changes are not related to the codebase, running the
@@ -215,5 +215,5 @@ Go provides the `gofmt` tool, which can be used for formatting your code.
 
 We kindly invite everyone interested in `urunc` to join our
 [Slack channel](https://cloud-native.slack.com/archives/C08V201G35J).
-To directly communicate with the maintainers, feel free to drop an email At
+To directly communicate with the maintainers, feel free to drop an email at
 [`urunc`'s maintainers' mailing list](cncf-urunc-maintainers@lists.cncf.io )

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -85,7 +85,7 @@ Using `cntr` with a urunc container gives:
 
 - Working PTY devices (`/dev/pts`, `/dev/ptmx`, `/dev/console`)
 - A debugging environment with common tools (e.g., `ls`, `ps`, `strace`)
-- Visibility into the container namespace where the monitor process (qemu/rirecracker/cloud-hypervisor/solo5) runs
+- Visibility into the container namespace where the monitor process (qemu/firecracker/cloud-hypervisor/solo5) runs
 
 > **Note:** `cntr` does **not** enter the unikernel VM — it only provides access to the container namespace hosting the monitor.
 

--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -55,7 +55,7 @@ by running the:
 - end-to-end tests: `sudo make e2etest`
 
 > Note: When running `make` commands for `urunc` that will use go (i.e. build,
-> unitest, e2etest) you might need to specify the path to the go binary
+> unittest, e2etest) you might need to specify the path to the go binary
 with `sudo GO=$(which go) make`.
 
 ## Next Steps

--- a/docs/developer-guide/governance.md
+++ b/docs/developer-guide/governance.md
@@ -1,6 +1,6 @@
 # Governance
 
-`urunc` is dedicated to enable the deployment of unikernels and single
+`urunc` is dedicated to enabling the deployment of unikernels and single
 application kernels in cloud-native environments. This governance document
 explains how the project is run.
 
@@ -100,7 +100,7 @@ and invited to the [private maintainer mailing list](mailto:dev-priv@urunc.io).
 Maintainers may resign at any time if they feel that they will not be able to
 continue fulfilling their project duties.
 
-Maintainers may also be removed after being inactive, failure to fulfill their
+Maintainers may also be removed after being inactive, failing to fulfill their
 Maintainer responsibilities, violating the Code of Conduct, or other reasons.
 Inactivity is defined as a period of very low or no activity in the project for
 6 months or more, with no definite schedule to return to full Maintainer
@@ -115,9 +115,9 @@ and can be rapidly returned to Maintainer status if their availability changes.
 ### Admin
 
 `urunc` Admins (as defined by the [urunc Admin
-team](https://github.com/orgs/urunc-dev/teams/admins) have admin access to the
-`urunc` repo, allowing them to do actions like, change the branch protection
-rules for repositories, delete a repository and manage the access of others.
+team](https://github.com/orgs/urunc-dev/teams/admins)) have admin access to the
+`urunc` repo, allowing them to do actions like changing the branch protection
+rules for repositories, deleting a repository and managing the access of others.
 The Admin group is intentionally kept small, however, individuals can
 be granted temporary admin access to carry out tasks, like creating a secret
 that is used in a particular CI infrastructure.

--- a/docs/developer-guide/llm-policy.md
+++ b/docs/developer-guide/llm-policy.md
@@ -15,12 +15,12 @@ amounts of code in a very short period of time. While this can be beneficial,
 like many open source projects, `urunc` has experienced an increase in
 contributions that exhibit low quality and clear signs of unreviewed LLM usage.
 For that reason, the `urunc` project has decided to enforce some rules
-regarding the use of LLM in its development process:
+regarding the use of LLMs in its development process:
 
 - LLM generated code must be treated in the same way as any other code.
 - The use of LLMs for any contributions must be disclosed, including the exact
   model that was used.
-- The user of LLM takes full responsibility of the generated output.
+- The user of an LLM takes full responsibility for the generated output.
 - All LLM-generated content must be reviewed by the contributor before opening
   issues or PRs, ensuring correctness, quality, and relevance.
 - The use of LLMs to respond to comments in issues or PRs is not permitted.
@@ -40,7 +40,7 @@ and this policy is not intended to prohibit their use. Instead, it aims to
 protect the project from the misuse of such tools. LLM outputs are
 probabilistic in nature and may introduce subtle bugs, outdated practices,
 security risks, or incorrect assumptions. As such, any code or technical
-contribution produced with the assistance of an LLMs must be carefully reviewed
+contribution produced with the assistance of an LLM must be carefully reviewed
 and tested. Responsibility for the correctness and quality of LLM-generated
 output lies solely with the contributor who uses the tool.
 

--- a/docs/developer-guide/security.md
+++ b/docs/developer-guide/security.md
@@ -20,7 +20,7 @@ finding a proper fix.
 ## Reporting Vulnerabilities
 
 Please do not open public issues or PRs to report a vulnerability. Instead, use
-the private vulnerability reporting of the `urunc`'s Github repository. In
+the private vulnerability reporting of `urunc`'s Github repository. In
 particular, in `urunc`'s repository page, navigate to the [Security
 tab](https://github.com/urunc-dev/urunc/security), click
 [`Advisories`](https://github.com/urunc-dev/urunc/security/advisories) and then
@@ -81,7 +81,7 @@ _eg. github.com/urunc-dev/urunc_
 _eg. < 0.5.0_
 
 ### Patched Versions
-_eg. 0.5.1
+_eg. 0.5.1_
 
 ### Severity
 _eg. Low, Critical etc._

--- a/docs/developer-guide/timestamps.md
+++ b/docs/developer-guide/timestamps.md
@@ -34,7 +34,7 @@ The timestamps currently depicting each unikernel container execution are the fo
 
 ## Timestamping logging method
 
-To log the timestamps with minimal overhead, we opted to use the [zerolog](https://github.com/rs/zerolog) package. We were able to keep the delay caused by the timestamp logging in a low level, around 38351ns for the 20 timestamps required. In comparison, when using [logrus](https://github.com/sirupsen/logrus) the overhead was measured at around 71589ns.
+To log the timestamps with minimal overhead, we opted to use the [zerolog](https://github.com/rs/zerolog) package. We were able to keep the delay caused by the timestamp logging at a low level, around 38351ns for the 20 timestamps required. In comparison, when using [logrus](https://github.com/sirupsen/logrus) the overhead was measured at around 71589ns.
 
 Timestamp logging is now handled through a fixed schema using zerolog. The previous logger benchmark suite has been removed, as it is no longer relevant to the current timestamping implementation.
 

--- a/docs/hypervisor-support.md
+++ b/docs/hypervisor-support.md
@@ -3,7 +3,7 @@
 One of the main goals of `urunc` is to be a generic OCI unikernel runtime for
 various unikernel frameworks and similar technologies. In order to achieve
 that, we want to support as many Virtual Machine Monitors (VMMs) and other
-types of sandboxing mechanisms such as user-space monitors based on
+types of sandboxing mechanisms as possible, such as user-space monitors based on
 [seccomp](https://en.wikipedia.org/wiki/Seccomp).
 
 In this document, we will go through the current state of `urunc`'s support for
@@ -18,7 +18,7 @@ somewhere in the `$PATH`.
 
 VMMs use hardware-assisted virtualization technologies in order to create a
 Virtual Machine (VM) where a guest OS will execute. It is one of the most
-widely used technology for providing strong isolation in multi-tenant
+widely used technologies for providing strong isolation in multi-tenant
 environments. For the time being `urunc` supports 4 types of such VMMs: 1)
 [Qemu](https://www.qemu.org/), 2)
 [Firecracker](https://firecracker-microvm.github.io/), 3)
@@ -120,7 +120,7 @@ versions.
 
 In the case of [Firecracker](https://firecracker-microvm.github.io/), `urunc`
 makes use of its `virtio-net` device to provide network support for the
-unikernel though a tap device. In addition, `urunc` can leverage
+unikernel through a tap device. In addition, `urunc` can leverage
 [Firecracker](https://firecracker-microvm.github.io/)'s initrd option in order
 to provide the Unikernel with an initial RamFS (initramfs).
 [Firecracker](https://firecracker-microvm.github.io/) does not support
@@ -192,8 +192,8 @@ sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubifi
 VMM designed to run unikernels in a virtualized environment. As a part of the
 broader Solo5 project, [Solo5-hvt](https://github.com/Solo5/solo5) provides a
 minimal, efficient abstraction layer for running unikernels on modern hardware,
-leveraging hardware virtualization technologies Some of the key benefits of
-[Solo5-hvt](https://github.com/Solo5/solo5) is its simplicity and extremely
+leveraging hardware virtualization technologies. Some of the key benefits of
+[Solo5-hvt](https://github.com/Solo5/solo5) are its simplicity and extremely
 fast boot times of unikernels. In contrast to the other VMMs,
 [Solo5-hvt](https://github.com/Solo5/solo5) does not provide support for virtIO
 devices. Instead, it defines its own interface, which can be used for network
@@ -239,7 +239,7 @@ In the second case, we copy directly all the files we want the unikernel to
 access inside the container's image. Using devmapper `urunc` will use the
 container's image snapshot as a block image for the unikernel. It is important
 to note that the unikernel framework must support the respective filesystem
-type (e.g. ext2/3/4). This is the case for Rumprun unikernel.
+type (e.g. ext2/3/4). This is the case for Rumprun unikernels.
 
 Supported unikernel frameworks with `urunc`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ from the OCI tools and methodology, `urunc` aims to become
 Runtime Interface (CRI). Unikernels are packaged inside OCI-compatible images
 and `urunc` launches the unikernel on top of the underlying Virtual Machine or
 seccomp monitors. Thus, developers and administrators can package, deliver,
-deploy and manage unikernels using familiar cloud-native practises.
+deploy and manage unikernels using familiar cloud-native practices.
 
 For the above purpose `urunc` acts as any other OCI runtime. The main
 difference of `urunc` with other container runtimes is that instead of
@@ -38,9 +38,9 @@ Unikernels are well known as a good fit for a variety of use cases, such as:
   satisfies the event-driven, short-lived and scalable characteristics of
   serverless computing
 - Edge computing: The lightweight notion of unikernels suits very well with edge
-  devices, where resources constraints and performance are critical.
+  devices, where resource constraints and performance are critical.
 - Sensitive environments: The inherited strong VM-based isolation, along with
-  the minimized attack surface of unikernels, provide strong security guarantees
+  the minimized attack surface of unikernels, provides strong security guarantees
   for sensitive applications which demand high security standards.
 
 In all the above use cases, `urunc` facilitates the seamless integration of

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,7 +129,7 @@ block device for a guest. Currently, `urunc` has been tested and verified with
 [devmapper](https://github.com/containerd/containerd/blob/main/docs/snapshotters/devmapper.md)
 and
 [blockfile](https://github.com/containerd/containerd/blob/main/docs/snapshotters/blockfile.md).
-Devmapper uses a thinpool for flexible management, while blockfile uses on a
+Devmapper uses a thinpool for flexible management, while blockfile uses a
 pre-allocated scratch file, though it lacks ext2 support and thus it is not
 compatible with Rumprun unikernels.
 
@@ -225,7 +225,7 @@ io.containerd.snapshotter.v1              devmapper                linux/amd64  
 #### Setting and configuring blockfile
 
 The first step of setting up `blockfile` is the creation of the
-scratch file, which will be used from the snapshotter:
+scratch file, which will be used by the snapshotter:
 
 ```bash
 sudo mkdir -p /opt/containerd/blockfile
@@ -305,7 +305,7 @@ respective installation guide.
 
 ### Option 1: Using the monitors-build repository
 
-The [monitor-builds repository](https://github.com/urunc-dev/monitors-build)
+The [monitors-build repository](https://github.com/urunc-dev/monitors-build)
 provides a reference setup for building and distributing static binaries of
 monitors and tools for `urunc`. In the [releases
 page](https://github.com/urunc-dev/monitors-build/releases) there are archives
@@ -337,7 +337,7 @@ rm release-${ARCH}-${VERSION}.tar.gz
 
 After downloading all the binaries, we need to instruct `urunc` about the
 location of the binaries. Therefore, in [`urunc`'s
-configuration](../configuration). there are three fields that need to
+configuration](../configuration), there are three fields that need to
 get updated:
 
 1. in each monitor the `path` field,
@@ -417,7 +417,7 @@ rm -fr release-${VERSION}-${ARCH}
 
 [Cloud-Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)
 provides releases with statically-built binaries. To get a specific version
-(e.g. "v[[ versions.clh ]]":
+(e.g. "v[[ versions.clh ]]"):
 
 ```bash
 ARCH="$(uname -m)"
@@ -458,12 +458,12 @@ To install `urunc`, there are three options:
 
 1. building from source,
 2. grabbing the binaries from the latest release, or
-3. grabbing the binaries from the lastest commit in main.
+3. grabbing the binaries from the latest commit in main.
 
 #### Option 1: Building from source
 
-In order to build `urunc` from source, any earlier version of Go 1.20.6 should
-be sufficient, Let's download Go [[versions.go ]]
+In order to build `urunc` from source, any version of Go 1.20.6 or later should
+be sufficient. Let's download Go [[versions.go ]]
 
 ```bash
 GO_VERSION=[[ versions.go ]]

--- a/docs/package/index.md
+++ b/docs/package/index.md
@@ -52,14 +52,14 @@ required annotations are the following:
 - `com.urunc.unikernel.unikernelType`: The type of the unikernel. Currently
   supported values: a) unikraft, b) rumprun, c) mirage.
 - `com.urunc.unikernel.hypervisor`: The VMM or sandbox monitor to run the
-  unikernel Currently supported values: a) `qemu`, b) `firecracker`, c)
+  unikernel. Currently supported values: a) `qemu`, b) `firecracker`, c)
   `cloud-hypervisor`, d) `spt`,  e) `hvt`.
 - `com.urunc.unikernel.binary`: The path to the unikernel binary inside the
   container's rootfs
 - `com.urunc.unikernel.cmdline`: The application's cmdline to pass to the
   unikernel.
 
-Except of the above, `urunc` accepts the following optional annotations:
+Apart from the above, `urunc` accepts the following optional annotations:
 
 - `com.urunc.unikernel.initrd`: The path to the initrd of the unikernel inside
   the container's rootfs.
@@ -88,7 +88,7 @@ package unikernels in OCI images with `urunc`'s annotations.
 ### bunny
 
 In an effort to simplify the process of building various unikernels, we built
-[bunny](https://github.com/nubificus/bunny). Except of building unikernels [bunny](https://github.com/nubificus/bunny)
+[bunny](https://github.com/nubificus/bunny). Apart from building unikernels [bunny](https://github.com/nubificus/bunny)
 can also pack existing unikernels (whether locally or from OCI images) as OCI images
 for `urunc`. At its core [bunny](https://github.com/nubificus/bunny) leverages
 [buildkit's LLB](https://github.com/moby/buildkit?tab=readme-ov-file#exploring-llb),
@@ -113,7 +113,7 @@ can handle the following *instructions*:
 To further extend the functionality and provide a common interface to facilitate
 unikernel building, we defined `bunnyfile`. It is a YAML-based special file that
 [bunny](https://github.com/nubificus/bunny) transforms to LLB with all the
-necessary steps to build the respective unikernel. Except of building
+necessary steps to build the respective unikernel. Apart from building
 unikernels, [bunny](https://github.com/nubificus/bunny) can also be used to build or append files in the unikernel's
 rootfs.
 
@@ -157,7 +157,7 @@ Since [bunny](https://github.com/nubificus/bunny) uses
 [buildkit](https://github.com/moby/buildkit?tab=readme-ov-file#output) it
 supports two modes of execution. In the first mode it acts as a [buildkit
 frontend](https://docs.docker.com/build/buildkit/frontend/) and in the second
-mode it outputs a LLB which can be passed to `buildctl`.Therefore,
+mode it outputs a LLB which can be passed to `buildctl`. Therefore,
 [bunny](https://github.com/nubificus/bunny) depends on
 [buildkit](https://github.com/moby/buildkit?tab=readme-ov-file#output) which
 should be installed. However, if [docker](https://www.docker.com/) is already
@@ -175,7 +175,7 @@ we need to start the Containerfile with the following line:
 ***Using a Dockerfile-like syntax file***
 
 If we want to package a locally built Nginx Unikraft unikernel, we
-can define the a Dockerfile-like syntax file as:
+can define a Dockerfile-like syntax file as:
 
 ```Dockerfile
 #syntax=harbor.nbfc.io/nubificus/bunny:latest
@@ -222,7 +222,7 @@ and we can build it with a docker command:
 docker build -f bunnyfile -t nubificus/urunc/nginx-unikraft-qemu:test .
 ```
 
-> **NOTE**: We can use the above command and switch form bunnyfile to the
+> **NOTE**: We can use the above command and switch from bunnyfile to the
 > Dockerfile-like file and build the same unikernel OCI image.
 
 For more information check [bunny's README](https://github.com/nubificus/bunny?tab=readme-ov-file#bunny-build-and-package-unikernels-like-containers).
@@ -241,7 +241,7 @@ particular, this file is the `args.nix` file, which expects the same fields:
 - files: a list of key-value pairs with all the files to copy inside the
   container image. The key-value pairs have the following format:
   `"<path-based-on-cwd>" = "<path-inside-container>"`.
-- annotations: a list will all the `urunc` annotations.
+- annotations: a list with all the `urunc` annotations.
 
 #### Packaging a unikernel with bunix
 

--- a/docs/package/pre-built.md
+++ b/docs/package/pre-built.md
@@ -93,7 +93,7 @@ docker build -f Containerfile -t urunc/prebuilt/network-mirage-hvt:test .
 ## Using `bunix`
 
 In the case of [bunix](https://github.com/nubificus/bunix) we need to clone the whole
-repository in the same directly as the
+repository in the same directory as the
 unikernel. Then, we simply need to edit the `args.nix` file as:
 
 ```Nix

--- a/docs/package/reuse.md
+++ b/docs/package/reuse.md
@@ -9,7 +9,7 @@ description: "Reusing OCI images that contain unikernels"
 In this page we will explain how we can reuse existing OCI images that contain
 unikernels to either update or append `urunc` annotations. As an
 example, we will use an existing [Unikraft](https://unikraft.org) Unikernel
-image from [Unikraft's catalog](https://github.com/unikraft/catalog), The goal
+image from [Unikraft's catalog](https://github.com/unikraft/catalog). The goal
 will be to transform this image to an OCI image that `urunc` can handle, by
 simply appending the necessary annotations.
 
@@ -39,13 +39,13 @@ kernel:
 cmdline: "nginx -c /nginx/conf/nginx.conf"
 ```
 
-In the above file we specify the followings:
+In the above file we specify the following:
 
 - We want to use a [Unikraft](https://unikraft.org) unikernel that will execute on top of Qemu over x86
   architecture.
 - We want to use the unikernel binary `/unikraft/bin/kernel` from the
   `unikraft.org/nginx:1.15` OCI image.
-- We specify the cmdline for the unikernel as `nginx -c /nginx/conf/nginx.conf"`
+- We specify the cmdline for the unikernel as `nginx -c /nginx/conf/nginx.conf`
 
 With the above file, `bunny` will fetch the OCI image and append the `urunc`
 annotations. We can build the OCI image with the following command:

--- a/docs/package/rootfs.md
+++ b/docs/package/rootfs.md
@@ -18,7 +18,7 @@ tools and explain how to use them to create and package a root filesystem
 For the time being, `urunc` supports three ways for passing the rootfs to the
 unikernel: a) through initrd, b) as a virtio-block and c) through shared-fs.
 In the virtio-block case,
-`urunc` can either levarage the container's snapshot and pass the whole
+`urunc` can either leverage the container's snapshot and pass the whole
 container's rootfs as the rootfs, or `urunc` can make use of
 a user-created file inside the OCI image to pass as a virtio-block device
 to the unikernel.
@@ -71,7 +71,7 @@ In the above file we specify the following:
 - We want to package a [Unikraft](https://unikraft.org) unikernel that will execute on top of [Qemu](https://qemu.org) over
   x86 architecture.
 - We want to create from `scratch` a rootfs with `initrd` as its type. In
-  particular, we want a initrd file that contains the file `redis.conf` in
+  particular, we want an initrd file that contains the file `redis.conf` in
   `/data/conf/redis.conf`. In that way, [bunny](https://github.com/nubificus/bunny) creates the initrd file for us
   and sets up the respective `urunc` annotations to attach this initrd file
   when we boot the unikernel.
@@ -93,9 +93,9 @@ rootfs. For this scenario we can use both
 [bunny](https://github.com/nubificus/bunny) and
 [bunix](https://github.com/nubificus/bunix).
 
-> **NOTE**: In case the unikernel does not supports shared-fs (e.g. 9pfs/virtiofs), we
+> **NOTE**: In case the unikernel does not support shared-fs (e.g. 9pfs/virtiofs), we
 > can only use block devices and for that reason we need to create the unikernel
-> container using devmapper as a snapshotter. In that way,`urunc` will use the
+> container using devmapper as a snapshotter. In that way, `urunc` will use the
 > snapshot of the container's image and directly attach it to the unikernel as  a
 > block device.
 
@@ -148,7 +148,7 @@ In the above file we specify the following:
 - We want to create a rootfs from `scratch` with a `raw` type, meaning that
   we will just copy the
   specified files directly to the OCI image's rootfs. In particular, we copy the
-  file `redis.conf` and place it at `/conf/redis.conf`.This is similar to
+  file `redis.conf` and place it at `/conf/redis.conf`. This is similar to
   `COPY` in Dockerfile.  Because of this type selection, [bunny](https://github.com/nubificus/bunny) will also set up
   the respective annotations to mount the OCI images rootfs directly to the
   unikernel.
@@ -198,7 +198,7 @@ docker build -f Containerfile -t urunc/prebuilt/redis-rumprun-hvt:test .
 
 ### Using `bunix`
 
-In the case of [bunix](https://github.com/nubificus/bunix) we need the whole repository in the same directly as
+In the case of [bunix](https://github.com/nubificus/bunix) we need the whole repository in the same directory as
 the unikernel. Then, we simply need to edit the `args.nix` file. For our
 pre-built Redis [Rumprun](https://github.com/nubificus/rumprun) unikernel we can define the files as:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ on a number of GNU/Linux distributions.
 
 ## Using Docker
 
-The easiest and fastest way to try out `urunc` would be with `docker`
+The easiest and fastest way to try out `urunc` would be with `docker`.
 Before doing so, please make sure that the host system satisfies the
 following dependencies:
 
@@ -212,7 +212,7 @@ rm -f nerdctl-$NERDCTL_VERSION-linux-$(dpkg --print-architecture).tar.gz
 
 ### Install `urunc` from its latest release
 
-At last, but not least, we will install `urunc` from its latest release. At first, we
+Last but not least, we will install `urunc` from its latest release. At first, we
 will install the `urunc` binary:
 
 ```bash
@@ -236,7 +236,7 @@ We will try out a Rumprun unikernel running over Solo5-hvt with [nerdctl](https:
 
 #### Install solo5
 
-Lets install `solo5-hvt`:
+Let's install `solo5-hvt`:
 
 ```bash
 sudo apt install make gcc pkg-config libseccomp-dev
@@ -254,7 +254,7 @@ Now, let's run a Redis unikernel on top of Rumprun and solo5-hvt:
 sudo nerdctl run -d --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/redis-hvt-rumprun-raw:latest
 ```
 
-We can inspect the running container to check it's IP address:
+We can inspect the running container to check its IP address:
 
 ```console
 $ sudo nerdctl ps 

--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -11,7 +11,7 @@ To use `urunc` in a k8s cluster there are 2 options:
 
 ### Install urunc
 
-Before we start, we need to have working Kubernetes cluster with [urunc installed](../installation.md) on one or more nodes.
+Before we start, we need to have a working Kubernetes cluster with [urunc installed](../installation.md) on one or more nodes.
 
 ### Add urunc as a RuntimeClass
 

--- a/docs/tutorials/Non-root-monitor-execution.md
+++ b/docs/tutorials/Non-root-monitor-execution.md
@@ -23,7 +23,7 @@ monitor with `urunc` as `nobody`, we use the following command:
 sudo nerdctl run  --user 65534:65534 --runtime "io.containerd.urunc.v2" --rm -it harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
 ```
 
-> Note The commands are the same for docker.
+> Note: The commands are the same for docker.
 
 
 ### In a k8s deployment

--- a/docs/tutorials/eks-tutorial.md
+++ b/docs/tutorials/eks-tutorial.md
@@ -314,7 +314,7 @@ installation.operator.tigera.io/default created
 ##### Step 4: Provision nodes
 
 Now, you are ready to provision nodes for the cluster. Use the following description to create two bare-metal nodes, one for each supported architecture (`amd64` and `arm64`):
-> Note: Make sure the `metadata.name` entry corresponds to the name you specified for your cluster above, and that the managedNodeGroups.[].subnets entry correspond to the ones specified above.
+> Note: Make sure the `metadata.name` entry corresponds to the name you specified for your cluster above, and that the managedNodeGroups.[].subnets entry corresponds to the ones specified above.
 
 ```bash
 eksctl create nodegroup -f - <<EOF
@@ -452,7 +452,7 @@ done
 
 #### Verify the cluster is operational
 
-We have successfully setup the cluster. Let's see what we have using a simple `kubectl get pods -o wide -A`:
+We have successfully set up the cluster. Let's see what we have using a simple `kubectl get pods -o wide -A`:
 
 ```console
 NAMESPACE         NAME                                       READY   STATUS    RESTARTS   AGE     IP                NODE                                               NOMINATED NODE   READINESS GATES
@@ -564,11 +564,11 @@ Commercial support is available at
 </body>
 </html>
 ```
-There we go! We have a working EKS cluster, with Calico and two bare-metal nodes. Time to setup urunc! 
+There we go! We have a working EKS cluster, with Calico and two bare-metal nodes. Time to set up urunc! 
 
 ### `urunc` setup
 
-The easiest way to setup `urunc` in such a setting is to use `urunc-deploy`. This process follows the principles of `kata-deploy` and is build to work on `k8s` and `k3s`. The process is as follows:
+The easiest way to set up `urunc` in such a setting is to use `urunc-deploy`. This process follows the principles of `kata-deploy` and is built to work on `k8s` and `k3s`. The process is as follows:
 
 #### 1. Clone the repo
 

--- a/docs/tutorials/existing-container-linux.md
+++ b/docs/tutorials/existing-container-linux.md
@@ -42,7 +42,7 @@ Alternatively, prebuilt kernels are available via the following container images
 - `harbor.nbfc.io/nubificus/urunc/linux-kernel-qemu:v6.14`
 - `harbor.nbfc.io/nubificus/urunc/linux-kernel-firecracker:v6.14`
 
-> NOTE: For cloud-hypervisor users can use the Linux kernel image of Firecracker.
+> NOTE: For cloud-hypervisor, users can use the Linux kernel image of Firecracker.
 
 Each image contains the Linux kernel binary at `/kernel`.
 
@@ -65,7 +65,7 @@ treated as a separate argument.
   parameters. If too many or very long environment variables are passed, the
   boot process will fail once that limit is exceeded. 
 
-Especially, for CLI argument handing, `urunc` follows a simple convention. All
+Especially, for CLI argument handling, `urunc` follows a simple convention. All
 multi-word CLI arguments are wrapped in single quotes and the init process (or
 application) is expected to reconstruct them properly.
 
@@ -76,7 +76,7 @@ designed specifically for `urunc`. It performs the following actions:
 1. Sets default route through eth0. This is necessary when we deploy
    the container in a Kubernetes cluster, where there is a high chance that
    the gateway of the container might be in a different subnet than the IP.
-   As a result, Linux kernel will fail to set the gateway.
+   As a result, the Linux kernel will fail to set the gateway.
 2. Groups multi-word arguments correctly.
 3. Mounts `/proc` and `/sys`.
 4. Reads and sets the environment variables for the application execution
@@ -85,7 +85,7 @@ designed specifically for `urunc`. It performs the following actions:
 
 To pass the necessary information to
 [urunit](https://github.com/nubificus/urunit), `urunc` uses a configuration
-file that passes to the VM with the following format:
+file that it passes to the VM with the following format:
 
 ```
 UES
@@ -120,7 +120,7 @@ You can obtain [urunit](https://github.com/nubificus/urunit) in two ways:
 
 - Fetch a static binary from [urunit's release
   page](https://github.com/nubificus/urunit/releases).
-  Via the container image: `harbor.nbfc.io/nubificus/urunit:latest`,
+- Via the container image: `harbor.nbfc.io/nubificus/urunit:latest`,
   with the binary located at `/urunit`.
 
 ## Preparing the image
@@ -137,7 +137,7 @@ are three main ways to do this:
 
 1. Using directly the rootfs of the container's image (requires either a block based snapshotter or 9pfs/Virtiofs).
 2. Creating a block image out of a container's image rootfs.
-3. Creating a initrd.
+3. Creating an initrd.
 
 ### Using directly the container's rootfs
 

--- a/docs/tutorials/knative.md
+++ b/docs/tutorials/knative.md
@@ -107,7 +107,7 @@ kubectl patch configmap/config-features --namespace knative-serving --type merge
 kubectl get ksvc -A -o wide
 ```
 
-Should be empty. Create an simple httpreply
+Should be empty. Create a simple httpreply
 [service](https://github.com/nubificus/c-httpreply/blob/main/service.yaml),
 based on a [simple C program](https://github.com/nubificus/c-httpreply):
 
@@ -141,7 +141,7 @@ NAME             URL                                                  LATESTCREA
 hellounikernelfc http://hellounikernelfc.default.127.0.0.1.nip.io     hellounikernelfc-00001     hellounikernelfc-00001     True
 ```
 
-and once it's on a `Ready` state, you could issue a request:
+and once it's in a `Ready` state, you could issue a request:
 > Note: 10.244.9.220 is the IP of the `kourier-internal` svc. You can check your own from:
 > `kubectl get svc -n kourier-system |grep kourier-internal`
 

--- a/docs/unikernel-support.md
+++ b/docs/unikernel-support.md
@@ -80,7 +80,7 @@ compiled for production deployment. We can easily set up and build
 be installed through the [Opam](https://opam.ocaml.org/) source package manager.
 The framework is fully event-driven, with no support for preemptive threading.
 
-[MirageOS](https://github.com/mirage/mirage) is characterized from the extremely
+[MirageOS](https://github.com/mirage/mirage) is characterized by the extremely
 fast start up times (just a few milliseconds), small binaries (usually a few
 megabytes), small footprint (requires a few megabytes of memory) and safe logic,
 as it is completely written in OCaml.
@@ -113,15 +113,15 @@ storage through [Solo5](https://github.com/Solo5/solo5)'s I/O interface.
 ### MirageOS and `urunc`
 
 In the case of [MirageOS](https://github.com/mirage/mirage) `urunc` provides
-support for [Solo5](https://github.com/Solo5/solo5),
-[Solo5](https://github.com/Solo5/solo5) and [Qemu](https://qemu.org). For all
+support for [Solo5-hvt](https://github.com/Solo5/solo5),
+[Solo5-spt](https://github.com/Solo5/solo5) and [Qemu](https://qemu.org). For all
 monitors of [Solo5](https://github.com/Solo5/solo5) `urunc` allows the access
 of both network and block storage through
 [Solo5](https://github.com/Solo5/solo5)'s I/O interface and for
 [Qemu](https://qemu.org) through virtio-net and virtio-block.
 
 For the time being, the block image that the
-[MirageOS](https://github.com/mirage/mirage) unikernel access during its
+[MirageOS](https://github.com/mirage/mirage) unikernel accesses during its
 execution should be placed inside the container image.
 
 For more information on packaging
@@ -170,7 +170,7 @@ Especially in the case of KVM,
 It can access the network through virtio-net in the case of
 [Qemu](https://qemu.org) and using [Solo5](https://github.com/Solo5/solo5)'s
 I/O interface in the case of [Solo5](https://github.com/Solo5/solo5).  As far
-as we concern, [Rumprun](https://github.com/cloudkernels/rumprun) only supports
+as we know, [Rumprun](https://github.com/cloudkernels/rumprun) only supports
 block storage through virtio-block and
 [Solo5](https://github.com/Solo5/solo5)'s I/O in [Qemu](https://qemu.org) and
 [Solo5](https://github.com/Solo5/solo5) respectively.
@@ -185,8 +185,8 @@ storage through [Solo5](https://github.com/Solo5/solo5)'s I/O interface.
 ### Rumprun and `urunc`
 
 In the case of [Rumprun](https://github.com/cloudkernels/rumprun), `urunc`
-provides support for [Solo5](https://github.com/Solo5/solo5) and
-[Solo5](https://github.com/Solo5/solo5), but not yet for
+provides support for [Solo5-hvt](https://github.com/Solo5/solo5) and
+[Solo5-spt](https://github.com/Solo5/solo5), but not yet for
 [Qemu](https://qemu.org). For all monitors of
 [Solo5](https://github.com/Solo5/solo5) `urunc` allows the access of both
 network and block storage through [Solo5](https://github.com/Solo5/solo5)'s I/O
@@ -241,7 +241,7 @@ the linked WASM application. [Mewz](https://github.com/Mewz-project/Mewz) has
 partial support for [WASI](https://github.com/WebAssembly/WASI) and it provides
 support for networking and an in-memory, read-only filesystem. In addition,
 [Mewz](https://github.com/Mewz-project/Mewz) has socket compatibility with
-[WasmEdge](https://github.com/WasmEdge/WasmEdge),
+[WasmEdge](https://github.com/WasmEdge/WasmEdge).
 
 A few examples of [Mewz](https://github.com/Mewz-project/Mewz) unikernels can
 be found in the [examples directory of Mewz's
@@ -290,7 +290,7 @@ how we can turn the [Linux](https://github.com/torvalds/linux) kernel into a
 unikernel.
 
 Using [Linux](https://github.com/torvalds/linux), we can execute the vast
-majority of the existing containers on top of `urunc`. However, the rational is
+majority of the existing containers on top of `urunc`. However, the rationale is
 to target single application containers and not fully-blown distro containers.
 Focusing on a single application, we can further minimize the
 [Linux](https://github.com/torvalds/linux) kernel and keep only the necessary
@@ -311,14 +311,14 @@ emulated devices etc.).
 
 Focusing on the single-application notion of using the
 [Linux](https://github.com/torvalds/linux) kernel, `urunc` provides support for
-both [Qemu](https://qemu.org),
+[Qemu](https://qemu.org),
 [Firecracker](https://github.com/firecracker-microvm/firecracker) and
 [Cloud-Hypervisor](https://www.cloudhypervisor.org/). For network,
 `urunc` will make use of virtio-net either through PCI or MMIO, depending on
 the monitor. In the case of storage, `urunc` can use initrd, virtio-block, 9pfs
 or Virtiofs. In particular, `urunc` takes advantage of the extensive filesystem
 support of [Linux](https://github.com/torvalds/linux) and can directly mount
-containerd's snapshot directly to a [Linux](https://github.com/torvalds/linux)
+containerd's snapshot to a [Linux](https://github.com/torvalds/linux)
 VM. This is only possible using devmapper as a snapshotter in containerd. For
 more information on setting up devmapper, please take a look on our
 [installation guide](../installation#setup-thinpool-devmapper).
@@ -355,10 +355,10 @@ sudo nerdctl run --rm -ti --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubifi
 
 [Hermit](https://hermit-os.org/) is a unikernel designed for
 high-performance and cloud/HPC workloads.
-Its a Rust re-write of the Hermit-Core unikernel in order to leverage the
+It's a Rust re-write of the Hermit-Core unikernel in order to leverage the
 memory/thread-safety guarantees provided by the Rust ownership model.
 
-Hermit provides support for multiple compiled languages like Rust, C, C++, Go and Fotran. Hermit applications are compiled
+Hermit provides support for multiple compiled languages like Rust, C, C++, Go and Fortran. Hermit applications are compiled
 into a unikernel image that includes both the application and the operating system.
 When the unikernel boots, the application starts execution immediately.
 

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -24,12 +24,12 @@ type DynamicNetwork struct {
 }
 
 // NetworkSetup checks if any tap device is available in the current netns. If it is, it assumes a running unikernel
-// is present in the current netns and returns an error, because network functionality for more than one unikernels
+// is present in the current netns and returns an error, because network functionality for more than one unikernel
 // is not yet implemented.
 // If no TAP devices are available in the current netns, it creates a new tap device and
 // sets TC rules between the veth interface and the tap device inside the namespace.
 //
-// FIXME: CUrrently only one tap device per netns can provide functional networking. We need to find a proper way to handle networking
+// FIXME: Currently only one tap device per netns can provide functional networking. We need to find a proper way to handle networking
 // for multiple unikernels in the same pod/network namespace.
 // See: https://github.com/urunc-dev/urunc/issues/13
 func (n DynamicNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {

--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -109,7 +109,7 @@ func getMountInfo(path string) (types.BlockDevParams, error) {
 	}
 
 	// Check if the source of the mountpoint that refers to path
-	// exists i the map with the found sources. If this is the case,
+	// exists in the map with the found sources. If this is the case,
 	// then we are not dealing with a mount regarding a block device
 	// that we can attach to the sandbox.
 	_, ok := nonSpecialSources[blockDev.Source]

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -29,12 +29,12 @@ import (
 
 var ErrEmptyAnnotations = errors.New("spec annotations are empty")
 
-// Important: Unfortunately GOlang does not allow to use constant values for
-// struct tagsAs a result, please always keep the constant definitions and the
+// Important: Unfortunately Golang does not allow to use constant values for
+// struct tags. As a result, please always keep the constant definitions and the
 // UnikernelConfig struct below in sync.
 
 // Urunc specific annotations
-// ALways keep it in sync with the struct UnikernelConfig struct
+// Always keep it in sync with the struct UnikernelConfig struct
 const (
 	annotType          = "com.urunc.unikernel.unikernelType"
 	annotVersion       = "com.urunc.unikernel.unikernelVersion"

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -153,7 +153,7 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	}
 
 	// Block config for Firecracker
-	// TODO: Add support for block devices in FIrecracker
+	// TODO: Add support for block devices in Firecracker
 	FCDrives := make([]FirecrackerDrive, 0)
 
 	bArgs := ukernel.MonitorBlockCli()

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -34,8 +34,8 @@ type HVT struct {
 	binary     string
 }
 
-// applySeccompFilter applies some secomp filters for the Hvt process.
-// By default all systemcalls will cause a SIGSYS, except the ones that we whitelist
+// applySeccompFilter applies some seccomp filters for the Hvt process.
+// By default all system calls will cause a SIGSYS, except the ones that we whitelist
 func applySeccompFilter() error {
 	syscalls := []string{
 		"rt_sigaction",
@@ -86,7 +86,7 @@ func applySeccompFilter() error {
 	// Some of the actions that we can take for accessing non-permitted system calls are:
 	// - seccomp.ActionKillThread will kill the thread that tried to use a non-permitted
 	//	system call, but the rest of the threads can still run
-	// - seccomp.ActionErrno will result to returning EPERM error in all non-permitted
+	// - seccomp.ActionErrno will result in returning EPERM error in all non-permitted
 	//	system calls.
 	// - ActionTrap will cause a SIGSYS trap to the process.
 	//

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -81,7 +81,7 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 		cmdString += ",elevateprivileges=deny"
 		// Allow or Deny *fork and execve
 		cmdString += ",spawn=deny"
-		// Allow or Deny process affinity and schedular priority
+		// Allow or Deny process affinity and scheduler priority
 		cmdString += ",resourcecontrol=deny"
 	}
 

--- a/pkg/unikontainers/mount.go
+++ b/pkg/unikontainers/mount.go
@@ -73,7 +73,7 @@ func createTmpfs(monRootfs string, path string, flags uint64, mode string, size 
 	return nil
 }
 
-// SetupDev set ups one new device in the container's rootfs.
+// SetupDev sets up one new device in the container's rootfs.
 // This function will get the major and minor number of
 // the device from the host's rootfs and it will replicate the device
 // inside the container's rootfs.
@@ -130,7 +130,7 @@ func setupDev(monRootfs string, devPath string) error {
 
 	// Set up permissions, adding rw for others to ensure that any user can
 	// read/write them. This is helpful for non-root monitor execution and
-	// removes the burdain of getting kvm/block group id
+	// removes the burden of getting kvm/block group id
 	permBits := devStat.Mode & 0o777
 	permBits |= 0o006
 	err = unix.Chmod(dstPath, permBits)
@@ -147,7 +147,7 @@ func setupDev(monRootfs string, devPath string) error {
 	return nil
 }
 
-// fileFromHost set ups a mirror of file from the host's rootfs inside the
+// fileFromHost sets up a mirror of file from the host's rootfs inside the
 // container's rootfs. Also, it preserves the permissions and ownership of the
 // file in the host's rootfs.
 // if withCopy is set then copy the file, otherwise

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -274,7 +274,7 @@ func pivotRootfs(newRoot string) error {
 	// Make oldroot rslave to make sure our unmounts don't propagate to the
 	// host (and thus bork the machine). We don't use rprivate because this is
 	// known to cause issues due to races where we still have a reference to a
-	// mount while a process in the host namespace are trying to operate on
+	// mount while a process in the host namespace is trying to operate on
 	// something they think has no mounts (devicemapper in particular).
 	err = unix.Mount("", "old_root", "", unix.MS_SLAVE|unix.MS_REC, "")
 	if err != nil {

--- a/pkg/unikontainers/unikernels/mewz.go
+++ b/pkg/unikontainers/unikernels/mewz.go
@@ -61,7 +61,7 @@ func (m *Mewz) MonitorNetCli(ifName string, mac string) string {
 	}
 }
 
-// Mewz does not seem to support virtio block or anu other kind of block/fs.
+// Mewz does not seem to support virtio block or any other kind of block/fs.
 func (m *Mewz) MonitorBlockCli() []types.MonitorBlockArgs {
 	return nil
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -48,7 +48,7 @@ const (
 
 var uniklog = logrus.WithField("subsystem", "unikontainers")
 
-var ErrQueueProxy = errors.New("this a queue proxy container")
+var ErrQueueProxy = errors.New("this is a queue proxy container")
 var ErrNotUnikernel = errors.New("this is not a unikernel container")
 var ErrNotExistingNS = errors.New("the namespace does not exist")
 
@@ -168,7 +168,7 @@ func (u *Unikontainer) InitialSetup() error {
 	// By default, urunc will not set any rootfs for the guest. However,
 	// if the respective annotation is set then, depending on the guest
 	// (supports block or 9pfs), it will use the supported option. In case
-	// both ae supported, then the block option will be used by default.
+	// both are supported, then the block option will be used by default.
 	var rootfsParams types.RootfsParams
 
 	// Read the rootfs choice written by the shim.
@@ -261,7 +261,7 @@ func (u *Unikontainer) SetupNet() (types.NetDevParams, error) {
 		// TODO: Handle this case better. We do not need to show an error
 		// since there was no network in the container. Therefore, we
 		// need better error handling and specifically check if the container
-		// di not have any network.
+		// did not have any network.
 		uniklog.Errorf("Failed to setup network :%v. Possibly due to ctr", err)
 	}
 	// if network info is nil, we didn't find eth0, so we are running with ctr
@@ -477,7 +477,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// By default, urunc will not set any rootfs for the guest. However,
 	// if the respective annotation is set then, depending on the guest
 	// (supports block or 9pfs), it will use the supported option. In case
-	// both ae supported, then the block option will be used by default.
+	// both are supported, then the block option will be used by default.
 	var rootfsParams types.RootfsParams
 
 	// Read the rootfs choice written by the shim.
@@ -639,7 +639,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// pivot
 	_, err = findNS(u.Spec.Linux.Namespaces, specs.MountNamespace)
-	// We just want to check if a mount namespace was define din the list
+	// We just want to check if a mount namespace was defined in the list
 	// Therefore, if there was no error and the mount namespace was found
 	// we can pivot.
 	withPivot := err != nil
@@ -805,7 +805,7 @@ func (u *Unikontainer) Delete() error {
 	// the kernel cleanup the mounts and shim to remove directories.
 	// However, just to be on the safe side, we remove all the newly
 	// created directories from urunc. In order to check if we used the
-	// rootfs under the bundle directory or we create anew one, we can check
+	// rootfs under the bundle directory or we create a new one, we can check
 	// if the monitorRootfsDirName directory exists under the bundle.
 	_, err = os.Stat(monRootfs)
 	if !os.IsNotExist(err) {
@@ -815,7 +815,7 @@ func (u *Unikontainer) Delete() error {
 		dirs = append(dirs, monitorRootfsDirName)
 		prefPath = bundleDir
 	} else {
-		// Otherwise remove the enw directories we created inside the
+		// Otherwise remove the new directories we created inside the
 		// container's rootfs.
 		// We do not need to unmount anything here, since we rely on Linux
 		// to do the cleanup for us. This will happen automatically,

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -125,7 +125,7 @@ func writePidFile(path string, pid int) error {
 
 // handleQueueProxy adds a hardcoded IP to the process's environment.
 // Then, the container is identified as a non-bima container
-// is spawned using runc.
+// and is spawned using runc.
 func handleQueueProxy(spec specs.Spec, configFile string) error {
 	var readinessProbeEnv string
 	for i, envVar := range spec.Process.Env {
@@ -246,7 +246,7 @@ func fileExists(fpath string) bool {
 	return true
 }
 
-// containsNS checks of the container's configuration contains a specific namespace
+// containsNS checks if the container's configuration contains a specific namespace
 func findNS(namespaces []specs.LinuxNamespace, nsType specs.LinuxNamespaceType) (string, error) {
 	for _, ns := range namespaces {
 		if ns.Type == nsType {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -77,7 +77,7 @@ const (
 	testNerdctl = "TestNerdctl"
 )
 
-var errToolDoesNotSupport = errors.New("Operation not support")
+var errToolDoesNotSupport = errors.New("Operation not supported")
 
 func commonNewContainerCmd(a containerTestArgs) string {
 	cmdBase := "--runtime io.containerd.urunc.v2 "

--- a/tests/e2e/test_functions.go
+++ b/tests/e2e/test_functions.go
@@ -417,7 +417,7 @@ func httpStaticNetTest(tool testTool) (err error) {
 		return fmt.Errorf("Failed to receive valid response")
 	}
 
-	// FIXME: Investigate why the GET request using net/http fails, while is successful using curl
+	// FIXME: Investigate why the GET request using net/http fails, while it is successful using curl
 	//
 	// client := http.DefaultClient
 	// client.Timeout = 10 * time.Second


### PR DESCRIPTION
## Description

This PR sweeps the repository for typos and grammar errors and fixes the reason CI was not catching them.

**Typo and grammar fixes** (`docs:` and `style:` commits):

- Documentation, README and CHANGELOG: misspellings (e.g. `rirecracker` -> `firecracker`, `lastest` -> `latest`, `Fotran` -> `Fortran`, `Cloud-HYpervisor` -> `Cloud-Hypervisor`, "in the same directly" -> "directory") and a number of grammar slips (subject-verb agreement, "a initrd" -> "an initrd", "Except of" -> "Apart from", missing sentence breaks).
- Two semantic corrections in the docs, please double-check these:
  - `docs/unikernel-support.md`: the MirageOS and Rumprun monitor lists linked `Solo5` twice; they now name **Solo5-hvt** and **Solo5-spt** explicitly.
  - `docs/installation.md`: "any **earlier** version of Go 1.20.6 should be sufficient" inverted the intended meaning; it now reads "any version of Go 1.20.6 **or later**". Also `monitor-builds` -> `monitors-build` (the actual repository name).
- Go sources: typo fixes in comments and two error message strings (`"this a queue proxy container"`, `"Operation not support"`). No functional change: both error values are only compared as sentinels, never by text.
- Makefile: fix the "Dcos targets" comment.

**Why CI missed these** (`ci:` commit):

1. **Ignore-regex bug**: the inline-code pattern `` `[^`]+` `` in `.github/linters/.cspell.json` matched across newlines, pairing the closing backtick of one code span with the opening backtick of the next one. In backtick-heavy pages this hid most of the prose from cspell entirely. The pattern is now restricted to a single line and a duplicate entry was dropped. This alone surfaced 25 previously hidden words.
2. **Typos whitelisted in the dictionary**: several entries in `urunc-dict.txt` were real misspellings added to silence the checker (`burdain`, `levarage`, `secomp`, `triger`, `isues`, `vlaid`, ...). These are removed and their occurrences fixed. Entries that look like typos but are required by cspell's tokenizer were kept (e.g. `urunce`/`etesting` from `package urunce2etesting`, `Prettyfier` from logrus's `CallerPrettyfier` field, `scontroller`/`sworker` from the `k0scontroller`/`k0sworker` service names).
3. **Residual limits**: `misspell` in golangci-lint runs with `only-new-issues: true`, so pre-existing typos in Go code are never reported, and grammar-level errors ("the followings", "instructions fo using": `fo` and `followings` are valid en_US dictionary words) are invisible to any spell checker. Those categories were fixed manually here and will need human review to catch in the future.

### Related issues

- Fixes #832

### How was this tested?

All testing on Linux amd64 (Ubuntu 24.04, containerd 2.3.3, devmapper), plus spell/commit lint locally:

- `cspell --config .github/linters/.cspell.json`: 0 issues on 158 files with the stricter regex.
- `commitlint --from=origin/main` with the repo config: all three commits pass.
- `go build ./... && go vet ./... && gofmt -l`: clean; the Go diff touches only comments and the two string literals.
- `make lint` (golangci-lint v2.9 container): reports 4 findings (1 ineffassign, 3 unused) that are byte-identical on pristine `origin/main`; this branch introduces no new findings (the CI gate runs with `only-new-issues: true`).
- Unit tests (`make unittest`): pass. (When run as root, `TestCopyFile`/`TestMoveFile` fail because root bypasses the permission denials they assert; this reproduces identically on pristine `main` and is unrelated.)
- e2e (`make test_ctr`) with urunc + shim built from this branch (`make` + `make install`): all 11 specs for the working monitors on the test host (qemu, firecracker) pass. The 6 Solo5 (`Hvt-*`/`Spt-*`) specs fail with the exact same reexec `RX_ERROR` when running urunc built from pristine `origin/main` on the same host (nested-KVM environment issue, pre-existing and unrelated to this PR).

### LLM usage

Claude Fable 5 (via Claude Code) assisted with this PR and the associated issue, per the [LLM policy](https://urunc.io/developer-guide/llm-policy/). All changes were reviewed and tested by the contributor, who takes full responsibility for them.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
