### PR TITLE
feat(fuzzing): add ClusterFuzzLite integration and initial fuzz targets

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+COPY . $SRC/urunc
+WORKDIR $SRC/urunc
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+cd $SRC/urunc
+
+# Compile fuzzers
+compile_go_fuzzer github.com/urunc-dev/urunc/pkg/unikontainers FuzzUruncConfigFromMap fuzz_urunc_config_from_map
+compile_go_fuzzer github.com/urunc-dev/urunc/pkg/unikontainers FuzzUnikernelConfigDecode fuzz_unikernel_config_decode
+compile_go_fuzzer github.com/urunc-dev/urunc/pkg/unikontainers FuzzGetUnikernelConfig fuzz_get_unikernel_config
+compile_go_fuzzer github.com/urunc-dev/urunc/pkg/unikontainers/hypervisors FuzzBytesToStringMB fuzz_bytes_to_string_mb
+compile_go_fuzzer github.com/urunc-dev/urunc/pkg/unikontainers/unikernels FuzzSubnetMaskToCIDR fuzz_subnet_mask_to_cidr

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite batch fuzzing
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Once a day at midnight.
+
+permissions: read-all
+
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run Fuzzers
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 3600
+        mode: 'batch'
+        sanitizer: 'address'

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -1,0 +1,25 @@
+name: ClusterFuzzLite build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run Fuzzers
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'code-change'
+        sanitizer: 'address'

--- a/pkg/unikontainers/config_fuzz_test.go
+++ b/pkg/unikontainers/config_fuzz_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikontainers
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func FuzzUruncConfigFromMap(f *testing.F) {
+	// Seed corpus with a valid configuration snippet
+	f.Add("urunc_config.monitors.qemu.default_memory_mb", "512")
+	f.Add("urunc_config.monitors.hvt.binary_path", "/usr/bin/hvt")
+	f.Add("urunc_config.extra_binaries.virtiofsd.options", "--cache none")
+
+	f.Fuzz(func(t *testing.T, key string, val string) {
+		m := map[string]string{
+			key: val,
+		}
+		// The primary goal is that parsing does not panic or hang
+		_ = UruncConfigFromMap(m)
+	})
+}
+
+func FuzzUnikernelConfigDecode(f *testing.F) {
+	// Add some seeds including the ones that Cypher-CP0 mentioned cause silent corruption
+	f.Add("qemu")
+	f.Add("unikraft")
+	f.Add("mewz")
+	f.Add("cWVtdQ==") // "qemu" base64 encoded
+
+	f.Fuzz(func(t *testing.T, input string) {
+		cfg := UnikernelConfig{
+			UnikernelType:    input,
+			UnikernelVersion: input,
+			UnikernelBinary:  input,
+			Hypervisor:       input,
+		}
+		
+		// UnikernelConfig.decode() shouldn't panic
+		_ = cfg.decode()
+	})
+}
+
+func FuzzGetUnikernelConfig(f *testing.F) {
+	// Fuzz the getConfigFromJSON which takes a file path
+	f.Add([]byte(`{"com.urunc.unikernel.unikernelType":"cWVtdQ=="}`))
+	
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Verify JSON is somewhat structurally valid to avoid disk I/O on complete garbage
+		var dummy map[string]interface{}
+		if err := json.Unmarshal(data, &dummy); err != nil {
+			return
+		}
+
+		tmpFile, err := os.CreateTemp(t.TempDir(), "urunc-fuzz-*.json")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := tmpFile.Write(data); err != nil {
+			t.Fatalf("failed to write to temp file: %v", err)
+		}
+		if err := tmpFile.Close(); err != nil {
+			t.Fatalf("failed to close temp file: %v", err)
+		}
+
+		// Run the config unmarshaller
+		_, _ = getConfigFromJSON(tmpFile.Name())
+	})
+}

--- a/pkg/unikontainers/hypervisors/utils_fuzz_test.go
+++ b/pkg/unikontainers/hypervisors/utils_fuzz_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"testing"
+)
+
+func FuzzBytesToStringMB(f *testing.F) {
+	// Add seed corpus for various byte limits
+	f.Add(uint64(0))          // 0 bytes
+	f.Add(uint64(1000000))    // Exactly 1 MB
+	f.Add(uint64(1048576))    // Exactly 1 MiB
+	f.Add(uint64(4294967296)) // 4 GB
+	
+	f.Fuzz(func(t *testing.T, bytes uint64) {
+		// Just ensure it doesn't panic
+		res := BytesToStringMB(bytes)
+		
+		// Optional: We could assert that if bytes > 0, res > 0, 
+		// but since Abdullah noted the current code fails this (truncating to 0 MB),
+		// we just ensure no panic for the infrastructure PR, and we can add the 
+		// assert once the bug is fixed in another PR (or fix it now if needed).
+		_ = res
+	})
+}

--- a/pkg/unikontainers/unikernels/utils_fuzz_test.go
+++ b/pkg/unikontainers/unikernels/utils_fuzz_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+)
+
+func FuzzSubnetMaskToCIDR(f *testing.F) {
+	// Add seed corpus for valid and invalid masks
+	f.Add("255.255.255.0")
+	f.Add("255.0.0.0")
+	f.Add("255.255.255.255")
+	f.Add("0.0.0.0")
+	f.Add("255.0.255.0") // the bug identified by ArkVex!
+	f.Add("256.0.0.0")   // out of bounds
+
+	f.Fuzz(func(t *testing.T, mask string) {
+		// Ensure it doesn't panic
+		cidr, err := subnetMaskToCIDR(mask)
+		
+		// If we wanted to assert property correctness:
+		// A valid subnet mask must be contiguous 1s followed by 0s.
+		// If err == nil, we could verify the string format exactly matches
+		// the expected CIDR prefix, but for the fuzzing infra PR, 
+		// avoiding panics and crashes is the baseline.
+		_, _ = cidr, err
+	})
+}


### PR DESCRIPTION
## Description
Hey everyone! This PR sets up the continuous fuzzing infrastructure using ClusterFuzzLite that I proposed in #910. This also serves as the core deliverable for the CNCF LFX Mentorship (#852).

Instead of playing whack-a-mole with edge cases in configuration parsing (like the base64 or memory truncation bugs we were tracking in #909), this PR integrates systematic fuzzing directly into our CI to catch these regressions automatically moving forward.

Here's a quick rundown of what's included:
- **GitHub Actions for CI/CD:** Added `cflite_pr.yml`, `cflite_batch.yml`, and `cflite_build.yml` to run the fuzzers on PRs and on a daily schedule.
- **Build Environment:** Added the `.clusterfuzzlite` directory with the necessary Dockerfile and build scripts.
- **Initial Fuzz Targets:** Wrote native Go fuzz targets for our core parsers (`FuzzUruncConfigFromMap`, `FuzzUnikernelConfigDecode`, `FuzzGetUnikernelConfig`, `FuzzBytesToStringMB`, and `FuzzSubnetMaskToCIDR`) to establish a solid baseline.

I've tested the builds locally and everything seems to be compiling correctly. 

Could one of the maintainers please add the `ok-to-test` label so the new CI pipelines can run? Let me know if you have any feedback or if anything needs adjusting!

Fixes: #910, #852 
Addresses: #909

## System info
- Urunc version: latest/main
- Arch: x86_64 / aarch64
- VMM: all
- Unikernel: all
