### PR TITLE
fix(cloud-hypervisor): Add initrd for urunit configuration

### DIFF
--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -203,7 +203,7 @@ func (l *Linux) MonitorCli() types.MonitorCliArgs {
 			extraCliArgs.ExtraInitrd = urunitConfPath
 		}
 		return extraCliArgs
-	case "firecracker":
+	case "firecracker", "cloud-hypervisor":
 		if l.InitrdConf && l.RootFsType != "initrd" {
 			return types.MonitorCliArgs{
 				ExtraInitrd: urunitConfPath,


### PR DESCRIPTION
## Description

Include cloud-hypervisor in Linux's `MonitorCli` in order to set the urunit configuration as the initrd for the cloud-hypervisor VM.

### Related issues

- Fixes  https://github.com/urunc-dev/urunc/issues/842

### How was this tested?

Executed the `arbor.nbfc.io/nubificus/urunc/busybox-cloud-hypervisor-linux-raw:latest` and checked urunit logs along with cloud-hypervisor command

logs:
```
[   11.863133] Run /urunit as init process
Warning: No configuration for block mounts
/bin/sh: can't access tty; job control turned off
/ # 
[   32.981715] ACPI: PM: Preparing to enter system sleep state S5
[   33.008017] reboot: Restarting system
[   33.020332] reboot: machine restart
```

urunit found the configuration since it reports no block configuration. Also the cloud-hypervisor command:

```
$ ps aux | grep cloud
root       11277  7.8  0.1  19348  7052 pts/1    S+   15:59   0:00 sudo docker run --rm -it --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/busybox-cloud-hypervisor-linux-raw:latest
root       11278  0.0  0.0  19348  2588 pts/3    Ss   15:59   0:00 sudo docker run --rm -it --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/busybox-cloud-hypervisor-linux-raw:latest
root       11279 15.7  0.7 1809316 29568 pts/3   Sl+  15:59   0:01 docker run --rm -it --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/busybox-cloud-hypervisor-linux-raw:latest
root       11319 52.4  0.9 287932 36608 ?        Ssl  15:59   0:03 /opt/urunc/bin/cloud-hypervisor --memory size=268M,shared=on --cpus boot=1 --kernel /cntrRootfs/.boot/kernel --console off --serial tty --seccomp true --net tap=tap0_urunc,mac=92:18:8b:9d:fa:a9,mtu=1500 --initramfs /urunit.conf --fs tag=fs0,socket=/tmp/vhostqemu --cmdline panic=-1 console=ttyS0 root=fs0 rw rootfstype=virtiofs ip=172.17.0.2::172.17.0.1:255.255.0.0:urunc:eth0:off retain_initrd URUNIT_CONFIG=/sys/firmware/initrd init=/urunit -- /bin/sh
cmainas    11371  0.0  0.0   9144  2260 pts/4    S+   15:59   0:00 grep --color=auto cloud
```

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
