### PR TITLE
docs: fix typos

### DIFF
--- a/docs/developer-guide/contribute.md
+++ b/docs/developer-guide/contribute.md
@@ -215,5 +215,5 @@ Go provides the `gofmt` tool, which can be used for formatting your code.
 
 We kindly invite everyone interested in `urunc` to join our
 [Slack channel](https://cloud-native.slack.com/archives/C08V201G35J).
-To directly communicate with the maintainers, feel free to drop an email At
+To directly communicate with the maintainers, feel free to drop an email at
 [`urunc`'s maintainers' mailing list](cncf-urunc-maintainers@lists.cncf.io )

--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -55,7 +55,7 @@ by running the:
 - end-to-end tests: `sudo make e2etest`
 
 > Note: When running `make` commands for `urunc` that will use go (i.e. build,
-> unitest, e2etest) you might need to specify the path to the go binary
+> unittest, e2etest) you might need to specify the path to the go binary
 with `sudo GO=$(which go) make`.
 
 ## Next Steps

--- a/docs/package/index.md
+++ b/docs/package/index.md
@@ -59,7 +59,7 @@ required annotations are the following:
 - `com.urunc.unikernel.cmdline`: The application's cmdline to pass to the
   unikernel.
 
-Except of the above, `urunc` accepts the following optional annotations:
+Except for the above, `urunc` accepts the following optional annotations:
 
 - `com.urunc.unikernel.initrd`: The path to the initrd of the unikernel inside
   the container's rootfs.
@@ -88,7 +88,7 @@ package unikernels in OCI images with `urunc`'s annotations.
 ### bunny
 
 In an effort to simplify the process of building various unikernels, we built
-[bunny](https://github.com/nubificus/bunny). Except of building unikernels [bunny](https://github.com/nubificus/bunny)
+[bunny](https://github.com/nubificus/bunny). Except for building unikernels [bunny](https://github.com/nubificus/bunny)
 can also pack existing unikernels (whether locally or from OCI images) as OCI images
 for `urunc`. At its core [bunny](https://github.com/nubificus/bunny) leverages
 [buildkit's LLB](https://github.com/moby/buildkit?tab=readme-ov-file#exploring-llb),
@@ -113,7 +113,7 @@ can handle the following *instructions*:
 To further extend the functionality and provide a common interface to facilitate
 unikernel building, we defined `bunnyfile`. It is a YAML-based special file that
 [bunny](https://github.com/nubificus/bunny) transforms to LLB with all the
-necessary steps to build the respective unikernel. Except of building
+necessary steps to build the respective unikernel. Except for building
 unikernels, [bunny](https://github.com/nubificus/bunny) can also be used to build or append files in the unikernel's
 rootfs.
 

--- a/docs/package/pre-built.md
+++ b/docs/package/pre-built.md
@@ -93,7 +93,7 @@ docker build -f Containerfile -t urunc/prebuilt/network-mirage-hvt:test .
 ## Using `bunix`
 
 In the case of [bunix](https://github.com/nubificus/bunix) we need to clone the whole
-repository in the same directly as the
+repository in the same directory as the
 unikernel. Then, we simply need to edit the `args.nix` file as:
 
 ```Nix

--- a/docs/package/rootfs.md
+++ b/docs/package/rootfs.md
@@ -198,7 +198,7 @@ docker build -f Containerfile -t urunc/prebuilt/redis-rumprun-hvt:test .
 
 ### Using `bunix`
 
-In the case of [bunix](https://github.com/nubificus/bunix) we need the whole repository in the same directly as
+In the case of [bunix](https://github.com/nubificus/bunix) we need the whole repository in the same directory as
 the unikernel. Then, we simply need to edit the `args.nix` file. For our
 pre-built Redis [Rumprun](https://github.com/nubificus/rumprun) unikernel we can define the files as:
 

--- a/docs/tutorials/existing-container-linux.md
+++ b/docs/tutorials/existing-container-linux.md
@@ -65,12 +65,12 @@ treated as a separate argument.
   parameters. If too many or very long environment variables are passed, the
   boot process will fail once that limit is exceeded. 
 
-Especially, for CLI argument handing, `urunc` follows a simple convention. All
+Especially, for CLI argument handling, `urunc` follows a simple convention. All
 multi-word CLI arguments are wrapped in single quotes and the init process (or
 application) is expected to reconstruct them properly.
 
 For all the above reasons, we strongly recommend using a dedicated init process.
-We provide [urunit](https://github.com/nubificus/urunit#); a lightweight init
+We provide [urunit](https://github.com/nubificus/urunit); a lightweight init
 designed specifically for `urunc`. It performs the following actions:
 
 1. Sets default route through eth0. This is necessary when we deploy


### PR DESCRIPTION
## Description

Fixes #854

This PR fixes a batch of small typos and one broken link across the documentation. Nothing functional changed, just spelling, grammar, and a bad urunit URL that pointed nowhere.

Changes include fixing "handing" to "handling", "same directly" to "same directory", "Except of" to "Except for", "unitest" to "unittest", and "email At" to "email at".

### How was this tested?

Docs only change. I read through each edited file to confirm the fixes look correct in context. No code or runtime behavior was touched so e2e tests were not run.

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
