### PR TITLE
docs(design): document loop autoclear for block bind mounts

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -116,4 +116,7 @@ users:
   Anand-240:
     name: Anand Prakash Srivastava
     email: anandprakashsrivastava68@gmail.com
+  Vi-shub:
+    name: Shubham Vishwakarma
+    email: smsharma3121@gmail.com
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,5 +1,7 @@
 This section describes the high-level architecture of `urunc`, along with the
-design choices and limitations.
+design choices and limitations. For storage-specific runtime behavior (including
+how bind mounts are turned into guest block devices and how loop-device
+autoclear is handled), see [Storage handling](./storage.md).
 
 ## Overview
 

--- a/docs/design/storage.md
+++ b/docs/design/storage.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: "Storage handling"
+description: "How urunc prepares and attaches guest storage"
+---
+
+# Storage handling in urunc
+
+This page describes selected storage behaviors that are easy to miss when
+reading only the packaging guides. For how to build and package a guest rootfs
+(initrd, block, or shared-fs), see [Creating rootfs for unikernels](../package/rootfs.md).
+
+## Bind mounts attached as guest block devices
+
+Some guests can consume host bind mounts as virtio-block devices when the
+mounted filesystem type is supported by the unikernel. During create, `urunc`
+inspects the container mounts, and for each eligible bind mount it:
+
+1. Resolves the mount source from `/proc/self/mountinfo`.
+2. Detaches the host mount so the backing device can be handed to the guest.
+3. Attaches that source as a block device in the sandbox.
+
+### Loop devices and the autoclear flag
+
+When the bind mount source is a regular file (for example an ext2 image), the
+kernel typically exposes it through a [loop
+device](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-block-loop).
+`/proc/self/mountinfo` then lists that loop device (for example `/dev/loopN`)
+as the mount source.
+
+If `urunc` unmounted the filesystem while the loop device still had
+**autoclear** enabled, the kernel could destroy the loop device as soon as the
+last mount was gone. In that case there would be nothing left to attach to the
+guest.
+
+To avoid that, `urunc` clears the loop device autoclear flag before unmounting
+the host mount. The loop device therefore remains available for attachment to
+the sandbox.
+
+### Restore on delete
+
+On the delete path, `urunc` remounts the original host mountpoint when needed
+and, if autoclear was cleared during create, restores the autoclear flag on the
+loop device.
+
+> **Note:** If the container is never deleted through `urunc` (for example the
+> process is killed and state is discarded without a delete), the autoclear
+> flag may stay cleared and the host mount may not be remounted. Operators
+> should ensure container delete runs for workloads that use this path, or
+> clean up leftover loop devices manually if create/delete is interrupted.
+
+### Where this lives in the code
+
+- Clearing autoclear and unmounting eligible bind mounts: `getBlockVolumes` in
+  `pkg/unikontainers/block.go`
+- Remounting and restoring autoclear: `restoreBlockVolumes` in the same file,
+  called from the unikontainer delete path

--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -212,20 +212,8 @@ func getBlockVolumes(mounts []specs.Mount, ukernel types.Unikernel) ([]types.Blo
 			return nil, err
 		}
 		if ukernel.SupportsFS(mInfo.FsType) {
-			// So, there was an issue which was manifested from the testing.
-			// If we have a file (e.g. ext2) and mount it, then we use
-			// a loop device for the mount and this is what is shown
-			// in the mount list. However, since we perform the unmount
-			// the device might also get removed. See
-			// https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-block-loop
-			// If the device gets removed, then we attach nothing to the
-			// sandbox. To resolve this we remove the autoclear flag
-			// and therefore the device will persist.
-			// NOTE: Although we restore the autoclear flag in the delete path,
-			// if delete is never called then the autoclear flag will never
-			// get restored.and remounted
-			// TODO; Add the above note in a documentation for storage
-			// handling
+			// Clear loop autoclear before unmount so the loop device survives
+			// and can be attached to the guest. See docs/design/storage.md.
 			cleared, err := setLoopAutoclear(mInfo.Source, false)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION

## Description

As diving more in the codebase I observe this TODO and critical part to be documented.
Documents the loop-device autoclear behavior used when urunc turns host bind mounts into guest block devices.
This addresses the TODO in `pkg/unikontainers/block.go` that asked for storage-handling documentation covering:
- why autoclear is cleared before unmount
- that delete restores autoclear / remounts when possible
- the caveat if delete never runs
Also adds a short link from the design overview and replaces the long inline TODO with a pointer to the new page.


### Related issues

Fixes #873  and comment that contributors.yaml is now a clean 3-line add (LF).

### How was this tested?

- Reviewed the new page against `getBlockVolumes` / `restoreBlockVolumes` in `pkg/unikontainers/block.go`
- Confirmed `docs/design/*.md` is already included in `mkdocs.yml` nav

### LLM usage

Claude Code assisted with drafting the documentation; I reviewed it for accuracy against the code.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).

@cmainas - please take a look when you have a moment. Thanks for your time 😄 