### PR TITLE
fix[vAccel]: optimized hash function in idToGuestCID to reduce collisions

### DIFF
--- a/pkg/unikontainers/vaccel.go
+++ b/pkg/unikontainers/vaccel.go
@@ -17,6 +17,7 @@ package unikontainers
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"regexp"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -30,14 +31,13 @@ var ErrVAccelDisabled = errors.New("vaccel is disabled")
 // idToGuestCID generates a deterministic guest CID (Context Identifier)
 // for vsock communication based on a container or VM ID.
 func idToGuestCID(id string) int {
-	sum := 0
-	for _, c := range id {
-		sum += int(c)
-	}
+	h := fnv.New32a()
+	h.Write([]byte(id))
+	hashVal := h.Sum32()
+
 	const minVal = 3
-	const maxVal = 99
-	const valRange = maxVal - minVal + 1
-	val := (sum % valRange) + minVal
+	// Max uint32 is 4294967295. Range size = 4294967295 - 3 + 1 = 4294967293
+	val := int((hashVal % 4294967293) + minVal)
 
 	return val
 }

--- a/pkg/unikontainers/vaccel_test.go
+++ b/pkg/unikontainers/vaccel_test.go
@@ -30,12 +30,22 @@ func TestIdToGuestCID(t *testing.T) {
 		{
 			name:        "empty string",
 			id:          "",
-			expectedCID: 3,
+			expectedCID: 2166136264,
 		},
 		{
 			name:        "simple id",
 			id:          "container123",
-			expectedCID: 49,
+			expectedCID: 1588278395,
+		},
+		{
+			name:        "anagram id 1",
+			id:          "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			expectedCID: 4118960264,
+		},
+		{
+			name:        "anagram id 2",
+			id:          "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+			expectedCID: 1919582536,
 		},
 	}
 


### PR DESCRIPTION
## Description

Currently the vsock CID for the guest unikontainers spawned with vAccel are restricted to the range 3 to 99, leaving the actually permitted ceiling space of `2^32 - 1` unused, thus introducing redundancy. This is a very small range and thus the probability of a collision is very high. Moreover, the hash function used (ASCII Summation + Modulo Arithmetic) does not account for anagrams. 

This PR optimizes this redundancy by replacing with the standard `hash/fnc` function for hashing which increases the range to the full capacity of `3` to `2^32 - 1`, thus reducing the probability of a collision near zero (not zero however). Moreover, due to the `hash/fnv` function, the anagram problem is solved, as, unlike ASCII addition, the `hash/fnv` function depends on the direction of traversal as well; thus, Anagramic addresses would result in completely different hashes and thus collision would be avoided.

Also, this PR modifies the `vAcccel_test.go` file to account for the new 32 bit addresses.

### Related issues

- Fixes #688 

### How was this tested?

- **Automated Unit Tests**: Updated TestIdToGuestCID in `pkg/unikontainers/vaccel_test.go` to assert against the new 32-bit hashes. Also added a specific test using the exact anagram IDs ("abcdef0123456789" * 4 vs "9876543210fedcba" * 4). All tests passed.
- **Manual E2E Testing**: 
1. Executed a vaccel-enabled container image, explicitly passing the required annotations to trigger vsock initialization:
```
sudo docker run --runtime io.containerd.urunc.v2 --rm -it \
  --annotation com.urunc.unikernel.vAccel="vsock" \
  --annotation com.urunc.unikernel.RPCAddress="vsock://2:2049" \
  harbor.nbfc.io/nubificus/ubuntu-vaccel-urunc-qemu:x86_64
```
(Debug level set to 4 in env variables)

2. Verified that the QEMU CLI execution accurately reflected the high-entropy CID (32 bit uint): `-device vhost-vsock-pci, id=vhost-vsock-pci0,guest-cid=688968749`.

### LLM usage

Gemini 3.1 Pro

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [X] The linter passes locally (`make lint`).
- [X] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
