### PR TITLE
fix(rootfs): only pivot_root when a mount namespace actually exists

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -113,3 +113,7 @@ users:
   pocopepe:
     name: Viju Sanjai
     email: avijusanjai@gmail.com
+  Anand-240:
+    name: Anand Prakash Srivastava
+    email: anandprakashsrivastava68@gmail.com
+

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -698,10 +698,12 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// pivot
 	_, err = findNS(u.Spec.Linux.Namespaces, specs.MountNamespace)
-	// We just want to check if a mount namespace was define din the list
-	// Therefore, if there was no error and the mount namespace was found
-	// we can pivot.
-	withPivot := err != nil
+	// Only pivot if a mount namespace entry is actually present in the
+	// spec, either to join (err is nil) or to create (err is
+	// ErrNotExistingNS). If the entry is missing entirely, no new mount
+	// namespace gets created and we have to chroot instead, otherwise
+	// pivot_root would run against the caller's own root filesystem.
+	withPivot := err == nil || errors.Is(err, ErrNotExistingNS)
 	err = changeRoot(rootfsParams.MonRootfs, withPivot)
 	if err != nil {
 		return err

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWritePidFile(t *testing.T) {
@@ -252,13 +251,12 @@ func TestFindNS(t *testing.T) {
 	t.Run("namespace type missing from spec", func(t *testing.T) {
 		t.Parallel()
 		namespaces := []specs.LinuxNamespace{
-			{Type: specs.NetworkNamespace, Path: "/proc/1/ns/net"},
+			{Type: specs.NetworkNamespace, Path: "/dummy/path"},
 		}
 		path, err := findNS(namespaces, specs.MountNamespace)
 		assert.Empty(t, path)
 		assert.Error(t, err)
-		assert.False(t, errors.Is(err, ErrNotExistingNS),
-			"a namespace type absent from the spec must not be reported as ErrNotExistingNS")
+		assert.False(t, errors.Is(err, ErrNotExistingNS), "a namespace type absent from the spec must not be reported as ErrNotExistingNS")
 	})
 
 	t.Run("namespace present without a path yet", func(t *testing.T) {
@@ -273,8 +271,7 @@ func TestFindNS(t *testing.T) {
 
 	t.Run("namespace present with an existing path", func(t *testing.T) {
 		t.Parallel()
-		nsPath := filepath.Join(t.TempDir(), "mnt")
-		require.NoError(t, os.WriteFile(nsPath, []byte{}, 0644))
+		nsPath := t.TempDir()
 
 		namespaces := []specs.LinuxNamespace{
 			{Type: specs.MountNamespace, Path: nsPath},

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -16,6 +16,7 @@ package unikontainers
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWritePidFile(t *testing.T) {
@@ -238,6 +240,49 @@ func TestRemovePreservesOrder(t *testing.T) {
 	t.Parallel()
 	result := remove([]string{"a", "b", "c", "d"}, 0)
 	assert.Equal(t, []string{"b", "c", "d"}, result)
+}
+
+// TestFindNS checks that findNS lets callers tell apart a namespace type
+// missing from the spec from one that's present but not created yet
+// (empty path). Exec() relies on that distinction to decide when it's
+// safe to pivot_root.
+func TestFindNS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("namespace type missing from spec", func(t *testing.T) {
+		t.Parallel()
+		namespaces := []specs.LinuxNamespace{
+			{Type: specs.NetworkNamespace, Path: "/proc/1/ns/net"},
+		}
+		path, err := findNS(namespaces, specs.MountNamespace)
+		assert.Empty(t, path)
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrNotExistingNS),
+			"a namespace type absent from the spec must not be reported as ErrNotExistingNS")
+	})
+
+	t.Run("namespace present without a path yet", func(t *testing.T) {
+		t.Parallel()
+		namespaces := []specs.LinuxNamespace{
+			{Type: specs.MountNamespace, Path: ""},
+		}
+		path, err := findNS(namespaces, specs.MountNamespace)
+		assert.Empty(t, path)
+		assert.ErrorIs(t, err, ErrNotExistingNS)
+	})
+
+	t.Run("namespace present with an existing path", func(t *testing.T) {
+		t.Parallel()
+		nsPath := filepath.Join(t.TempDir(), "mnt")
+		require.NoError(t, os.WriteFile(nsPath, []byte{}, 0644))
+
+		namespaces := []specs.LinuxNamespace{
+			{Type: specs.MountNamespace, Path: nsPath},
+		}
+		path, err := findNS(namespaces, specs.MountNamespace)
+		assert.NoError(t, err)
+		assert.Equal(t, nsPath, path)
+	})
 }
 
 func TestLoadSpec(t *testing.T) {


### PR DESCRIPTION
## Description

Exec() decides whether to pivot_root or chroot into the monitor's rootfs by checking whether findNS() returned an error for the mount namespace. findNS() returns a non-nil error in two different situations though: the namespace type is entirely absent from Linux.Namespaces, or it's present but not created yet (empty Path). The old code treated both the same way (`withPivot := err != nil`), so it ended up pivoting even when the mount namespace type was missing from the spec altogether.

When that happens, FormatNsenterInfo() never sets unix.CLONE_NEWNS, so no new mount namespace gets created. The process just stays in whatever mount namespace the caller (normally urunc create itself) is running in, which is usually the host's. pivot_root then runs against that namespace instead of an isolated one.

This mirrors the distinction joinSandboxNetNs already makes using ErrNotExistingNS: only pivot when findNS returns nil (joining an existing namespace) or ErrNotExistingNS (namespace entry present, about to be created). If the namespace type is missing from the spec entirely, fall back to chroot.

Also fixed the comment above this line, since it described the intended behavior but didn't match what the code actually did.

### Related issues

- Fixes #861

### How was this tested?

- gofmt -l clean
- Built and vetted with GOOS=linux GOARCH=amd64, no build/vet issues
- Added TestFindNS in pkg/unikontainers/utils_test.go covering the three cases the fix depends on: namespace type absent from the spec, namespace present without a path yet, namespace present with an existing path
- Ran the full unit test suite (go test ./pkg/unikontainers/... -v) in a golang container, not just the new test
- CI unit tests pass on both amd64 and arm64

### LLM usage

Used Claude to help investigate the bug (reported as #861) and put together this fix. Reviewed, tested, and pushed the follow-up fixes myself.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
