### PR TITLE
fix(rootfs): only pivot_root when a mount namespace actually exists

### DIFF
--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -698,10 +698,17 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// pivot
 	_, err = findNS(u.Spec.Linux.Namespaces, specs.MountNamespace)
-	// We just want to check if a mount namespace was define din the list
-	// Therefore, if there was no error and the mount namespace was found
-	// we can pivot.
-	withPivot := err != nil
+	// We only want to pivot_root if we are actually going to end up in an
+	// isolated mount namespace. That is the case if a mount namespace
+	// entry exists in the spec: either we are joining an existing one
+	// (err is nil) or FormatNsenterInfo will create a fresh one for us
+	// (err is ErrNotExistingNS, i.e. the entry is present but has no
+	// path yet). If the mount namespace type is missing from the spec
+	// altogether, findNS returns a different, non-ErrNotExistingNS error,
+	// no new mount namespace gets created, and pivoting would instead
+	// operate on the caller's own (most likely host) root filesystem. In
+	// that case we must fall back to chroot.
+	withPivot := err == nil || errors.Is(err, ErrNotExistingNS)
 	err = changeRoot(rootfsParams.MonRootfs, withPivot)
 	if err != nil {
 		return err

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -16,6 +16,7 @@ package unikontainers
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWritePidFile(t *testing.T) {
@@ -238,6 +240,52 @@ func TestRemovePreservesOrder(t *testing.T) {
 	t.Parallel()
 	result := remove([]string{"a", "b", "c", "d"}, 0)
 	assert.Equal(t, []string{"b", "c", "d"}, result)
+}
+
+// TestFindNS verifies that findNS lets callers distinguish "namespace type
+// missing from the spec entirely" from "namespace present but not created
+// yet" (empty path). Exec() relies on exactly this distinction to decide
+// whether it is safe to pivot_root: it must only pivot when a mount
+// namespace entry actually exists in the spec, i.e. when findNS returns a
+// nil error or ErrNotExistingNS, never when the namespace type is absent
+// from the list altogether.
+func TestFindNS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("namespace type missing from spec", func(t *testing.T) {
+		t.Parallel()
+		namespaces := []specs.LinuxNamespace{
+			{Type: specs.NetworkNamespace, Path: "/proc/1/ns/net"},
+		}
+		path, err := findNS(namespaces, specs.MountNamespace)
+		assert.Empty(t, path)
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrNotExistingNS),
+			"a namespace type absent from the spec must not be reported as ErrNotExistingNS")
+	})
+
+	t.Run("namespace present without a path yet", func(t *testing.T) {
+		t.Parallel()
+		namespaces := []specs.LinuxNamespace{
+			{Type: specs.MountNamespace, Path: ""},
+		}
+		path, err := findNS(namespaces, specs.MountNamespace)
+		assert.Empty(t, path)
+		assert.ErrorIs(t, err, ErrNotExistingNS)
+	})
+
+	t.Run("namespace present with an existing path", func(t *testing.T) {
+		t.Parallel()
+		nsPath := filepath.Join(t.TempDir(), "mnt")
+		require.NoError(t, os.WriteFile(nsPath, []byte{}, 0644))
+
+		namespaces := []specs.LinuxNamespace{
+			{Type: specs.MountNamespace, Path: nsPath},
+		}
+		path, err := findNS(namespaces, specs.MountNamespace)
+		assert.NoError(t, err)
+		assert.Equal(t, nsPath, path)
+	})
 }
 
 func TestLoadSpec(t *testing.T) {


### PR DESCRIPTION
## Description

`Exec()` decided whether to `pivot_root` or `chroot` into the monitor's rootfs by checking whether `findNS()` returned an error for the mount namespace. `findNS()` returns a non-nil error in two different situations: the namespace type is entirely absent from `Linux.Namespaces`, or it's present but not created yet (empty `Path`). The old code treated both the same way (`withPivot := err != nil`), so it ended up pivoting even when the mount namespace type was missing from the spec altogether.

When that happens, `FormatNsenterInfo()` never sets `unix.CLONE_NEWNS`, so no new mount namespace is created — the process stays in whatever mount namespace the caller (normally `urunc create` itself) is running in, which is usually the host's. `pivot_root` then runs against that namespace instead of an isolated one.

This mirrors the distinction `joinSandboxNetNs` already makes using `ErrNotExistingNS`: only pivot when `findNS` returns `nil` (joining an existing namespace) or `ErrNotExistingNS` (namespace entry present, about to be created). If the namespace type is missing from the spec entirely, fall back to `chroot`.

Also fixes the comment above this line, which described the intended (correct) behavior but didn't match what the code actually did.

### Related issues

- Fixes #861

### How was this tested?

- `gofmt -l` clean
- Built and vetted with `GOOS=linux GOARCH=amd64` (no build/vet issues)
- Added `TestFindNS` in `pkg/unikontainers/utils_test.go`, covering the three cases the fix depends on: namespace type absent from the spec, namespace present without a path yet, namespace present with an existing path
- Didn't have a Linux box handy to run the full `make test_unikontainers` / e2e suite, so leaving that to CI

### LLM usage

Used Claude to help investigate the bug (reported as #861) and put together this fix; reviewed and tested locally before opening this.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).